### PR TITLE
Restore Placeholder properties function (backwards compatibility)

### DIFF
--- a/pyagentspec/src/pyagentspec/templating.py
+++ b/pyagentspec/src/pyagentspec/templating.py
@@ -25,6 +25,13 @@ def get_placeholders_from_string(string_with_placeholders: str) -> List[str]:
     )
 
 
+def get_placeholder_properties_from_string(
+    string_with_placeholders: str,
+) -> List[Property]:
+    """Get the property descriptions for the placeholder names extracted from a string (backwards compatible)."""
+    return get_placeholder_properties_from_json_object(string_with_placeholders)
+
+
 def get_placeholder_properties_from_json_object(
     object: Any,
 ) -> List[Property]:


### PR DESCRIPTION
**Context**: In [this commit](https://github.com/oracle/agent-spec/commit/68ad569adb03cb672e02bd7f3060cb63a65ce3bd#diff-a2718a6a60dc05adc9f249795b38dc92844a826b55c92371abca299f4737629a), the public API `get_placeholder_properties_from_string` was changed to `get_placeholder_properties_from_json_object`. However, the `get_placeholder_properties_from_string` API is needed for backwards compatibility in AgentSpec and Oracle WayFlow. 

**Fix**: Restore `get_placeholder_properties_from_string` to now call `get_placeholder_properties_from_json_object` internally. 