### PR TITLE
Feat: [langgraph adapter] add support for exporting graph with ReAct agent node to Flow with AgentNode

### DIFF
--- a/docs/pyagentspec/source/changelog.rst
+++ b/docs/pyagentspec/source/changelog.rst
@@ -158,6 +158,13 @@ Improvements
 
   Introduced support for Python version 3.14.
 
+* **ReAct agent node conversion in LangGraph → Agent Spec**
+
+  When converting from LangGraph to Agent Spec, graphs that include a node with a ReAct agent
+  now convert into an Agent Spec Flow containing an AgentNode for that node (instead of only
+  ToolNodes). Pure ReAct agents continue to convert to an Agent, while arbitrary graphs still
+  convert to a Flow with supported node types preserved.
+
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Currently, we can only convert LangGraph ReAct agents into an AgentSpec agent, and arbitrary LangGraph graphs will get converted into a Flow with ToolNodes. In this PR we support to convert at least a graph with a node with the ReAct agent into a Flow with an AgentNode.

closes #81 