### PR TITLE
Draft: feat: Add Tool Confirmation for LangGraph adapter

### DIFF
--- a/pyagentspec/src/pyagentspec/adapters/langgraph/_langgraphconverter.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/_langgraphconverter.py
@@ -789,6 +789,8 @@ class AgentSpecToLangGraphConverter:
             checkpointer=checkpointer,
             config=config,
         )
+
+        tools_with_confirmation = [t.name for t in tools if t.requires_confirmation]
         langgraph_tools = [
             self.convert(
                 t,
@@ -844,6 +846,7 @@ class AgentSpecToLangGraphConverter:
             checkpointer=checkpointer,
             response_format=output_model,
             state_schema=input_model,
+            interrupt_before=tools_with_confirmation,
         )
 
     def _agent_convert_to_langgraph(


### PR DESCRIPTION
**Context**: Tool Confirmation has been present in PyAgentSpec, but was not supported for the LangGraph adapter. 

**Changes**: This PR tries a best-effort support for LangGraph adapter by passing Tools (or nodes) requiring confirmation in the `interrupts_before` flag such that the execution is interrupted before the Tool is called. The user can then choose to stop the Tool from executing if needed.