### PR TITLE
feat: add timeout field to RemoteTool

### DIFF
--- a/pyagentspec/src/pyagentspec/adapters/_tools_common.py
+++ b/pyagentspec/src/pyagentspec/adapters/_tools_common.py
@@ -51,6 +51,7 @@ def _create_remote_tool_func(remote_tool: AgentSpecRemoteTool) -> Callable[..., 
             data=data,
             json=json_data,
             content=content,
+            timeout=remote_tool.timeout,
         )
         return response.json()
 

--- a/pyagentspec/src/pyagentspec/tools/remotetool.py
+++ b/pyagentspec/src/pyagentspec/tools/remotetool.py
@@ -54,6 +54,10 @@ class RemoteTool(Tool):
     """Additional headers for the API call.
        These headers are intended to be used for sensitive information such as
        authentication tokens and will be excluded form exported JSON configs."""
+    timeout: Optional[float] = None
+    """Timeout in seconds for the HTTP request.
+       Defaults to None, which uses the httpx default timeout (5 seconds).
+       Set to a higher value for slow endpoints (e.g. transcription, inference)."""
 
     def _get_inferred_inputs(self) -> List["Property"]:
         return get_placeholder_properties_from_json_object(

--- a/pyagentspec/tests/adapters/langgraph/test_tools.py
+++ b/pyagentspec/tests/adapters/langgraph/test_tools.py
@@ -698,3 +698,44 @@ def test_invalid_confirmation_resume_payload_raises() -> None:
         ),
     ):
         app.invoke(bad, config=config)
+
+
+def test_remote_tool_timeout_is_forwarded_to_httpx() -> None:
+    """Verify that the timeout field on RemoteTool is forwarded to httpx.request."""
+    from pyagentspec.adapters.langgraph import AgentSpecLoader
+
+    remote_tool = RemoteTool(
+        name="slow_service",
+        description="A slow remote service",
+        url="https://example.com/api",
+        http_method="GET",
+        timeout=300.0,
+    )
+
+    lang_tool = AgentSpecLoader().load_component(remote_tool)
+
+    with patch("pyagentspec.adapters._tools_common.httpx.request") as mock_request:
+        mock_request.return_value = DummyResponse({"result": "ok"})
+        lang_tool.func()
+        _, called_kwargs = mock_request.call_args
+        assert called_kwargs["timeout"] == 300.0
+
+
+def test_remote_tool_default_timeout_is_none() -> None:
+    """Verify that timeout defaults to None when not set on RemoteTool."""
+    from pyagentspec.adapters.langgraph import AgentSpecLoader
+
+    remote_tool = RemoteTool(
+        name="default_service",
+        description="A remote service with default timeout",
+        url="https://example.com/api",
+        http_method="GET",
+    )
+
+    lang_tool = AgentSpecLoader().load_component(remote_tool)
+
+    with patch("pyagentspec.adapters._tools_common.httpx.request") as mock_request:
+        mock_request.return_value = DummyResponse({"result": "ok"})
+        lang_tool.func()
+        _, called_kwargs = mock_request.call_args
+        assert called_kwargs["timeout"] is None


### PR DESCRIPTION
Add an optional `timeout` field to `RemoteTool` that is forwarded directly to `httpx.request()`. This allows agent spec authors to configure per-tool HTTP timeouts for slow endpoints such as transcription or inference services.

The field defaults to `None`, preserving existing behaviour where httpx uses its own default timeout (5 seconds).

Example usage in an agent spec:
  {
    "component_type": "RemoteTool",
    "timeout": 300.0,
    ...
  }