### PR TITLE
feat: support tool confirmation in langgraph adapter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         types_or: [python]
     -   id: mypy-type-checking-hook
         name: Run type checking (mypy)
-        entry: bash -xc 'mypy -- "$@"' --
+        entry: bash -xc 'mypy --config ./pyproject.toml -- "$@"' --
         language: system
         types_or: [python]
         # We exclude the fuzz tests from this check


### PR DESCRIPTION
## Context

This PR is enabling support for Tool confirmation in the Agent Spec adapter for LangGraph

**Note: Only Agent Spec -> LangGraph direction**

Using https://docs.langchain.com/oss/python/langchain/human-in-the-loop as reference