### PR TITLE
Add support for flows in CrewAI adapter

### DIFF
--- a/pyagentspec/src/pyagentspec/adapters/_utils.py
+++ b/pyagentspec/src/pyagentspec/adapters/_utils.py
@@ -5,8 +5,12 @@
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 
 import re
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Literal, Tuple, Union
 
+from pydantic import BaseModel, ConfigDict, Field, create_model
+
+from pyagentspec.property import Property as AgentSpecProperty
+from pyagentspec.property import _empty_default as _agentspec_empty_default
 from pyagentspec.templating import TEMPLATE_PLACEHOLDER_REGEXP
 
 
@@ -84,3 +88,116 @@ def _recursive_template_splitting_rendering(template: str, inputs: List[Tuple[st
     ]
     rendered_template = str(input_value).join(rendered_split_templates)
     return rendered_template
+
+
+class SchemaRegistry:
+    def __init__(self) -> None:
+        self.models: Dict[str, type[BaseModel]] = {}
+
+
+def _build_type_from_schema(
+    name: str,
+    schema: Dict[str, Any],
+    registry: SchemaRegistry,
+) -> Any:
+    # Enum -> Literal[…]
+    if "enum" in schema and isinstance(schema["enum"], list):
+        values = schema["enum"]
+        # Literal supports a tuple of literal values as a single subscription argument
+        return Literal[tuple(values)]
+
+    # anyOf / oneOf -> Union[…]
+    for key in ("anyOf", "oneOf"):
+        if key in schema:
+            variants = [
+                _build_type_from_schema(f"{name}Alt{i}", s, registry)
+                for i, s in enumerate(schema[key])
+            ]
+            return Union[tuple(variants)]
+
+    t = schema.get("type")
+
+    # list of types -> Union[…]
+    if isinstance(t, list):
+        variants = [
+            _build_type_from_schema(f"{name}Alt{i}", {"type": subtype}, registry)
+            for i, subtype in enumerate(t)
+        ]
+        return Union[tuple(variants)]
+
+    # arrays
+    if t == "array":
+        items_schema = schema.get("items", {"type": "any"})
+        item_type = _build_type_from_schema(f"{name}Item", items_schema, registry)
+        return List[item_type]  # type: ignore
+    # objects
+    if t == "object" or ("properties" in schema or "required" in schema):
+        # Create or reuse a Pydantic model for this object schema
+        model_name = schema.get("title") or name
+        unique_name = model_name
+        suffix = 1
+        while unique_name in registry.models:
+            suffix += 1
+            unique_name = f"{model_name}_{suffix}"
+
+        props = schema.get("properties", {}) or {}
+        required = set(schema.get("required", []))
+
+        fields: Dict[str, Tuple[Any, Any]] = {}
+        for prop_name, prop_schema in props.items():
+            prop_type = _build_type_from_schema(f"{unique_name}_{prop_name}", prop_schema, registry)
+            desc = prop_schema.get("description")
+            default_field = (
+                Field(..., description=desc)
+                if prop_name in required
+                else Field(None, description=desc)
+            )
+            fields[prop_name] = (prop_type, default_field)
+
+        # Enforce additionalProperties: False (extra=forbid)
+        extra_forbid = schema.get("additionalProperties") is False
+        model_kwargs: Dict[str, Any] = {}
+        if extra_forbid:
+            # Pydantic v2: pass a ConfigDict/dict into __config__
+            model_kwargs["__config__"] = ConfigDict(extra="forbid")
+
+        model_cls = create_model(unique_name, **fields, **model_kwargs)  # type: ignore
+        registry.models[unique_name] = model_cls
+        return model_cls
+
+    # primitives / fallback
+    mapping = {
+        "string": str,
+        "number": float,
+        "integer": int,
+        "boolean": bool,
+        "null": type(None),
+        "any": Any,
+        None: Any,
+        "": Any,
+    }
+    return mapping.get(t, Any)
+
+
+def create_pydantic_model_from_properties(
+    model_name: str, properties: List[AgentSpecProperty]
+) -> type[BaseModel]:
+    registry = SchemaRegistry()
+    fields: Dict[str, Tuple[Any, Any]] = {}
+
+    for property_ in properties:
+        # Build the annotation from the json_schema (handles enum/array/object/etc.)
+        annotation = _build_type_from_schema(property_.title, property_.json_schema, registry)
+
+        field_params: Dict[str, Any] = {}
+        if property_.description:
+            field_params["description"] = property_.description
+
+        if property_.default is not _agentspec_empty_default:
+            default_field = Field(property_.default, **field_params)
+        else:
+            default_field = Field(..., **field_params)
+
+        fields[property_.title] = (annotation, default_field)
+
+    return create_model(model_name, **fields)  # type: ignore

--- a/pyagentspec/src/pyagentspec/adapters/crewai/_node_execution.py
+++ b/pyagentspec/src/pyagentspec/adapters/crewai/_node_execution.py
@@ -1,0 +1,265 @@
+# Copyright © 2025 Oracle and/or its affiliates.
+#
+# This software is under the Apache License 2.0
+# (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
+# (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
+
+from __future__ import annotations
+
+import json
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Dict, List, Optional
+
+from pydantic import BaseModel
+
+from pyagentspec.adapters._utils import create_pydantic_model_from_properties, render_template
+from pyagentspec.adapters.crewai._types import (
+    CrewAIFlow,
+    CrewAILlm,
+    CrewAITool,
+    ExecuteOutput,
+    FlowState,
+    NodeInput,
+    NodeOutput,
+)
+from pyagentspec.flows.edges import DataFlowEdge
+from pyagentspec.flows.node import Node as AgentSpecNode
+from pyagentspec.flows.nodes import EndNode as AgentSpecEndNode
+from pyagentspec.flows.nodes import InputMessageNode as AgentSpecInputMessageNode
+from pyagentspec.flows.nodes import LlmNode as AgentSpecLlmNode
+from pyagentspec.flows.nodes import OutputMessageNode as AgentSpecOutputMessageNode
+from pyagentspec.flows.nodes import StartNode as AgentSpecStartNode
+from pyagentspec.flows.nodes import ToolNode as AgentSpecToolNode
+from pyagentspec.property import Property as AgentSpecProperty
+from pyagentspec.property import _empty_default as pyagentspec_empty_default
+
+
+class NodeExecutor(ABC):
+    def __init__(self, node: AgentSpecNode) -> None:
+        self.node = node
+        self.edges: List[DataFlowEdge] = []
+
+    def attach_edge(self, edge: DataFlowEdge) -> None:
+        self.edges.append(edge)
+
+    @abstractmethod
+    def _execute(self, inputs: NodeInput) -> ExecuteOutput:
+        """
+        Returns the output of executing node with the given inputs.
+        """
+
+    def get_node_wrapper(self) -> Callable[..., NodeOutput]:
+        """
+        Prepares a callable that will be decorated and part of the CrewAI Flow class.
+        This wraps around the node's _execute method and handles all inputs and outputs
+        using the state variable of the CrewAI Flow.
+        """
+
+        def node_wrapper(self_flow: CrewAIFlow[FlowState], *args: Any, **kwargs: Any) -> NodeOutput:
+            inputs = self._get_inputs(self_flow.state)
+            execute_outputs = self._execute(inputs)
+            node_outputs = self._update_status(self_flow.state, execute_outputs)
+
+            return node_outputs
+
+        return node_wrapper
+
+    def _get_inputs(self, state: FlowState) -> NodeInput:
+        input_properties = self.node.inputs or []
+        input_values = {}
+
+        for edge in self.edges:
+            if edge.destination_node.id == self.node.id:
+                property_name = edge.destination_input
+                property_name_global = self._globalize_property_name(property_name)
+                input_values[property_name] = state[property_name_global]
+
+        return self._cast_values_and_add_defaults(input_values, input_properties)
+
+    def _update_status(self, state: FlowState, outputs: ExecuteOutput) -> NodeOutput:
+        output_properties = self.node.outputs or []
+        output_values = self._cast_values_and_add_defaults(outputs, output_properties)
+
+        for edge in self.edges:
+            if edge.source_node.id == self.node.id:
+                property_value = output_values[edge.source_output]
+
+                output_property_name_global = self._globalize_property_name(edge.source_output)
+                state[output_property_name_global] = property_value
+
+                next_input_property_name_global = self._globalize_property_name(
+                    edge.destination_input, edge.destination_node.id
+                )
+                state[next_input_property_name_global] = property_value
+
+        return {
+            property.title: output_values[property.title]
+            for property in output_properties
+            if property.title in output_values
+        }
+
+    def _globalize_property_name(self, property_name: str, node_id: Optional[str] = None) -> str:
+        return f"{node_id or self.node.id}::{property_name}"
+
+    def _cast_values_and_add_defaults(
+        self,
+        values_dict: Dict[str, Any],
+        properties: List[AgentSpecProperty],
+    ) -> Dict[str, Any]:
+        results_dict: Dict[str, Any] = {}
+        for property_ in properties:
+            key = property_.title
+            if key in values_dict:
+                value = values_dict.get(key)
+                if property_.type == "string" and not isinstance(value, str):
+                    value = json.dumps(value)
+                elif property_.type == "boolean" and isinstance(value, (int, float)):
+                    value = bool(value)
+                elif property_.type == "integer" and isinstance(value, (float, bool)):
+                    value = int(value)
+                elif property_.type == "number" and isinstance(value, (int, bool)):
+                    value = float(value)
+                results_dict[key] = value
+            elif property_.default is not pyagentspec_empty_default:
+                results_dict[key] = property_.default
+            else:
+                raise ValueError(
+                    f"Expected node `{self.node.name}` to have a value "
+                    f"for property `{property_.title}`, but none was found."
+                )
+        return results_dict
+
+
+class StartNodeExecutor(NodeExecutor):
+    node: AgentSpecStartNode
+
+    def _get_inputs(self, state: FlowState) -> NodeInput:
+        input_properties = self.node.inputs or []
+        input_values = {}
+
+        for property in input_properties:
+            if property.title in state:
+                input_values[property.title] = state[property.title]
+
+        return self._cast_values_and_add_defaults(input_values, input_properties)
+
+    def _execute(self, inputs: NodeInput) -> ExecuteOutput:
+        return inputs
+
+
+class EndNodeExecutor(NodeExecutor):
+    node: AgentSpecEndNode
+
+    def _update_status(self, state: FlowState, outputs: ExecuteOutput) -> NodeOutput:
+        output_properties = self.node.outputs or []
+        output_values = {}
+
+        for property in output_properties:
+            if property.title in outputs:
+                output_values[property.title] = outputs[property.title]
+
+        output_values = self._cast_values_and_add_defaults(output_values, output_properties)
+
+        for property_name, property_value in output_values.items():
+            state[self._globalize_property_name(property_name)] = property_value
+
+        return output_values
+
+    def _execute(self, inputs: NodeInput) -> ExecuteOutput:
+        return inputs
+
+
+class ToolNodeExecutor(NodeExecutor):
+    node: AgentSpecToolNode
+
+    def __init__(self, node: AgentSpecToolNode, tool: CrewAITool) -> None:
+        super().__init__(node)
+        if not isinstance(self.node, AgentSpecToolNode):
+            raise TypeError("ToolNodeExecutor can only be initialized with ToolNode")
+        self.tool = tool
+
+    def _execute(self, inputs: NodeInput) -> ExecuteOutput:
+        tool_output = self.tool.run(**inputs)
+
+        if isinstance(tool_output, dict):
+            return tool_output
+
+        output_name = self.node.outputs[0].title if self.node.outputs else "tool_output"
+        return {output_name: tool_output}
+
+
+class LlmNodeExecutor(NodeExecutor):
+    node: AgentSpecLlmNode
+
+    def __init__(self, node: AgentSpecLlmNode, llm: CrewAILlm) -> None:
+        super().__init__(node)
+
+        self.llm: CrewAILlm = llm
+
+        node_outputs = self.node.outputs or []
+        requires_structured_generation = not (
+            len(node_outputs) == 1 and node_outputs[0].type == "string"
+        )
+        if requires_structured_generation:
+            self.llm.response_format = create_pydantic_model_from_properties(
+                self.node.name.title() + "ResponseFormat", node_outputs
+            )
+
+    def _execute(self, inputs: Dict[str, Any]) -> ExecuteOutput:
+        prompt_template = self.node.prompt_template
+        rendered_prompt = render_template(prompt_template, inputs)
+
+        generated_message = self.llm.call(rendered_prompt)
+
+        if self.llm.response_format is not None:
+            if not isinstance(generated_message, BaseModel):
+                raise TypeError(
+                    f"Expected LLM response format to be BaseModel, got {type(generated_message)!r}"
+                )
+
+            return generated_message.dict()
+        else:
+            node_outputs = self.node.outputs or []
+            output_name = node_outputs[0].title if node_outputs else "generated_text"
+            return {output_name: generated_message}
+
+
+class InputMessageNodeExecutor(NodeExecutor):
+    node: AgentSpecInputMessageNode
+
+    def _execute(self, inputs: Dict[str, Any]) -> ExecuteOutput:
+        from crewai.events.event_listener import event_listener
+        from crewai.utilities.printer import Printer
+
+        printer = Printer()
+        event_listener.formatter.pause_live_updates()
+
+        try:
+            printer.print(content=f"\nPlease provide your input message:", color="bold_yellow")
+            response = input().strip()
+            output_name = (
+                self.node.outputs[0].title
+                if self.node.outputs
+                else AgentSpecInputMessageNode.DEFAULT_OUTPUT
+            )
+            return {output_name: response}
+        finally:
+            event_listener.formatter.resume_live_updates()
+
+
+class OutputMessageNodeExecutor(NodeExecutor):
+    node: AgentSpecOutputMessageNode
+
+    def _execute(self, inputs: Dict[str, Any]) -> ExecuteOutput:
+        from crewai.events.event_listener import event_listener
+        from crewai.utilities.printer import Printer
+
+        printer = Printer()
+        event_listener.formatter.pause_live_updates()
+
+        try:
+            message = render_template(self.node.message, inputs)
+            printer.print(content=f"\n{message}\n", color="bold_yellow")
+            return {}
+        finally:
+            event_listener.formatter.resume_live_updates()

--- a/pyagentspec/src/pyagentspec/adapters/crewai/_types.py
+++ b/pyagentspec/src/pyagentspec/adapters/crewai/_types.py
@@ -4,7 +4,9 @@
 # (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 
-from typing import TYPE_CHECKING, Any, Callable, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Hashable, Union
+
+from typing_extensions import TypeAlias
 
 from pyagentspec._lazy_loader import LazyLoader
 
@@ -40,6 +42,9 @@ if TYPE_CHECKING:
     from crewai.events.types.tool_usage_events import (
         ToolUsageStartedEvent as CrewAIToolUsageStartedEvent,
     )
+    from crewai.flow.flow import listen as CrewAIListenNode
+    from crewai.flow.flow import or_ as CrewAIOrOperator
+    from crewai.flow.flow import start as CrewAIStartNode
     from crewai.tools import BaseTool as CrewAIBaseTool
     from crewai.tools.base_tool import Tool as CrewAITool
     from crewai.tools.structured_tool import CrewStructuredTool as CrewAIStructuredTool
@@ -78,9 +83,22 @@ else:
     CrewAIToolUsageStartedEvent = LazyLoader(
         "crewai.events.types.tool_usage_events"
     ).ToolUsageStartedEvent
+    CrewAIStartNode = LazyLoader("crewai.flow.flow").start
+    CrewAIListenNode = LazyLoader("crewai.flow.flow").listen
+    CrewAIOrOperator = LazyLoader("crewai.flow.flow").or_
 
 CrewAIComponent = Union[CrewAIAgent, CrewAIFlow[Any]]
 CrewAIServerToolType = Union[CrewAITool, Callable[..., Any]]
+
+NodeInput: TypeAlias = Union[Dict[str, Any]]
+NodeOutput: TypeAlias = Union[Dict[str, Any]]
+ExecuteOutput: TypeAlias = Union[Dict[str, Any]]
+FlowState: TypeAlias = Dict[str, Any]
+
+SourceNodeId: TypeAlias = str
+BranchName: TypeAlias = Hashable
+TargetNodeId: TypeAlias = str
+ControlFlow: TypeAlias = Dict[SourceNodeId, Dict[BranchName, TargetNodeId]]
 
 __all__ = [
     "crewai",
@@ -91,6 +109,9 @@ __all__ = [
     "CrewAIBaseTool",
     "CrewAITool",
     "CrewAIStructuredTool",
+    "CrewAIStartNode",
+    "CrewAIListenNode",
+    "CrewAIOrOperator",
     "CrewAIComponent",
     "CrewAIServerToolType",
     "CrewAIBaseEvent",
@@ -105,4 +126,11 @@ __all__ = [
     "CrewAIAgentExecutionCompletedEvent",
     "CrewAILiteAgentExecutionStartedEvent",
     "CrewAILiteAgentExecutionCompletedEvent",
+    "NodeInput",
+    "NodeOutput",
+    "FlowState",
+    "SourceNodeId",
+    "BranchName",
+    "TargetNodeId",
+    "ControlFlow",
 ]

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/_langgraphconverter.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/_langgraphconverter.py
@@ -9,14 +9,12 @@ import logging
 import sys
 from typing import (
     TYPE_CHECKING,
-    Annotated,
     Any,
     AsyncGenerator,
     Callable,
     Dict,
     Generator,
     List,
-    Literal,
     Optional,
     Tuple,
     TypeGuard,
@@ -25,11 +23,16 @@ from typing import (
 )
 from uuid import uuid4
 
-from pydantic import BaseModel, ConfigDict, Field, SecretStr, create_model
+from pydantic import BaseModel, SecretStr
 from typing_extensions import NotRequired, Required
 
 from pyagentspec import Component as AgentSpecComponent
 from pyagentspec.adapters._tools_common import _create_remote_tool_func
+from pyagentspec.adapters._utils import (
+    SchemaRegistry,
+    _build_type_from_schema,
+    create_pydantic_model_from_properties,
+)
 from pyagentspec.adapters.langgraph._node_execution import (
     NodeExecutor,
     extract_outputs_from_invoke_result,
@@ -130,128 +133,6 @@ def _ensure_mcp_dependency_installed() -> None:
             "langchain-mcp-adapters is required to preload MCP tools. "
             "Install it (e.g., pip install langchain-mcp-adapters) or remove MCP tools from the spec."
         )
-
-
-class SchemaRegistry:
-    def __init__(self) -> None:
-        self.models: Dict[str, type[BaseModel]] = {}
-
-
-def _build_type_from_schema(
-    name: str,
-    schema: Dict[str, Any],
-    registry: SchemaRegistry,
-) -> Any:
-    # Enum -> Literal[…]
-    if "enum" in schema and isinstance(schema["enum"], list):
-        values = schema["enum"]
-        # Literal supports a tuple of literal values as a single subscription argument
-        return Literal[tuple(values)]
-
-    # anyOf / oneOf -> Union[…]
-    for key in ("anyOf", "oneOf"):
-        if key in schema:
-            variants = [
-                _build_type_from_schema(f"{name}Alt{i}", s, registry)
-                for i, s in enumerate(schema[key])
-            ]
-            return Union[tuple(variants)]
-
-    t = schema.get("type")
-
-    # list of types -> Union[…]
-    if isinstance(t, list):
-        variants = [
-            _build_type_from_schema(f"{name}Alt{i}", {"type": subtype}, registry)
-            for i, subtype in enumerate(t)
-        ]
-        return Union[tuple(variants)]
-
-    # arrays
-    if t == "array":
-        items_schema = schema.get("items", {"type": "any"})
-        item_type = _build_type_from_schema(f"{name}Item", items_schema, registry)
-        return List[item_type]  # type: ignore
-    # objects
-    if t == "object" or ("properties" in schema or "required" in schema):
-        # Create or reuse a Pydantic model for this object schema
-        model_name = schema.get("title") or name
-        unique_name = model_name
-        suffix = 1
-        while unique_name in registry.models:
-            suffix += 1
-            unique_name = f"{model_name}_{suffix}"
-
-        props = schema.get("properties", {}) or {}
-        required = set(schema.get("required", []))
-
-        fields: Dict[str, Tuple[Any, Any]] = {}
-        for prop_name, prop_schema in props.items():
-            prop_type = _build_type_from_schema(f"{unique_name}_{prop_name}", prop_schema, registry)
-            desc = prop_schema.get("description")
-            default_field = (
-                Field(..., description=desc)
-                if prop_name in required
-                else Field(None, description=desc)
-            )
-            fields[prop_name] = (prop_type, default_field)
-
-        # Enforce additionalProperties: False (extra=forbid)
-        extra_forbid = schema.get("additionalProperties") is False
-        model_kwargs: Dict[str, Any] = {}
-        if extra_forbid:
-            # Pydantic v2: pass a ConfigDict/dict into __config__
-            model_kwargs["__config__"] = ConfigDict(extra="forbid")
-
-        model_cls = create_model(unique_name, **fields, **model_kwargs)  # type: ignore
-        registry.models[unique_name] = model_cls
-        return model_cls
-
-    # primitives / fallback
-    mapping = {
-        "string": str,
-        "number": float,
-        "integer": int,
-        "boolean": bool,
-        "null": type(None),
-        "any": Any,
-        None: Any,
-        "": Any,
-    }
-    return mapping.get(t, Any)
-
-
-def _create_pydantic_model_from_properties(
-    model_name: str, properties: List[AgentSpecProperty]
-) -> type[BaseModel]:
-    from langchain_core.messages import BaseMessage
-    from langgraph.graph.message import add_messages
-
-    registry = SchemaRegistry()
-    fields: Dict[str, Tuple[Any, Any]] = {}
-
-    for property_ in properties:
-        field_params: Dict[str, Any] = {}
-        if property_.description:
-            field_params["description"] = property_.description
-
-        annotation: Any
-        if property_.title == "messages":
-            # Special-case: LangGraph messages state
-            annotation = Annotated[list[BaseMessage], add_messages]
-            default_field = Field(..., **field_params)  # required
-        else:
-            # Otherwise: build the annotation from the json_schema
-            # (handles enum/array/object/etc.)
-            annotation = _build_type_from_schema(property_.title, property_.json_schema, registry)
-            if property_.default is not _agentspec_empty_default:
-                default_field = Field(property_.default, **field_params)
-            else:
-                default_field = Field(..., **field_params)
-
-        fields[property_.title] = (annotation, default_field)
-
-    return create_model(model_name, **fields)  # type: ignore
 
 
 def _create_agent_state_typed_dict(
@@ -866,7 +747,7 @@ class AgentSpecToLangGraphConverter:
         )
 
         # Use a Pydantic model for args_schema
-        args_model = _create_pydantic_model_from_properties(
+        args_model = create_pydantic_model_from_properties(
             f"{tool_name}Args",
             remote_tool.inputs or [],
         )
@@ -937,7 +818,7 @@ class AgentSpecToLangGraphConverter:
             requires_confirmation=requires_confirmation,
         )
 
-        args_model = _create_pydantic_model_from_properties(
+        args_model = create_pydantic_model_from_properties(
             f"{tool_name}Args",
             agentspec_server_tool.inputs or [],
         )
@@ -987,7 +868,7 @@ class AgentSpecToLangGraphConverter:
             return response
 
         # Use a Pydantic model for args_schema
-        args_model = _create_pydantic_model_from_properties(
+        args_model = create_pydantic_model_from_properties(
             f"{tool_name}Args",
             agentspec_client_tool.inputs or [],
         )
@@ -1114,7 +995,7 @@ class AgentSpecToLangGraphConverter:
 
         # Build response (output) model (used for response_format)
         if outputs:
-            output_model = _create_pydantic_model_from_properties("AgentOutputModel", outputs)
+            output_model = create_pydantic_model_from_properties("AgentOutputModel", outputs)
 
         if inputs:
             state_schema = _create_agent_state_typed_dict(

--- a/pyagentspec/tests/adapters/crewai/conftest.py
+++ b/pyagentspec/tests/adapters/crewai/conftest.py
@@ -54,3 +54,14 @@ def no_network_plusapi(monkeypatch):
         monkeypatch.setattr(PlusAPI, "_make_request", fake_response, raising=True)
     except ImportError:
         pass
+
+
+@pytest.fixture
+def mute_crewai_console_prints():
+    try:
+        from crewai.events.event_listener import event_listener as default_listener
+        from crewai.events.utils.console_formatter import ConsoleFormatter
+    except Exception:
+        return
+
+    default_listener.formatter = ConsoleFormatter(verbose=False)

--- a/pyagentspec/tests/adapters/crewai/flows/test_inputmessagenode_crewai.py
+++ b/pyagentspec/tests/adapters/crewai/flows/test_inputmessagenode_crewai.py
@@ -1,0 +1,60 @@
+# Copyright © 2025 Oracle and/or its affiliates.
+#
+# This software is under the Apache License 2.0
+# (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
+# (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
+
+import pytest
+
+from pyagentspec.flows.edges import ControlFlowEdge, DataFlowEdge
+from pyagentspec.flows.flow import Flow
+from pyagentspec.flows.nodes import EndNode, InputMessageNode, StartNode
+from pyagentspec.property import StringProperty
+
+
+@pytest.mark.usefixtures("mute_crewai_console_prints")
+def test_inputmessagenode_can_be_imported_and_executed(monkeypatch) -> None:
+    from crewai import Flow as CrewAIFlow
+
+    from pyagentspec.adapters.crewai import AgentSpecLoader
+
+    # Mock interactive input() used by InputMessageNodeExecutor
+    monkeypatch.setattr("builtins.input", lambda: "3")
+
+    custom_input_property = StringProperty(title="custom_input")
+    input_message_node = InputMessageNode(
+        name="input_message",
+        outputs=[custom_input_property],
+    )
+    start_node = StartNode(name="start")
+    end_node = EndNode(name="end", outputs=[custom_input_property])
+
+    flow = Flow(
+        name="flow",
+        start_node=start_node,
+        nodes=[start_node, input_message_node, end_node],
+        control_flow_connections=[
+            ControlFlowEdge(name="start_to_node", from_node=start_node, to_node=input_message_node),
+            ControlFlowEdge(name="node_to_end", from_node=input_message_node, to_node=end_node),
+        ],
+        data_flow_connections=[
+            DataFlowEdge(
+                name="input_edge",
+                source_node=input_message_node,
+                source_output=custom_input_property.title,
+                destination_node=end_node,
+                destination_input=custom_input_property.title,
+            ),
+        ],
+        outputs=[custom_input_property],
+    )
+
+    flow_instance = AgentSpecLoader().load_component(flow)
+
+    assert isinstance(flow_instance, CrewAIFlow)
+
+    result = flow_instance.kickoff()
+
+    assert isinstance(result, dict)
+    assert custom_input_property.title in result
+    assert result[custom_input_property.title] == "3"

--- a/pyagentspec/tests/adapters/crewai/flows/test_llmnode_crewai.py
+++ b/pyagentspec/tests/adapters/crewai/flows/test_llmnode_crewai.py
@@ -1,0 +1,77 @@
+# Copyright © 2025 Oracle and/or its affiliates.
+#
+# This software is under the Apache License 2.0
+# (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
+# (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
+
+import os
+
+import pytest
+
+from pyagentspec.flows.edges import ControlFlowEdge, DataFlowEdge
+from pyagentspec.flows.flow import Flow
+from pyagentspec.flows.nodes import EndNode, LlmNode, StartNode
+from pyagentspec.llms import OpenAiCompatibleConfig
+from pyagentspec.property import StringProperty
+
+
+@pytest.mark.usefixtures("mute_crewai_console_prints")
+def test_llmnode_can_be_imported_and_executed() -> None:
+    from crewai import Flow as CrewAIFlow
+
+    from pyagentspec.adapters.crewai import AgentSpecLoader
+
+    nationality_property = StringProperty(title="nationality")
+    car_property = StringProperty(title="car")
+    llm_config = OpenAiCompatibleConfig(
+        name="llm_config",
+        model_id="/storage/models/Llama-3.3-70B-Instruct",
+        url=os.environ.get("LLAMA_API_URL"),
+    )
+    llm_node = LlmNode(
+        name="llm_node",
+        llm_config=llm_config,
+        prompt_template="What is the fastest {{nationality}} car? Output in the format <country>: <car_brand>",
+        inputs=[nationality_property],
+        outputs=[car_property],
+    )
+    start_node = StartNode(name="start", inputs=[nationality_property])
+    end_node = EndNode(name="end", outputs=[car_property])
+
+    flow = Flow(
+        name="flow",
+        start_node=start_node,
+        nodes=[start_node, llm_node, end_node],
+        control_flow_connections=[
+            ControlFlowEdge(name="start_to_node", from_node=start_node, to_node=llm_node),
+            ControlFlowEdge(name="node_to_end", from_node=llm_node, to_node=end_node),
+        ],
+        data_flow_connections=[
+            DataFlowEdge(
+                name="input_edge",
+                source_node=start_node,
+                source_output=nationality_property.title,
+                destination_node=llm_node,
+                destination_input=nationality_property.title,
+            ),
+            DataFlowEdge(
+                name="car_edge",
+                source_node=llm_node,
+                source_output=car_property.title,
+                destination_node=end_node,
+                destination_input=car_property.title,
+            ),
+        ],
+        outputs=[car_property],
+    )
+
+    flow_instance = AgentSpecLoader().load_component(flow)
+
+    assert isinstance(flow_instance, CrewAIFlow)
+
+    result = flow_instance.kickoff({"nationality": "italian"})
+
+    assert isinstance(result, dict)
+    assert car_property.title in result
+    assert isinstance(result[car_property.title], str)
+    assert result[car_property.title] != ""

--- a/pyagentspec/tests/adapters/crewai/flows/test_outputmessagenode_crewai.py
+++ b/pyagentspec/tests/adapters/crewai/flows/test_outputmessagenode_crewai.py
@@ -1,0 +1,69 @@
+# Copyright © 2025 Oracle and/or its affiliates.
+#
+# This software is under the Apache License 2.0
+# (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
+# (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
+
+import pytest
+
+from pyagentspec.flows.edges import ControlFlowEdge, DataFlowEdge
+from pyagentspec.flows.flow import Flow
+from pyagentspec.flows.nodes import EndNode, OutputMessageNode, StartNode
+from pyagentspec.property import StringProperty
+
+
+@pytest.mark.usefixtures("mute_crewai_console_prints")
+def test_outputmessagenode_can_be_imported_and_executed(monkeypatch) -> None:
+    from crewai import Flow as CrewAIFlow
+
+    from pyagentspec.adapters.crewai import AgentSpecLoader
+
+    # Capture printed message from OutputMessageNodeExecutor via Printer.print
+    captured: dict[str, str] = {}
+
+    def fake_print(self, content: str = "", color=None) -> None:
+        captured["content"] = content
+
+    monkeypatch.setattr("crewai.utilities.printer.Printer.print", fake_print, raising=True)
+
+    custom_input_property = StringProperty(title="custom_input")
+    output_message_node = OutputMessageNode(
+        name="output_message",
+        message="Hey {{custom_input}}",
+        inputs=[custom_input_property],
+    )
+    start_node = StartNode(name="start", inputs=[custom_input_property])
+    end_node = EndNode(name="end")
+
+    flow = Flow(
+        name="flow",
+        start_node=start_node,
+        nodes=[start_node, output_message_node, end_node],
+        control_flow_connections=[
+            ControlFlowEdge(
+                name="start_to_node", from_node=start_node, to_node=output_message_node
+            ),
+            ControlFlowEdge(name="node_to_end", from_node=output_message_node, to_node=end_node),
+        ],
+        data_flow_connections=[
+            DataFlowEdge(
+                name="input_edge",
+                source_node=start_node,
+                source_output=custom_input_property.title,
+                destination_node=output_message_node,
+                destination_input=custom_input_property.title,
+            ),
+        ],
+        inputs=[custom_input_property],
+    )
+
+    flow_instance = AgentSpecLoader().load_component(flow)
+
+    assert isinstance(flow_instance, CrewAIFlow)
+
+    result = flow_instance.kickoff({"custom_input": "custom"})
+
+    assert isinstance(result, dict)
+    assert result == {}
+    assert "content" in captured
+    assert captured["content"].strip() == "Hey custom"

--- a/pyagentspec/tests/adapters/crewai/flows/test_toolnode_crewai.py
+++ b/pyagentspec/tests/adapters/crewai/flows/test_toolnode_crewai.py
@@ -1,0 +1,74 @@
+# Copyright © 2025 Oracle and/or its affiliates.
+#
+# This software is under the Apache License 2.0
+# (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
+# (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
+
+import pytest
+
+from pyagentspec.flows.edges import ControlFlowEdge, DataFlowEdge
+from pyagentspec.flows.flow import Flow
+from pyagentspec.flows.nodes import EndNode, StartNode, ToolNode
+from pyagentspec.property import Property
+from pyagentspec.tools import ServerTool
+
+
+@pytest.mark.usefixtures("mute_crewai_console_prints")
+def test_toolnode_can_be_imported_and_executed() -> None:
+    from crewai import Flow as CrewAIFlow
+
+    from pyagentspec.adapters.crewai import AgentSpecLoader
+
+    x_property = Property(json_schema={"title": "input", "type": "number"})
+    x_square_property = Property(json_schema={"title": "input_square", "type": "number"})
+
+    square_tool = ServerTool(
+        name="square_tool",
+        description="Computes the square of a number",
+        inputs=[x_property],
+        outputs=[x_square_property],
+    )
+
+    start_node = StartNode(name="subflow_start", inputs=[x_property])
+    end_node = EndNode(name="subflow_end", outputs=[x_square_property])
+    square_tool_node = ToolNode(name="square_tool_node", tool=square_tool)
+
+    flow = Flow(
+        name="Square number flow",
+        start_node=start_node,
+        nodes=[start_node, square_tool_node, end_node],
+        control_flow_connections=[
+            ControlFlowEdge(name="start_to_tool", from_node=start_node, to_node=square_tool_node),
+            ControlFlowEdge(name="tool_to_end", from_node=square_tool_node, to_node=end_node),
+        ],
+        data_flow_connections=[
+            DataFlowEdge(
+                name="input_edge",
+                source_node=start_node,
+                source_output="input",
+                destination_node=square_tool_node,
+                destination_input="input",
+            ),
+            DataFlowEdge(
+                name="input_square_edge",
+                source_node=square_tool_node,
+                source_output="input_square",
+                destination_node=end_node,
+                destination_input="input_square",
+            ),
+        ],
+    )
+
+    def square_tool_callable(input: float) -> float:
+        return input * input
+
+    tool_registry = {"square_tool": square_tool_callable}
+    flow_instance = AgentSpecLoader(tool_registry).load_component(flow)
+
+    assert isinstance(flow_instance, CrewAIFlow)
+
+    result = flow_instance.kickoff({"input": 4})
+
+    assert isinstance(result, dict)
+    assert "input_square" in result
+    assert result["input_square"] == 16.0

--- a/pyagentspec/tests/adapters/crewai/test_crewai_to_agentspec.py
+++ b/pyagentspec/tests/adapters/crewai/test_crewai_to_agentspec.py
@@ -1,0 +1,104 @@
+# Copyright © 2025 Oracle and/or its affiliates.
+#
+# This software is under the Apache License 2.0
+# (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
+# (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
+
+
+import os
+from secrets import choice
+from typing import TYPE_CHECKING, Any, Dict
+
+import pytest
+
+from pyagentspec.component import Component as AgentSpecComponent
+from pyagentspec.flows.flow import Flow as AgentSpecFlow
+
+if TYPE_CHECKING:
+    from crewai import Flow as CrewAIFlow
+
+    from pyagentspec.adapters.crewai import AgentSpecExporter
+
+
+@pytest.fixture
+def agentspec_exporter() -> "AgentSpecExporter":
+    from pyagentspec.adapters.crewai import AgentSpecExporter
+
+    return AgentSpecExporter()
+
+
+@pytest.fixture
+def crewai_flow() -> "CrewAIFlow":
+    from crewai import LLM as CrewAILlm
+    from crewai import Flow as CrewAIFlow
+    from crewai.flow.flow import listen, start
+
+    class PoemFlow(CrewAIFlow):
+
+        @start()
+        def generate_sentence_count(self) -> int:
+            return choice([1, 2, 3])
+
+        @listen(generate_sentence_count)
+        def generate_poem(self, sentence_count) -> str:
+            try:
+                llm = CrewAILlm(
+                    model="openai//storage/models/Llama-3.3-70B-Instruct",
+                    api_base=f"http://{os.environ.get('LLAMA_API_URL')}/v1",
+                    api_key="fake-api-key",
+                )
+                return llm.call(f"Generate a very short poem with {sentence_count} sentences")
+            except Exception:
+                return " ".join(["Very poetic sentence."] * sentence_count)
+
+        @listen(generate_poem)
+        def add_title(self, poem_text) -> str:
+            return f"The Best Poem\n{poem_text}"
+
+    return PoemFlow()
+
+
+def _get_tool_registry(flow: "CrewAIFlow") -> Dict[str, Any]:
+    """
+    CrewAI flows store the callables for their nodes in a private dict field called _methods.
+    We can reuse this as the tool registry for AgentSpecLoader.
+    """
+    return flow._methods
+
+
+def test_convert_flow_to_agentspec(
+    crewai_flow: "CrewAIFlow",
+    agentspec_exporter: "AgentSpecExporter",
+) -> None:
+    agentspec_flow: AgentSpecComponent = agentspec_exporter.to_component(crewai_flow)
+
+    assert isinstance(agentspec_flow, AgentSpecFlow)
+    assert len(agentspec_flow.nodes) == 5
+    assert set([n.name for n in agentspec_flow.nodes]) == set(
+        ["START", "END", "generate_sentence_count", "generate_poem", "add_title"]
+    )
+    assert len(agentspec_flow.control_flow_connections) == 4
+    assert len(agentspec_flow.data_flow_connections) == 3
+    assert len(agentspec_flow.outputs) == 1
+    assert agentspec_flow.outputs[0].title == "add_title_output"
+
+
+@pytest.mark.usefixtures("mute_crewai_console_prints")
+def test_convert_flow_to_agentspec_and_back_with_kickoff(
+    crewai_flow: "CrewAIFlow",
+    agentspec_exporter: "AgentSpecExporter",
+):
+    from pyagentspec.adapters.crewai import AgentSpecLoader
+
+    agentspec_flow_json: AgentSpecComponent = agentspec_exporter.to_json(crewai_flow)
+
+    tool_registry = _get_tool_registry(crewai_flow)
+    agentspec_loader = AgentSpecLoader(tool_registry=tool_registry)
+    crewai_flow_reproduced = agentspec_loader.load_json(agentspec_flow_json)
+
+    result = crewai_flow_reproduced.kickoff()
+
+    assert isinstance(result, dict)
+    assert len(result) == 1
+    assert "add_title_output" in result
+    assert result["add_title_output"].startswith("The Best Poem")


### PR DESCRIPTION
### AgentSpec -> CrewAI

- supported: StartNode, EndNode, ToolNode, LlmNode, InputMessageNode, OutputMessageNode
- not supported: branching (most notably)

### CrewAI -> AgentSpec

- all nodes are mapped to ToolNode
- not supported: branching (routers, listeners with multiple triggers)