### PR TITLE
Adding the AGENTS.md file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# Core AI Tools in Oracle Agent Spec Ecosystem
+
+* Framework-agnostic agent definitions
+  Agent Spec itself is a declarative configuration language for defining AI agents and workflows (not a single AI model/tool). It lets you describe how an agent should behave, what tools it uses, and how workflows are structured — in a portable, framework-neutral format.
+
+* Runtime execution frameworks
+  To actually run agents defined with Agent Spec, you use one of several runtime/agent execution tools:
+  * WayFlow — Oracle’s reference Agent Spec runtime.
+  * LangGraph, AutoGen, CrewAI — Community or partner frameworks that can interpret and execute Agent Spec definitions.
+
+* LLM integrations (AI models)
+  Agents typically call large language models (LLMs) to generate responses, reason, plan, and act. In the Agent Spec context (especially via the PyAgentSpec SDK), supported models include:
+
+  * OCI GenAI (Oracle Cloud’s generative models)
+  * OpenAI models
+  * Ollama models
+
+  These are configured via abstraction layers in the SDK, so the agent logic stays compatible regardless of the underlying LLM.
+
+* Oracle Cloud AI Platform tools (often combined with Agent Spec)
+  When building real enterprise agents (e.g., via OCI AI Agent Platform), Oracle’s tooling can include:
+
+* Retrieval-Augmented Generation (RAG) — to fetch context from enterprise knowledge bases.
+
+* SQL tools — convert natural language to SQL and run against databases.
+
+* Custom function calling — enables agents to execute arbitrary custom functions or APIs.
+
+* User interaction tooling
+  While not part of Agent Spec’s core spec, AG-UI (Agent-User Interaction protocol) can be used alongside Agent Spec to standardize how agents communicate with front-ends and interactive apps.

--- a/docs/pyagentspec/source/changelog.rst
+++ b/docs/pyagentspec/source/changelog.rst
@@ -15,6 +15,13 @@ Improvements
   via `components_registry` when loading the main configuration. This enables keeping sensitive
   fields (like API keys) out of the main spec while still resolving them at load time.
 
+* **Added AGENTS.md file:**
+
+  Added AGENTS.md file, a dedicated, open-format guide to help AI coding agents work effectively with the project
+  by providing essential context, build/test commands, code style guidelines, and other key instructions.
+
+  We thank @kanak02rawat for the contribution!
+
 
 New features
 ^^^^^^^^^^^^


### PR DESCRIPTION
First version of the AGENTS.md file for the agentspec repo.

Copy of the PR at https://github.com/oracle/agent-spec/pull/75.
Thanks @kanak02rawat for the contribution