### PR TITLE
disallow empty titles in properties

### DIFF
--- a/docs/pyagentspec/source/changelog.rst
+++ b/docs/pyagentspec/source/changelog.rst
@@ -38,6 +38,13 @@ New features
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 
+* **Empty titles in properties**
+
+Property titles in Agent Spec must not be empty. This is now enforced by validation in the pyagentspec SDK.
+
+Migration: If your YAML/JSON configurations have properties without titles, you’ll need to set a non-empty, descriptive title for those properties to pass validation. If you generate Agent Spec configurations via the SDK, your code may still work, but we recommend explicitly setting property titles to ensure forward compatibility.
+
+
 Agent Spec 26.1.0
 -----------------
 

--- a/pyagentspec/src/pyagentspec/property.py
+++ b/pyagentspec/src/pyagentspec/property.py
@@ -89,6 +89,12 @@ class Property(BaseModel):
             self.type = self.json_schema["type"]
 
     @model_validator_with_error_accumulation
+    def _validate_no_empty_titles(self) -> Self:
+        if len(self.title) == 0:
+            raise ValueError(f"Property {self.json_schema} cannot have an empty title")
+        return self
+
+    @model_validator_with_error_accumulation
     def _validate_default(self) -> Self:
         if self.default is Property.empty_default:
             return self

--- a/pyagentspec/tests/test_componentwithio.py
+++ b/pyagentspec/tests/test_componentwithio.py
@@ -46,21 +46,26 @@ def test_component_with_no_inputs_raises_when_input_is_passed() -> None:
         component_cls(name="my_component", inputs=[StringProperty(title="input_1")])
 
 
-def test_component_with_no_inputs_raises_when_empty_input_is_passed() -> None:
-    with pytest.raises(
-        ValueError,
-        match=(
-            r"The MockComponent component received a property titled ``, but did not expect any properties"
-        ),
-    ):
-        component_cls = create_mock_component_cls_with_defaults([], [])
-        component_cls(name="my_component", inputs=[StringProperty(title="")])
-
-
 def test_component_with_inputs_works_when_passed_correct_input() -> None:
     component_cls = create_mock_component_cls_with_defaults([StringProperty(title="input_1")], [])
     component = component_cls(name="my_component", inputs=[StringProperty(title="input_1")])
     assert component.inputs == [StringProperty(title="input_1")]
+
+
+def test_component_with_empty_title_input_raises() -> None:
+    with pytest.raises(ValueError, match=("cannot have an empty title")):
+        component_cls = create_mock_component_cls_with_defaults([StringProperty(title="")], [])
+        component_cls(name="my_component", inputs=[StringProperty(title="")])
+
+
+def test_component_with_empty_input_in_json_schema_raises() -> None:
+    with pytest.raises(ValueError, match=("cannot have an empty title")):
+        component_cls = create_mock_component_cls_with_defaults(
+            [Property(json_schema={"type": "string", "title": ""})], []
+        )
+        component_cls(
+            name="my_component", inputs=[Property(json_schema={"type": "string", "title": ""})]
+        )
 
 
 def test_component_with_inputs_raises_when_missing_inputs_are_not_passed() -> None:
@@ -77,20 +82,6 @@ def test_component_with_inputs_raises_when_missing_inputs_are_not_passed() -> No
         component_cls(name="my_component", inputs=[StringProperty(title="input_1")])
 
 
-def test_component_with_inputs_and_empty_title_raises_when_missing_inputs_are_not_passed() -> None:
-    with pytest.raises(
-        ValueError,
-        match=(
-            r"The MockComponent component expected a property titled ``, but none of the passed "
-            r"properties have this title:"
-        ),
-    ):
-        component_cls = create_mock_component_cls_with_defaults(
-            [StringProperty(title="input_1"), StringProperty(title="")], []
-        )
-        component_cls(name="my_component", inputs=[StringProperty(title="input_1")])
-
-
 def test_component_with_non_unique_inputs_raises() -> None:
     with pytest.raises(
         ValueError,
@@ -102,20 +93,6 @@ def test_component_with_non_unique_inputs_raises() -> None:
         component_cls(
             name="my_component",
             inputs=[StringProperty(title="input_1"), StringProperty(title="input_1")],
-        )
-
-
-def test_component_with_non_unique_empty_inputs_raises() -> None:
-    with pytest.raises(
-        ValueError,
-        match=r".*Found multiple instances of properties \(inputs or outputs\) with the same title in a MockComponent.*",
-    ):
-        component_cls = create_mock_component_cls_with_defaults(
-            [StringProperty(title=""), StringProperty(title="")], []
-        )
-        component_cls(
-            name="my_component",
-            inputs=[StringProperty(title=""), StringProperty(title="")],
         )
 
 


### PR DESCRIPTION
Add validation to disallow empty titles in properties

P.S: The tests that are removed are not needed anymore since empty titles are caught earlier by this new validation