### PR TITLE
Agent Spec Tracing API docs

### DIFF
--- a/docs/pyagentspec/source/_components/all_components.json
+++ b/docs/pyagentspec/source/_components/all_components.json
@@ -298,6 +298,16 @@
         ]
     },
     {
+        "name": "Tracing",
+        "path": "tracing",
+        "classes": [
+            {"path": "pyagentspec.tracing.trace.Trace"},
+            {"path": "pyagentspec.tracing.spanprocessor.SpanProcessor"},
+            {"path": "pyagentspec.tracing.spans.span.Span", "name": "pyagentspec.tracing.spans.Span"},
+            {"path": "pyagentspec.tracing.events.event.Event", "name": "pyagentspec.tracing.events.Event"}
+        ]
+    },
+    {
         "name": "A2A",
         "path": "a2a",
         "classes": [

--- a/docs/pyagentspec/source/api/tracing.rst
+++ b/docs/pyagentspec/source/api/tracing.rst
@@ -1,0 +1,140 @@
+Tracing
+=======
+
+This page presents all APIs and classes related to tracing in PyAgentSpec.
+
+
+Trace
+-----
+
+.. _trace:
+.. autoclass:: pyagentspec.tracing.trace.Trace
+
+
+SpanProcessor
+-------------
+
+.. _spanprocessor:
+.. autoclass:: pyagentspec.tracing.spanprocessor.SpanProcessor
+
+
+Spans
+-----
+
+.. _span:
+.. autoclass:: pyagentspec.tracing.spans.span.Span
+
+.. _rootspan:
+.. autoclass:: pyagentspec.tracing.spans.root.RootSpan
+
+.. _agentexecutionspan:
+.. autoclass:: pyagentspec.tracing.spans.agent.AgentExecutionSpan
+
+.. _flowexecutionspan:
+.. autoclass:: pyagentspec.tracing.spans.flow.FlowExecutionSpan
+
+.. _nodeexecutionspan:
+.. autoclass:: pyagentspec.tracing.spans.node.NodeExecutionSpan
+
+.. _toolexecutionspan:
+.. autoclass:: pyagentspec.tracing.spans.tool.ToolExecutionSpan
+
+.. _llmgenerationspan:
+.. autoclass:: pyagentspec.tracing.spans.llm.LlmGenerationSpan
+
+.. _managerworkersexecutionspan:
+.. autoclass:: pyagentspec.tracing.spans.managerworkers.ManagerWorkersExecutionSpan
+
+.. _swarmexecutionspan:
+.. autoclass:: pyagentspec.tracing.spans.swarm.SwarmExecutionSpan
+
+
+Events
+------
+
+.. _event:
+.. autoclass:: pyagentspec.tracing.events.event.Event
+
+Agent Events
+~~~~~~~~~~~~
+
+.. _agentexecutionstart:
+.. autoclass:: pyagentspec.tracing.events.agent.AgentExecutionStart
+
+.. _agentexecutionend:
+.. autoclass:: pyagentspec.tracing.events.agent.AgentExecutionEnd
+
+Flow Events
+~~~~~~~~~~~
+
+.. _flowexecutionstart:
+.. autoclass:: pyagentspec.tracing.events.flow.FlowExecutionStart
+
+.. _flowexecutionend:
+.. autoclass:: pyagentspec.tracing.events.flow.FlowExecutionEnd
+
+.. _nodeexecutionstart:
+.. autoclass:: pyagentspec.tracing.events.node.NodeExecutionStart
+
+.. _nodeexecutionend:
+.. autoclass:: pyagentspec.tracing.events.node.NodeExecutionEnd
+
+Tool Events
+~~~~~~~~~~~
+
+.. _toolexecutionrequest:
+.. autoclass:: pyagentspec.tracing.events.tool.ToolExecutionRequest
+
+.. _toolexecutionresponse:
+.. autoclass:: pyagentspec.tracing.events.tool.ToolExecutionResponse
+
+.. _toolconfirmationrequest:
+.. autoclass:: pyagentspec.tracing.events.tool.ToolConfirmationRequest
+
+.. _toolconfirmationresponse:
+.. autoclass:: pyagentspec.tracing.events.tool.ToolConfirmationResponse
+
+LLM Events
+~~~~~~~~~~
+
+.. _toolcall:
+.. autoclass:: pyagentspec.tracing.events.llmgeneration.ToolCall
+
+.. _message:
+.. autoclass:: pyagentspec.tracing.messages.message.Message
+
+.. _llmgenerationrequest:
+.. autoclass:: pyagentspec.tracing.events.llmgeneration.LlmGenerationRequest
+
+.. _llmgenerationchunkreceived:
+.. autoclass:: pyagentspec.tracing.events.llmgeneration.LlmGenerationChunkReceived
+
+.. _llmgenerationresponse:
+.. autoclass:: pyagentspec.tracing.events.llmgeneration.LlmGenerationResponse
+
+Multi-agent Events
+~~~~~~~~~~~~~~~~~~
+
+.. _managerworkersexecutionstart:
+.. autoclass:: pyagentspec.tracing.events.managerworkers.ManagerWorkersExecutionStart
+
+.. _managerworkersexecutionend:
+.. autoclass:: pyagentspec.tracing.events.managerworkers.ManagerWorkersExecutionEnd
+
+.. _swarmexecutionstart:
+.. autoclass:: pyagentspec.tracing.events.swarm.SwarmExecutionStart
+
+.. _swarmexecutionend:
+.. autoclass:: pyagentspec.tracing.events.swarm.SwarmExecutionEnd
+
+Other Events
+~~~~~~~~~~~~
+
+.. _exceptionraised:
+.. autoclass:: pyagentspec.tracing.events.exception.ExceptionRaised
+
+.. _humaninthelooprequest:
+.. autoclass:: pyagentspec.tracing.events.humanintheloop.HumanInTheLoopRequest
+
+.. _humanintheloopresponse:
+.. autoclass:: pyagentspec.tracing.events.humanintheloop.HumanInTheLoopResponse

--- a/docs/pyagentspec/source/conf.py
+++ b/docs/pyagentspec/source/conf.py
@@ -212,6 +212,8 @@ nitpick_ignore_regex = [
     ("py:class", r"autogen_agentchat\..*"),
     ("py:class", r"agent_framework\..*"),
     ("py:class", r"wayflowcore\..*"),
+    ("py:class", r"agents\..*"),
+    ("py:class", r"crewai\..*"),
     # Purposely ignoring classes
     ("py:class", r"pyagentspec.serialization.serializationcontext.FieldInfoTypeT"),
     ("py:class", r"pyagentspec.serialization.serializationcontext.T"),

--- a/docs/pyagentspec/source/ecosystem/integrations.rst
+++ b/docs/pyagentspec/source/ecosystem/integrations.rst
@@ -14,7 +14,7 @@ Agent Spec Integrations
 .. |wayflow-icon| image:: ../_static/icons/wayflow-icon.svg
    :width: 250px
 
-.. |crewai-icon| image:: ../_static/icons/crewai-icon.svg
+.. |crewai-icon| image:: ../_static/icons/crewai-icon.png
    :width: 250px
 
 


### PR DESCRIPTION
Closes https://github.com/oracle/agent-spec/issues/101

Add Tracing class documentation to the APIs section of Agent Spec docs.