### PR TITLE
fix: clean installation script fix & bump lower bound version for urllib3 to avoid CVE

### DIFF
--- a/clean-install-dev.sh
+++ b/clean-install-dev.sh
@@ -19,7 +19,7 @@ source ./_installation_tools.sh
 
 create_venv
 
-upgrade_pip_or_uv
+upgrade_pip
 
 ./install-all-dev.sh
 

--- a/pyagentspec/constraints/constraints.txt
+++ b/pyagentspec/constraints/constraints.txt
@@ -2,6 +2,7 @@ jsonschema==4.23.0
 pydantic==2.12.4
 pyyaml==6.0.3
 httpx==0.28.1
+urllib3==2.6.2
 
 # AutoGen adapter
 autogen-core==0.7.4

--- a/pyagentspec/setup.py
+++ b/pyagentspec/setup.py
@@ -56,6 +56,7 @@ setup(
         "pydantic>=2.10,<2.13",
         "pyyaml>=6,<7",
         "httpx>0.28.0",
+        "urllib3>=2.5.0",  # needed to avoid a CVE present on earlier versions
     ],
     test_suite="tests",
     entry_points={


### PR DESCRIPTION
- use the existing `upgrade_pip` helper instead of the non-existing `upgrade_pip_or_uv` in the `clean-install-script.sh` to ensure smooth installation process
- put a lower-bound for `urllib3` to ensure we use `>=2.5.0` that was fixed for https://nvd.nist.gov/vuln/detail/CVE-2025-50181