### PR TITLE
fix: remove output schema restriction for tools with requires_confirmation

### DIFF
--- a/docs/pyagentspec/source/changelog.rst
+++ b/docs/pyagentspec/source/changelog.rst
@@ -16,6 +16,26 @@ Improvements
 
   We thank @spichen for the contribution!
 
+Bug fixes
+^^^^^^^^^
+
+* **LangGraph tool confirmation handling**
+
+  Fixed LangGraph adapter handling for tools with ``requires_confirmation=True`` so confirmed
+  tools can use their declared output schemas, including typed and multi-output schemas, without
+  requiring an unspecified single output schema. Denied confirmations now raise a clear runtime
+  error instead of returning a synthetic denial value, and Flow ``ToolNode`` conversion continues
+  through the shared converter path for all supported tool types.
+
+  We thank @spichen for the contribution!
+
+* **LangGraph MCP custom CA verification**
+
+  Fixed LangGraph MCP HTTPS client setup so a configured custom CA file is treated as the
+  complete trust anchor set rather than being added to the system trust store.
+
+  We thank @spichen for the contribution!
+
 New features
 ^^^^^^^^^^^^
 

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/_langgraphconverter.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/_langgraphconverter.py
@@ -785,41 +785,13 @@ class AgentSpecToLangGraphConverter:
     ) -> "NodeExecutor":
         from pyagentspec.adapters.langgraph._node_execution import ToolNodeExecutor
 
-        agentspec_tool = tool_node.tool
-        tool_outputs = agentspec_tool.outputs or []
-
-        # When a confirmation tool declares multiple outputs, a denial returns a single
-        # string that cannot be mapped to those outputs. Bypass self.convert() for all
-        # affected tool types so we can pass raise_on_denial=True: on rejection the
-        # tool raises RuntimeError with a clear message instead of an opaque crash.
-        if agentspec_tool.requires_confirmation and len(tool_outputs) > 1:
-            _ensure_checkpointer_and_valid_tool_config(agentspec_tool, checkpointer)
-            if isinstance(agentspec_tool, AgentSpecServerTool):
-                tool = self._server_tool_convert_to_langgraph(
-                    agentspec_tool, tool_registry, config=config, raise_on_denial=True
-                )
-            elif isinstance(agentspec_tool, AgentSpecRemoteTool):
-                tool = self._remote_tool_convert_to_langgraph(
-                    agentspec_tool, config=config, raise_on_denial=True
-                )
-            elif isinstance(agentspec_tool, AgentSpecClientTool):
-                tool = self._client_tool_convert_to_langgraph(agentspec_tool, raise_on_denial=True)
-            else:
-                raise ValueError(
-                    f"Tool '{agentspec_tool.name}' of type "
-                    f"'{type(agentspec_tool).__name__}' declares multiple outputs and "
-                    f"requires_confirmation=True inside Flow ToolNode '{tool_node.name}'. "
-                    f"Multi-output confirmation is supported for ServerTool, RemoteTool, "
-                    f"and ClientTool. Use a single output or a supported tool type."
-                )
-        else:
-            tool = self.convert(
-                tool_node.tool,
-                tool_registry=tool_registry,
-                converted_components=converted_components,
-                checkpointer=checkpointer,
-                config=config,
-            )
+        tool = self.convert(
+            tool_node.tool,
+            tool_registry=tool_registry,
+            converted_components=converted_components,
+            checkpointer=checkpointer,
+            config=config,
+        )
 
         return ToolNodeExecutor(tool_node, tool)
 
@@ -837,7 +809,6 @@ class AgentSpecToLangGraphConverter:
         self,
         remote_tool: AgentSpecRemoteTool,
         config: RunnableConfig,
-        raise_on_denial: bool = False,
     ) -> StructuredTool:
         tool_name = remote_tool.name
         tool_description = remote_tool.description or ""
@@ -845,7 +816,6 @@ class AgentSpecToLangGraphConverter:
             func=_create_remote_tool_func(remote_tool),
             tool_name=tool_name,
             requires_confirmation=remote_tool.requires_confirmation,
-            raise_on_denial=raise_on_denial,
         )
 
         # Use a Pydantic model for args_schema
@@ -871,7 +841,6 @@ class AgentSpecToLangGraphConverter:
         agentspec_server_tool: AgentSpecServerTool,
         tool_registry: Dict[str, LangGraphTool],
         config: RunnableConfig,
-        raise_on_denial: bool = False,
     ) -> StructuredTool:
         def _is_structured_tool(x: Any) -> TypeGuard[StructuredTool]:
             return isinstance(x, StructuredTool)
@@ -900,7 +869,6 @@ class AgentSpecToLangGraphConverter:
             tool_obj,
             tool_name=tool_name,
             requires_confirmation=requires_confirmation,
-            raise_on_denial=raise_on_denial,
         )
         if _is_structured_tool(tool_obj):
             if not tool_callable_kwargs:
@@ -950,7 +918,7 @@ class AgentSpecToLangGraphConverter:
         )
 
     def _client_tool_convert_to_langgraph(
-        self, agentspec_client_tool: AgentSpecClientTool, raise_on_denial: bool = False
+        self, agentspec_client_tool: AgentSpecClientTool
     ) -> StructuredTool:
         # Warn at load time for Python < 3.11 since client tools use interrupt under the hood.
         if sys.version_info < (3, 11):
@@ -970,12 +938,9 @@ class AgentSpecToLangGraphConverter:
                 confirmed, reason = _confirm_tool_use(tool_name, **kwargs)
 
                 if not confirmed:
-                    if raise_on_denial:
-                        raise RuntimeError(
-                            f"Tool '{tool_name}' was denied by the user (reason: {reason}). "
-                            f"Denial cannot be mapped to multiple declared outputs."
-                        )
-                    return f"Tool '{tool_name}' was denied execution by the user. Reason: {reason}"
+                    raise RuntimeError(
+                        f"Tool '{tool_name}' was denied by the user (reason: {reason})."
+                    )
 
             tool_request = {
                 "type": "client_tool_request",
@@ -1849,7 +1814,6 @@ def _confirm_then(
     func: Callable[..., Awaitable[Any]],
     tool_name: str,
     requires_confirmation: bool,
-    raise_on_denial: bool = ...,
 ) -> Callable[..., Awaitable[Any]]: ...
 
 
@@ -1858,7 +1822,6 @@ def _confirm_then(
     func: Callable[..., Any],
     tool_name: str,
     requires_confirmation: bool,
-    raise_on_denial: bool = ...,
 ) -> Callable[..., Any]: ...
 
 
@@ -1866,14 +1829,8 @@ def _confirm_then(
     func: Callable[..., Any],
     tool_name: str,
     requires_confirmation: bool,
-    raise_on_denial: bool = False,
 ) -> Callable[..., Any]:
-    """Wrap a callable so that it first interrupts for confirmation (if required).
-
-    When raise_on_denial is True, denial raises RuntimeError instead of returning a
-    string. Use this inside a Flow ToolNode with multiple outputs where a denial
-    string cannot be mapped to the declared output structure.
-    """
+    """Wrap a callable so that it first interrupts for confirmation (if required)."""
     if not requires_confirmation:
         return func
 
@@ -1884,12 +1841,9 @@ def _confirm_then(
             confirmed, reason = _confirm_tool_use(tool_name, **confirmation_arguments)
 
             if not confirmed:
-                if raise_on_denial:
-                    raise RuntimeError(
-                        f"Tool '{tool_name}' was denied by the user (reason: {reason}). "
-                        f"Denial cannot be mapped to multiple declared outputs."
-                    )
-                return f"Tool '{tool_name}' was denied execution by the user. Reason: {reason}"
+                raise RuntimeError(
+                    f"Tool '{tool_name}' was denied by the user (reason: {reason})."
+                )
 
             return await func(*args, **kwargs)
 
@@ -1900,12 +1854,7 @@ def _confirm_then(
         confirmed, reason = _confirm_tool_use(tool_name, **confirmation_arguments)
 
         if not confirmed:
-            if raise_on_denial:
-                raise RuntimeError(
-                    f"Tool '{tool_name}' was denied by the user (reason: {reason}). "
-                    f"Denial cannot be mapped to multiple declared outputs."
-                )
-            return f"Tool '{tool_name}' was denied execution by the user. Reason: {reason}"
+            raise RuntimeError(f"Tool '{tool_name}' was denied by the user (reason: {reason}).")
 
         return func(*args, **kwargs)
 
@@ -1939,7 +1888,6 @@ def _get_structured_tool_callable_kwargs(
     tool_obj: Union[StructuredTool, BaseTool, Callable[..., Any]],
     tool_name: str,
     requires_confirmation: bool = False,
-    raise_on_denial: bool = False,
 ) -> StructuredToolCallableKwargs:
     """Return the callables to pass to StructuredTool.
 
@@ -1959,7 +1907,6 @@ def _get_structured_tool_callable_kwargs(
                 func=tool_func,
                 tool_name=tool_name,
                 requires_confirmation=requires_confirmation,
-                raise_on_denial=raise_on_denial,
             )
 
         tool_coroutine = getattr(tool_obj, "coroutine", None)
@@ -1968,14 +1915,12 @@ def _get_structured_tool_callable_kwargs(
                 func=tool_coroutine,
                 tool_name=tool_name,
                 requires_confirmation=requires_confirmation,
-                raise_on_denial=raise_on_denial,
             )
     elif callable(tool_obj):
         wrapped_tool = _confirm_then(
             func=tool_obj,
             tool_name=tool_name,
             requires_confirmation=requires_confirmation,
-            raise_on_denial=raise_on_denial,
         )
         if _is_async_callable(wrapped_tool):
             structured_tool_callable_kwargs["coroutine"] = wrapped_tool

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/_langgraphconverter.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/_langgraphconverter.py
@@ -60,7 +60,10 @@ from pyagentspec.adapters.langgraph._types import (
     langgraph_graph,
     langgraph_swarm,
 )
-from pyagentspec.adapters.langgraph.mcp_utils import _HttpxClientFactory, run_async_in_sync
+from pyagentspec.adapters.langgraph.mcp_utils import (
+    _HttpxClientFactory,
+    run_async_in_sync,
+)
 from pyagentspec.adapters.langgraph.tracing import (
     AgentSpecLlmCallbackHandler,
     AgentSpecToolCallbackHandler,
@@ -93,7 +96,10 @@ from pyagentspec.llms.ociclientconfig import (
 )
 from pyagentspec.llms.ocigenaiconfig import OciGenAiConfig
 from pyagentspec.llms.ollamaconfig import OllamaConfig
-from pyagentspec.llms.openaicompatibleconfig import OpenAIAPIType, OpenAiCompatibleConfig
+from pyagentspec.llms.openaicompatibleconfig import (
+    OpenAIAPIType,
+    OpenAiCompatibleConfig,
+)
 from pyagentspec.llms.openaiconfig import OpenAiConfig
 from pyagentspec.llms.vllmconfig import VllmConfig
 from pyagentspec.mcp.clienttransport import ClientTransport as AgentSpecClientTransport
@@ -345,9 +351,12 @@ class AgentSpecToLangGraphConverter:
         graph_builder: StateGraph["FlowStateSchema", None, "FlowInputSchema", "FlowOutputSchema"],
     ) -> None:
         for source_node_id, control_flow_mapping in control_flow.items():
-            get_branch = lambda state: state["node_execution_details"].get(
-                "branch", AgentSpecNode.DEFAULT_NEXT_BRANCH
-            )
+
+            def get_branch(state: "FlowStateSchema") -> str:
+                return state["node_execution_details"].get(
+                    "branch", AgentSpecNode.DEFAULT_NEXT_BRANCH
+                )
+
             graph_builder.add_conditional_edges(source_node_id, get_branch, control_flow_mapping)
 
     def _flow_convert_to_langgraph(
@@ -359,9 +368,10 @@ class AgentSpecToLangGraphConverter:
         config: RunnableConfig,
         middleware: List[Any],
     ) -> CompiledStateGraph[Any, Any, Any]:
-
         graph_builder = StateGraph(
-            FlowStateSchema, input_schema=FlowInputSchema, output_schema=FlowOutputSchema
+            FlowStateSchema,
+            input_schema=FlowInputSchema,
+            output_schema=FlowOutputSchema,
         )
 
         graph_builder.add_edge(langgraph_graph.START, flow.start_node.id)
@@ -629,7 +639,9 @@ class AgentSpecToLangGraphConverter:
         self,
         node: AgentSpecInputMessageNode,
     ) -> "NodeExecutor":
-        from pyagentspec.adapters.langgraph._node_execution import InputMessageNodeExecutor
+        from pyagentspec.adapters.langgraph._node_execution import (
+            InputMessageNodeExecutor,
+        )
 
         return InputMessageNodeExecutor(node)
 
@@ -637,7 +649,9 @@ class AgentSpecToLangGraphConverter:
         self,
         node: AgentSpecOutputMessageNode,
     ) -> "NodeExecutor":
-        from pyagentspec.adapters.langgraph._node_execution import OutputMessageNodeExecutor
+        from pyagentspec.adapters.langgraph._node_execution import (
+            OutputMessageNodeExecutor,
+        )
 
         return OutputMessageNodeExecutor(node)
 
@@ -702,7 +716,9 @@ class AgentSpecToLangGraphConverter:
         config: RunnableConfig,
         middleware: List[Any],
     ) -> "NodeExecutor":
-        from pyagentspec.adapters.langgraph._node_execution import CatchExceptionNodeExecutor
+        from pyagentspec.adapters.langgraph._node_execution import (
+            CatchExceptionNodeExecutor,
+        )
 
         subflow = self.convert(
             catch_node.subflow,
@@ -1800,7 +1816,7 @@ def _confirm_tool_use(tool_name: str, **tool_arguments: Any) -> Tuple[bool, str]
             f"should be of length 1, was of length {len(decision_list)}"
         )
     decision = decision_list[0]
-    if "type" not in decision or not decision["type"] in ALLOWED_DECISIONS:
+    if "type" not in decision or decision["type"] not in ALLOWED_DECISIONS:
         raise ValueError(
             f"Tool confirmation result for tool {tool_name} is not valid, "
             f"decision should be in {ALLOWED_DECISIONS}, was {decision}."
@@ -1841,9 +1857,7 @@ def _confirm_then(
             confirmed, reason = _confirm_tool_use(tool_name, **confirmation_arguments)
 
             if not confirmed:
-                raise RuntimeError(
-                    f"Tool '{tool_name}' was denied by the user (reason: {reason})."
-                )
+                raise RuntimeError(f"Tool '{tool_name}' was denied by the user (reason: {reason}).")
 
             return await func(*args, **kwargs)
 
@@ -1861,7 +1875,9 @@ def _confirm_then(
     return _wrapped_sync
 
 
-def _is_async_callable(func: Callable[..., Any]) -> TypeGuard[Callable[..., Awaitable[Any]]]:
+def _is_async_callable(
+    func: Callable[..., Any],
+) -> TypeGuard[Callable[..., Awaitable[Any]]]:
     return inspect.iscoroutinefunction(func) or inspect.iscoroutinefunction(
         getattr(func, "__call__", None)
     )

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/_langgraphconverter.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/_langgraphconverter.py
@@ -1940,14 +1940,3 @@ def _ensure_checkpointer_and_valid_tool_config(
         )
     elif isinstance(agentspec_tool, AgentSpecClientTool) and checkpointer is None:
         raise ValueError(f"A Checkpointer is required when using ClientTool '{tool_name}'.")
-
-    tool_output = agentspec_tool.outputs or []
-    if agentspec_tool.requires_confirmation and (
-        len(tool_output) != 1 or "type" in tool_output[0].json_schema
-    ):
-        # TODO: refine to only raise output property does not support string
-        raise ValueError(
-            f"Invalid output schema for tool '{tool_name}' requiring tool confirmation: "
-            f"json schema should be left unspecified when using tool confirmation, was {tool_output}. "
-            f'Please use outputs=[Property(title="{tool_name}", json_schema={{}})]'
-        )

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/_langgraphconverter.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/_langgraphconverter.py
@@ -785,29 +785,43 @@ class AgentSpecToLangGraphConverter:
     ) -> "NodeExecutor":
         from pyagentspec.adapters.langgraph._node_execution import ToolNodeExecutor
 
-        # A rejected confirmation returns a single denial string, which cannot be
-        # split across multiple declared outputs of a Flow ToolNode. Catch this
-        # at load time rather than letting it surface as an opaque mapping error
-        # at runtime on the rejection path.
         agentspec_tool = tool_node.tool
         tool_outputs = agentspec_tool.outputs or []
-        if agentspec_tool.requires_confirmation and len(tool_outputs) > 1:
-            raise ValueError(
-                f"Tool '{agentspec_tool.name}' declares multiple outputs and "
-                f"requires_confirmation=True inside Flow ToolNode '{tool_node.name}'. "
-                f"On rejection, the tool returns a single denial string, which "
-                f"cannot be mapped to multiple declared outputs. "
-                f"Use a single output (object-typed if structured data is needed), "
-                f"or move the tool out of the Flow ToolNode."
-            )
 
-        tool = self.convert(
-            tool_node.tool,
-            tool_registry=tool_registry,
-            converted_components=converted_components,
-            checkpointer=checkpointer,
-            config=config,
-        )
+        # When a confirmation tool declares multiple outputs, a denial returns a single
+        # string that cannot be mapped to those outputs. Bypass self.convert() for all
+        # affected tool types so we can pass raise_on_denial=True: on rejection the
+        # tool raises RuntimeError with a clear message instead of an opaque crash.
+        if agentspec_tool.requires_confirmation and len(tool_outputs) > 1:
+            _ensure_checkpointer_and_valid_tool_config(agentspec_tool, checkpointer)
+            if isinstance(agentspec_tool, AgentSpecServerTool):
+                tool = self._server_tool_convert_to_langgraph(
+                    agentspec_tool, tool_registry, config=config, raise_on_denial=True
+                )
+            elif isinstance(agentspec_tool, AgentSpecRemoteTool):
+                tool = self._remote_tool_convert_to_langgraph(
+                    agentspec_tool, config=config, raise_on_denial=True
+                )
+            elif isinstance(agentspec_tool, AgentSpecClientTool):
+                tool = self._client_tool_convert_to_langgraph(
+                    agentspec_tool, raise_on_denial=True
+                )
+            else:
+                raise ValueError(
+                    f"Tool '{agentspec_tool.name}' of type "
+                    f"'{type(agentspec_tool).__name__}' declares multiple outputs and "
+                    f"requires_confirmation=True inside Flow ToolNode '{tool_node.name}'. "
+                    f"Multi-output confirmation is supported for ServerTool, RemoteTool, "
+                    f"and ClientTool. Use a single output or a supported tool type."
+                )
+        else:
+            tool = self.convert(
+                tool_node.tool,
+                tool_registry=tool_registry,
+                converted_components=converted_components,
+                checkpointer=checkpointer,
+                config=config,
+            )
 
         return ToolNodeExecutor(tool_node, tool)
 
@@ -825,6 +839,7 @@ class AgentSpecToLangGraphConverter:
         self,
         remote_tool: AgentSpecRemoteTool,
         config: RunnableConfig,
+        raise_on_denial: bool = False,
     ) -> StructuredTool:
         tool_name = remote_tool.name
         tool_description = remote_tool.description or ""
@@ -832,6 +847,7 @@ class AgentSpecToLangGraphConverter:
             func=_create_remote_tool_func(remote_tool),
             tool_name=tool_name,
             requires_confirmation=remote_tool.requires_confirmation,
+            raise_on_denial=raise_on_denial,
         )
 
         # Use a Pydantic model for args_schema
@@ -857,6 +873,7 @@ class AgentSpecToLangGraphConverter:
         agentspec_server_tool: AgentSpecServerTool,
         tool_registry: Dict[str, LangGraphTool],
         config: RunnableConfig,
+        raise_on_denial: bool = False,
     ) -> StructuredTool:
         def _is_structured_tool(x: Any) -> TypeGuard[StructuredTool]:
             return isinstance(x, StructuredTool)
@@ -885,6 +902,7 @@ class AgentSpecToLangGraphConverter:
             tool_obj,
             tool_name=tool_name,
             requires_confirmation=requires_confirmation,
+            raise_on_denial=raise_on_denial,
         )
         if _is_structured_tool(tool_obj):
             if not tool_callable_kwargs:
@@ -934,7 +952,7 @@ class AgentSpecToLangGraphConverter:
         )
 
     def _client_tool_convert_to_langgraph(
-        self, agentspec_client_tool: AgentSpecClientTool
+        self, agentspec_client_tool: AgentSpecClientTool, raise_on_denial: bool = False
     ) -> StructuredTool:
         # Warn at load time for Python < 3.11 since client tools use interrupt under the hood.
         if sys.version_info < (3, 11):
@@ -954,6 +972,11 @@ class AgentSpecToLangGraphConverter:
                 confirmed, reason = _confirm_tool_use(tool_name, **kwargs)
 
                 if not confirmed:
+                    if raise_on_denial:
+                        raise RuntimeError(
+                            f"Tool '{tool_name}' was denied by the user (reason: {reason}). "
+                            f"Denial cannot be mapped to multiple declared outputs."
+                        )
                     return f"Tool '{tool_name}' was denied execution by the user. Reason: {reason}"
 
             tool_request = {
@@ -1828,6 +1851,7 @@ def _confirm_then(
     func: Callable[..., Awaitable[Any]],
     tool_name: str,
     requires_confirmation: bool,
+    raise_on_denial: bool = ...,
 ) -> Callable[..., Awaitable[Any]]: ...
 
 
@@ -1836,6 +1860,7 @@ def _confirm_then(
     func: Callable[..., Any],
     tool_name: str,
     requires_confirmation: bool,
+    raise_on_denial: bool = ...,
 ) -> Callable[..., Any]: ...
 
 
@@ -1843,8 +1868,14 @@ def _confirm_then(
     func: Callable[..., Any],
     tool_name: str,
     requires_confirmation: bool,
+    raise_on_denial: bool = False,
 ) -> Callable[..., Any]:
-    """Wrap a callable so that it first interrupts for confirmation (if required)."""
+    """Wrap a callable so that it first interrupts for confirmation (if required).
+
+    When raise_on_denial is True, denial raises RuntimeError instead of returning a
+    string. Use this inside a Flow ToolNode with multiple outputs where a denial
+    string cannot be mapped to the declared output structure.
+    """
     if not requires_confirmation:
         return func
 
@@ -1855,6 +1886,11 @@ def _confirm_then(
             confirmed, reason = _confirm_tool_use(tool_name, **confirmation_arguments)
 
             if not confirmed:
+                if raise_on_denial:
+                    raise RuntimeError(
+                        f"Tool '{tool_name}' was denied by the user (reason: {reason}). "
+                        f"Denial cannot be mapped to multiple declared outputs."
+                    )
                 return f"Tool '{tool_name}' was denied execution by the user. Reason: {reason}"
 
             return await func(*args, **kwargs)
@@ -1866,6 +1902,11 @@ def _confirm_then(
         confirmed, reason = _confirm_tool_use(tool_name, **confirmation_arguments)
 
         if not confirmed:
+            if raise_on_denial:
+                raise RuntimeError(
+                    f"Tool '{tool_name}' was denied by the user (reason: {reason}). "
+                    f"Denial cannot be mapped to multiple declared outputs."
+                )
             return f"Tool '{tool_name}' was denied execution by the user. Reason: {reason}"
 
         return func(*args, **kwargs)
@@ -1900,6 +1941,7 @@ def _get_structured_tool_callable_kwargs(
     tool_obj: Union[StructuredTool, BaseTool, Callable[..., Any]],
     tool_name: str,
     requires_confirmation: bool = False,
+    raise_on_denial: bool = False,
 ) -> StructuredToolCallableKwargs:
     """Return the callables to pass to StructuredTool.
 
@@ -1919,6 +1961,7 @@ def _get_structured_tool_callable_kwargs(
                 func=tool_func,
                 tool_name=tool_name,
                 requires_confirmation=requires_confirmation,
+                raise_on_denial=raise_on_denial,
             )
 
         tool_coroutine = getattr(tool_obj, "coroutine", None)
@@ -1927,12 +1970,14 @@ def _get_structured_tool_callable_kwargs(
                 func=tool_coroutine,
                 tool_name=tool_name,
                 requires_confirmation=requires_confirmation,
+                raise_on_denial=raise_on_denial,
             )
     elif callable(tool_obj):
         wrapped_tool = _confirm_then(
             func=tool_obj,
             tool_name=tool_name,
             requires_confirmation=requires_confirmation,
+            raise_on_denial=raise_on_denial,
         )
         if _is_async_callable(wrapped_tool):
             structured_tool_callable_kwargs["coroutine"] = wrapped_tool

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/_langgraphconverter.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/_langgraphconverter.py
@@ -785,6 +785,22 @@ class AgentSpecToLangGraphConverter:
     ) -> "NodeExecutor":
         from pyagentspec.adapters.langgraph._node_execution import ToolNodeExecutor
 
+        # A rejected confirmation returns a single denial string, which cannot be
+        # split across multiple declared outputs of a Flow ToolNode. Catch this
+        # at load time rather than letting it surface as an opaque mapping error
+        # at runtime on the rejection path.
+        agentspec_tool = tool_node.tool
+        tool_outputs = agentspec_tool.outputs or []
+        if agentspec_tool.requires_confirmation and len(tool_outputs) > 1:
+            raise ValueError(
+                f"Tool '{agentspec_tool.name}' declares multiple outputs and "
+                f"requires_confirmation=True inside Flow ToolNode '{tool_node.name}'. "
+                f"On rejection, the tool returns a single denial string, which "
+                f"cannot be mapped to multiple declared outputs. "
+                f"Use a single output (object-typed if structured data is needed), "
+                f"or move the tool out of the Flow ToolNode."
+            )
+
         tool = self.convert(
             tool_node.tool,
             tool_registry=tool_registry,

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/_langgraphconverter.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/_langgraphconverter.py
@@ -803,9 +803,7 @@ class AgentSpecToLangGraphConverter:
                     agentspec_tool, config=config, raise_on_denial=True
                 )
             elif isinstance(agentspec_tool, AgentSpecClientTool):
-                tool = self._client_tool_convert_to_langgraph(
-                    agentspec_tool, raise_on_denial=True
-                )
+                tool = self._client_tool_convert_to_langgraph(agentspec_tool, raise_on_denial=True)
             else:
                 raise ValueError(
                     f"Tool '{agentspec_tool.name}' of type "

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/mcp_utils.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/mcp_utils.py
@@ -38,9 +38,13 @@ class _HttpxClientFactory:
     ):
         self.verify: bool | ssl.SSLContext
         if verify:
-            ssl_ctx = ssl.create_default_context()
+            # When a custom CA is provided, use it as the sole trust anchor (replacing the
+            # system CA bundle) so the trust boundary stays exactly as configured.
+            # When no custom CA is given, fall back to the system CA bundle.
             if ssl_ca_cert:
-                ssl_ctx.load_verify_locations(cafile=ssl_ca_cert)
+                ssl_ctx = ssl.create_default_context(cafile=ssl_ca_cert)
+            else:
+                ssl_ctx = ssl.create_default_context()
 
             if key_file or cert_file:
                 # Client authentication requires both pieces of certificate material.

--- a/pyagentspec/tests/adapters/langgraph/test_tools.py
+++ b/pyagentspec/tests/adapters/langgraph/test_tools.py
@@ -837,32 +837,42 @@ async def test_async_server_tool_in_agent_executes_via_ainvoke() -> None:
     assert "10" in str(tool_result_message.content)
 
 
-def test_server_tool_confirmation_with_typed_outputs_works() -> None:
-    """Tools with requires_confirmation and typed output schemas should load
-    without error.  The output schema is metadata for the LLM, not a runtime
-    validation constraint, so it should not be rejected."""
+def test_server_tool_confirmation_with_typed_object_output_works() -> None:
+    """Tools with requires_confirmation and a typed (object) output schema
+    should load without error and execute the approved path. The output schema
+    is metadata for the LLM, not a runtime constraint, and on rejection the
+    denial string maps cleanly into a single declared output."""
     from langchain_core.runnables import RunnableConfig
     from langgraph.checkpoint.memory import MemorySaver
 
     from pyagentspec.adapters.langgraph import AgentSpecLoader
 
+    bash_result = {"stdout": "hello", "stderr": "", "exit_code": 0}
+
     def bash_func(command: str) -> dict:
-        return {"stdout": "hello", "stderr": "", "exit_code": 0}
+        return bash_result
 
     server_tool = ServerTool(
         name="bash",
         description="Run a shell command",
         inputs=[Property(title="command", json_schema={"title": "command", "type": "string"})],
         outputs=[
-            Property(title="stdout", json_schema={"title": "stdout", "type": "string"}),
-            Property(title="stderr", json_schema={"title": "stderr", "type": "string"}),
-            Property(title="exit_code", json_schema={"title": "exit_code", "type": "number"}),
+            Property(
+                title="result",
+                json_schema={
+                    "type": "object",
+                    "properties": {
+                        "stdout": {"type": "string"},
+                        "stderr": {"type": "string"},
+                        "exit_code": {"type": "number"},
+                    },
+                },
+            ),
         ],
         requires_confirmation=True,
     )
     flow = _make_simple_flow_with_tool(ToolNode(name="bash_node", tool=server_tool))
 
-    # Should not raise ValueError about output schema
     app = AgentSpecLoader(
         tool_registry={"bash": bash_func},
         checkpointer=MemorySaver(),
@@ -876,7 +886,40 @@ def test_server_tool_confirmation_with_typed_outputs_works() -> None:
     assert interrupt_payload["action_requests"][0]["name"] == "bash"
 
     result = app.invoke(_approve_command(), config=config)
-    assert result["outputs"] is not None
+    assert result["outputs"]["result"] == bash_result
+
+
+def test_server_tool_confirmation_with_multi_output_in_flow_tool_node_raises() -> None:
+    """Multiple declared outputs combined with requires_confirmation cannot be
+    used inside a Flow ToolNode: on rejection, the tool returns a single denial
+    string that has no principled mapping to multiple outputs. We catch this at
+    load time with a clear error rather than letting it surface as an opaque
+    mapping failure at runtime."""
+    from langgraph.checkpoint.memory import MemorySaver
+
+    from pyagentspec.adapters.langgraph import AgentSpecLoader
+
+    def bash_func(command: str) -> dict:
+        return {"stdout": "hello", "stderr": "", "exit_code": 0}
+
+    server_tool = ServerTool(
+        name="bash",
+        description="Run a shell command",
+        inputs=[Property(title="command", json_schema={"title": "command", "type": "string"})],
+        outputs=[
+            Property(title="stdout", json_schema={"type": "string"}),
+            Property(title="stderr", json_schema={"type": "string"}),
+            Property(title="exit_code", json_schema={"type": "number"}),
+        ],
+        requires_confirmation=True,
+    )
+    flow = _make_simple_flow_with_tool(ToolNode(name="bash_node", tool=server_tool))
+
+    with pytest.raises(ValueError, match="multiple outputs"):
+        AgentSpecLoader(
+            tool_registry={"bash": bash_func},
+            checkpointer=MemorySaver(),
+        ).load_component(flow)
 
 
 def test_requires_confirmation_without_checkpointer_raises_for_server_tool_in_flow() -> None:

--- a/pyagentspec/tests/adapters/langgraph/test_tools.py
+++ b/pyagentspec/tests/adapters/langgraph/test_tools.py
@@ -837,6 +837,48 @@ async def test_async_server_tool_in_agent_executes_via_ainvoke() -> None:
     assert "10" in str(tool_result_message.content)
 
 
+def test_server_tool_confirmation_with_typed_outputs_works() -> None:
+    """Tools with requires_confirmation and typed output schemas should load
+    without error.  The output schema is metadata for the LLM, not a runtime
+    validation constraint, so it should not be rejected."""
+    from langchain_core.runnables import RunnableConfig
+    from langgraph.checkpoint.memory import MemorySaver
+
+    from pyagentspec.adapters.langgraph import AgentSpecLoader
+
+    def bash_func(command: str) -> dict:
+        return {"stdout": "hello", "stderr": "", "exit_code": 0}
+
+    server_tool = ServerTool(
+        name="bash",
+        description="Run a shell command",
+        inputs=[Property(title="command", json_schema={"title": "command", "type": "string"})],
+        outputs=[
+            Property(title="stdout", json_schema={"title": "stdout", "type": "string"}),
+            Property(title="stderr", json_schema={"title": "stderr", "type": "string"}),
+            Property(title="exit_code", json_schema={"title": "exit_code", "type": "number"}),
+        ],
+        requires_confirmation=True,
+    )
+    flow = _make_simple_flow_with_tool(ToolNode(name="bash_node", tool=server_tool))
+
+    # Should not raise ValueError about output schema
+    app = AgentSpecLoader(
+        tool_registry={"bash": bash_func},
+        checkpointer=MemorySaver(),
+    ).load_component(flow)
+
+    config = RunnableConfig({"configurable": {"thread_id": "typed-out-1"}})
+
+    interrupt_payload = _invoke_until_interrupt(
+        app, {"inputs": {"command": "echo hello"}}, config=config
+    )
+    assert interrupt_payload["action_requests"][0]["name"] == "bash"
+
+    result = app.invoke(_approve_command(), config=config)
+    assert result["outputs"] is not None
+
+
 def test_requires_confirmation_without_checkpointer_raises_for_server_tool_in_flow() -> None:
     from pyagentspec.adapters.langgraph import AgentSpecLoader
 

--- a/pyagentspec/tests/adapters/langgraph/test_tools.py
+++ b/pyagentspec/tests/adapters/langgraph/test_tools.py
@@ -889,20 +889,67 @@ def test_server_tool_confirmation_with_typed_object_output_works() -> None:
     assert result["outputs"]["result"] == bash_result
 
 
-def test_server_tool_confirmation_with_multi_output_in_flow_tool_node_raises() -> None:
-    """Multiple declared outputs combined with requires_confirmation cannot be
-    used inside a Flow ToolNode: on rejection, the tool returns a single denial
-    string that has no principled mapping to multiple outputs. We catch this at
-    load time with a clear error rather than letting it surface as an opaque
-    mapping failure at runtime."""
-    from langgraph.checkpoint.memory import MemorySaver
+def _make_multi_output_flow_with_tool(tool_node):
+    """Build Start -> Tool -> End wiring all three bash outputs (stdout, stderr, exit_code)."""
+    from pyagentspec.flows.edges import ControlFlowEdge, DataFlowEdge
+    from pyagentspec.flows.flow import Flow
+    from pyagentspec.flows.nodes import EndNode, StartNode
 
-    from pyagentspec.adapters.langgraph import AgentSpecLoader
+    start_node = StartNode(
+        name="start",
+        inputs=[Property(title="command", json_schema={"title": "command", "type": "string"})],
+    )
+    end_node = EndNode(
+        name="end",
+        outputs=[
+            Property(title="stdout", json_schema={"type": "string"}),
+            Property(title="stderr", json_schema={"type": "string"}),
+            Property(title="exit_code", json_schema={"type": "number"}),
+        ],
+    )
+    return Flow(
+        name="flow",
+        start_node=start_node,
+        nodes=[start_node, tool_node, end_node],
+        control_flow_connections=[
+            ControlFlowEdge(name="start_to_tool", from_node=start_node, to_node=tool_node),
+            ControlFlowEdge(name="tool_to_end", from_node=tool_node, to_node=end_node),
+        ],
+        data_flow_connections=[
+            DataFlowEdge(
+                name="cmd_edge",
+                source_node=start_node,
+                source_output="command",
+                destination_node=tool_node,
+                destination_input="command",
+            ),
+            DataFlowEdge(
+                name="stdout_edge",
+                source_node=tool_node,
+                source_output="stdout",
+                destination_node=end_node,
+                destination_input="stdout",
+            ),
+            DataFlowEdge(
+                name="stderr_edge",
+                source_node=tool_node,
+                source_output="stderr",
+                destination_node=end_node,
+                destination_input="stderr",
+            ),
+            DataFlowEdge(
+                name="exit_code_edge",
+                source_node=tool_node,
+                source_output="exit_code",
+                destination_node=end_node,
+                destination_input="exit_code",
+            ),
+        ],
+    )
 
-    def bash_func(command: str) -> dict:
-        return {"stdout": "hello", "stderr": "", "exit_code": 0}
 
-    server_tool = ServerTool(
+def _make_multi_output_bash_server_tool():
+    return ServerTool(
         name="bash",
         description="Run a shell command",
         inputs=[Property(title="command", json_schema={"title": "command", "type": "string"})],
@@ -913,13 +960,99 @@ def test_server_tool_confirmation_with_multi_output_in_flow_tool_node_raises() -
         ],
         requires_confirmation=True,
     )
-    flow = _make_simple_flow_with_tool(ToolNode(name="bash_node", tool=server_tool))
 
-    with pytest.raises(ValueError, match="multiple outputs"):
-        AgentSpecLoader(
-            tool_registry={"bash": bash_func},
-            checkpointer=MemorySaver(),
-        ).load_component(flow)
+
+def test_server_tool_confirmation_with_multi_output_in_flow_tool_node_approve_executes() -> None:
+    """A ServerTool with multiple outputs and requires_confirmation loads and executes
+    correctly when the user approves. The outputs are mapped from the returned dict."""
+    from langchain_core.runnables import RunnableConfig
+    from langgraph.checkpoint.memory import MemorySaver
+
+    from pyagentspec.adapters.langgraph import AgentSpecLoader
+
+    bash_result = {"stdout": "hello", "stderr": "", "exit_code": 0}
+
+    def bash_func(command: str) -> dict:
+        return bash_result
+
+    server_tool = _make_multi_output_bash_server_tool()
+    flow = _make_multi_output_flow_with_tool(ToolNode(name="bash_node", tool=server_tool))
+
+    app = AgentSpecLoader(
+        tool_registry={"bash": bash_func},
+        checkpointer=MemorySaver(),
+    ).load_component(flow)
+
+    config = RunnableConfig({"configurable": {"thread_id": "multi-out-approve-1"}})
+    interrupt_payload = _invoke_until_interrupt(
+        app, {"inputs": {"command": "echo hello"}}, config=config
+    )
+    assert interrupt_payload["action_requests"][0]["name"] == "bash"
+
+    result = app.invoke(_approve_command(), config=config)
+    assert result["outputs"]["stdout"] == "hello"
+    assert result["outputs"]["stderr"] == ""
+    assert result["outputs"]["exit_code"] == 0
+
+
+def test_server_tool_confirmation_with_multi_output_in_flow_tool_node_reject_raises() -> None:
+    """When a ServerTool with multiple outputs is denied inside a Flow ToolNode, a
+    RuntimeError is raised with a clear message rather than returning an unmappable
+    denial string."""
+    from langchain_core.runnables import RunnableConfig
+    from langgraph.checkpoint.memory import MemorySaver
+
+    from pyagentspec.adapters.langgraph import AgentSpecLoader
+
+    def bash_func(command: str) -> dict:
+        return {"stdout": "hello", "stderr": "", "exit_code": 0}
+
+    server_tool = _make_multi_output_bash_server_tool()
+    flow = _make_multi_output_flow_with_tool(ToolNode(name="bash_node", tool=server_tool))
+
+    app = AgentSpecLoader(
+        tool_registry={"bash": bash_func},
+        checkpointer=MemorySaver(),
+    ).load_component(flow)
+
+    config = RunnableConfig({"configurable": {"thread_id": "multi-out-reject-1"}})
+    _ = _invoke_until_interrupt(app, {"inputs": {"command": "echo hello"}}, config=config)
+
+    with pytest.raises(Exception, match="denied"):
+        app.invoke(_reject_command("nope"), config=config)
+
+
+def test_client_tool_confirmation_with_multi_output_in_flow_tool_node_reject_raises() -> None:
+    """When a ClientTool with multiple outputs is denied inside a Flow ToolNode, a
+    RuntimeError is raised with a clear message rather than an unmappable denial string."""
+    from langchain_core.runnables import RunnableConfig
+    from langgraph.checkpoint.memory import MemorySaver
+
+    from pyagentspec.adapters.langgraph import AgentSpecLoader
+
+    client_tool = ClientTool(
+        name="bash",
+        description="Run a shell command",
+        inputs=[Property(title="command", json_schema={"title": "command", "type": "string"})],
+        outputs=[
+            Property(title="stdout", json_schema={"type": "string"}),
+            Property(title="stderr", json_schema={"type": "string"}),
+            Property(title="exit_code", json_schema={"type": "number"}),
+        ],
+        requires_confirmation=True,
+    )
+    flow = _make_multi_output_flow_with_tool(ToolNode(name="bash_node", tool=client_tool))
+
+    app = AgentSpecLoader(
+        tool_registry={},
+        checkpointer=MemorySaver(),
+    ).load_component(flow)
+
+    config = RunnableConfig({"configurable": {"thread_id": "client-multi-out-reject-1"}})
+    _ = _invoke_until_interrupt(app, {"inputs": {"command": "echo hello"}}, config=config)
+
+    with pytest.raises(Exception, match="denied"):
+        app.invoke(_reject_command("nope"), config=config)
 
 
 def test_requires_confirmation_without_checkpointer_raises_for_server_tool_in_flow() -> None:

--- a/pyagentspec/tests/adapters/langgraph/test_tools.py
+++ b/pyagentspec/tests/adapters/langgraph/test_tools.py
@@ -11,7 +11,9 @@ from unittest.mock import patch
 import httpx
 import pytest
 
-from pyagentspec.adapters.langgraph._langgraphconverter import AgentSpecToLangGraphConverter
+from pyagentspec.adapters.langgraph._langgraphconverter import (
+    AgentSpecToLangGraphConverter,
+)
 from pyagentspec.agent import Agent
 from pyagentspec.flows.edges.controlflowedge import ControlFlowEdge
 from pyagentspec.flows.edges.dataflowedge import DataFlowEdge
@@ -116,7 +118,12 @@ def test_remote_tool_having_nested_inputs_with_langgraph() -> None:
         # Call the underlying function of the StructuredTool directly with keyword args.
         # The LangGraph converter wraps the function as a StructuredTool with .func attribute.
         result = lang_tool.func(
-            city="Agadir", lat="30.4", lon="-9.6", user="alice", suffix="world", bin_suffix="blob"
+            city="Agadir",
+            lat="30.4",
+            lon="-9.6",
+            user="alice",
+            suffix="world",
+            bin_suffix="blob",
         )
         # Ensure httpx.request was invoked and inspect the kwargs it was called with.
         patched_request.assert_called_once()
@@ -230,11 +237,22 @@ def test_remote_tool_post_raw_body_with_langgraph() -> None:
         ),
         (
             {"value": "{{ v1 }}", "listofvalues": ["a", "{{ v2 }}", "c"]},
-            {"header1": "{{ h1 }}", "Content-Type": "application/x-www-form-urlencoded"},
+            {
+                "header1": "{{ h1 }}",
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
             False,
         ),
-        ("value: {{ v1 }}, listofvalues: [a, {{ v2 }}, c]", {"header1": "{{ h1 }}"}, False),
-        (["value: {{ v1 }}", "listofvalues: [a, {{ v2 }}, c]"], {"header1": "{{ h1 }}"}, True),
+        (
+            "value: {{ v1 }}, listofvalues: [a, {{ v2 }}, c]",
+            {"header1": "{{ h1 }}"},
+            False,
+        ),
+        (
+            ["value: {{ v1 }}", "listofvalues: [a, {{ v2 }}, c]"],
+            {"header1": "{{ h1 }}"},
+            True,
+        ),
     ],
 )
 def test_remote_tool_actual_endpoint_with_langgraph(
@@ -668,7 +686,9 @@ def test_flow_with_remote_tool_confirmation_reject_does_not_call_http() -> None:
 
 
 def _get_fake_model() -> Any:
-    from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
+    from langchain_core.language_models.fake_chat_models import (
+        FakeMessagesListChatModel,
+    )
     from langchain_core.messages import AIMessage
     from langchain_openai import ChatOpenAI
 
@@ -715,7 +735,9 @@ def test_server_tool_confirmation_in_agent_approve_executes_tool() -> None:
         checkpointer=MemorySaver(),
     )
     with patch.object(
-        AgentSpecToLangGraphConverter, "_llm_convert_to_langgraph", return_value=_get_fake_model()
+        AgentSpecToLangGraphConverter,
+        "_llm_convert_to_langgraph",
+        return_value=_get_fake_model(),
     ):
         app = loader.load_component(agent_spec)
 
@@ -767,7 +789,9 @@ def test_server_tool_confirmation_in_agent_reject_denies_and_does_not_execute() 
     )
 
     with patch.object(
-        AgentSpecToLangGraphConverter, "_llm_convert_to_langgraph", return_value=_get_fake_model()
+        AgentSpecToLangGraphConverter,
+        "_llm_convert_to_langgraph",
+        return_value=_get_fake_model(),
     ):
         app = loader.load_component(agent_spec)
 
@@ -782,7 +806,9 @@ def test_server_tool_confirmation_in_agent_reject_denies_and_does_not_execute() 
 
 @pytest.mark.anyio
 async def test_async_server_tool_in_agent_executes_via_ainvoke() -> None:
-    from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
+    from langchain_core.language_models.fake_chat_models import (
+        FakeMessagesListChatModel,
+    )
     from langchain_core.messages import AIMessage
 
     from pyagentspec.adapters.langgraph import AgentSpecLoader
@@ -817,7 +843,9 @@ async def test_async_server_tool_in_agent_executes_via_ainvoke() -> None:
     )
     with patch.object(FakeMessagesListChatModel, "bind_tools", return_value=fake_model):
         with patch.object(
-            AgentSpecToLangGraphConverter, "_llm_convert_to_langgraph", return_value=fake_model
+            AgentSpecToLangGraphConverter,
+            "_llm_convert_to_langgraph",
+            return_value=fake_model,
         ):
             app = AgentSpecLoader(tool_registry={"double_tool": double_tool_func}).load_component(
                 agent_spec

--- a/pyagentspec/tests/adapters/langgraph/test_tools.py
+++ b/pyagentspec/tests/adapters/langgraph/test_tools.py
@@ -490,7 +490,7 @@ def test_server_tool_confirmation_flow_approve_executes() -> None:
     assert result["outputs"] == {"result": 10}
 
 
-def test_flow_with_server_tool_confirmation_reject_skips_executes_denial_message() -> None:
+def test_flow_with_server_tool_confirmation_reject_raises_and_skips_execute() -> None:
     from langchain_core.runnables import RunnableConfig
     from langgraph.checkpoint.memory import MemorySaver
 
@@ -521,12 +521,10 @@ def test_flow_with_server_tool_confirmation_reject_skips_executes_denial_message
     config = RunnableConfig({"configurable": {"thread_id": "t2"}})
 
     _ = _invoke_until_interrupt(langgraph_agent, {"inputs": {"x": 5}}, config=config)
-    result = langgraph_agent.invoke(_reject_command("nope"), config=config)
+    with pytest.raises(RuntimeError, match="Tool 'double_tool' was denied"):
+        langgraph_agent.invoke(_reject_command("nope"), config=config)
 
     assert called["n"] == 0  # Tool should not be executed
-
-    assert "outputs" in result
-    assert "denied execution" in str(result["outputs"])
 
 
 def test_flow_with_client_tool_confirmation_approve_then_interrupts_for_client_execution() -> None:
@@ -561,7 +559,7 @@ def test_flow_with_client_tool_confirmation_approve_then_interrupts_for_client_e
     assert client_tool_request["inputs"]["kwargs"] == {"x": 7}
 
 
-def test_flow_with_client_tool_confirmation_reject_returns_denial_and_no_client_request() -> None:
+def test_flow_with_client_tool_confirmation_reject_raises_and_no_client_request() -> None:
     from langchain_core.runnables import RunnableConfig
     from langgraph.checkpoint.memory import MemorySaver
 
@@ -581,10 +579,8 @@ def test_flow_with_client_tool_confirmation_reject_returns_denial_and_no_client_
 
     _ = _invoke_until_interrupt(app, {"inputs": {"x": 7}}, config=config)
 
-    result = app.invoke(_reject_command("no"), config=config)
-    assert "__interrupt__" not in result  # should not proceed to client request
-    assert "outputs" in result
-    assert "denied execution" in str(result["outputs"])
+    with pytest.raises(RuntimeError, match="Tool 'client_double' was denied"):
+        app.invoke(_reject_command("no"), config=config)
 
 
 def test_client_tool_converts_to_structured_tool_with_func_and_coroutine() -> None:
@@ -666,10 +662,9 @@ def test_flow_with_remote_tool_confirmation_reject_does_not_call_http() -> None:
     _ = _invoke_until_interrupt(app, {"inputs": {"x": 3}}, config=config)
 
     with patch("httpx.request") as patched:
-        result = app.invoke(_reject_command("no"), config=config)
+        with pytest.raises(RuntimeError, match="Tool 'remote_echo' was denied"):
+            app.invoke(_reject_command("no"), config=config)
         patched.assert_not_called()
-        assert "outputs" in result
-        assert "denied execution" in str(result["outputs"])
 
 
 def _get_fake_model() -> Any:
@@ -779,12 +774,10 @@ def test_server_tool_confirmation_in_agent_reject_denies_and_does_not_execute() 
     config = RunnableConfig({"configurable": {"thread_id": "ag2"}})
 
     _ = _invoke_until_interrupt(app, {"inputs": {"x": 5}}, config=config)
-    result = app.invoke(_reject_command("no"), config=config)
+    with pytest.raises(RuntimeError, match="Tool 'double_tool' was denied"):
+        app.invoke(_reject_command("no"), config=config)
 
     assert called["n"] == 0
-    assert "messages" in result and len(result["messages"]) > 1
-    tool_result_message = result["messages"][-2]
-    assert "denied execution" in tool_result_message.content
 
 
 @pytest.mark.anyio
@@ -840,8 +833,7 @@ async def test_async_server_tool_in_agent_executes_via_ainvoke() -> None:
 def test_server_tool_confirmation_with_typed_object_output_works() -> None:
     """Tools with requires_confirmation and a typed (object) output schema
     should load without error and execute the approved path. The output schema
-    is metadata for the LLM, not a runtime constraint, and on rejection the
-    denial string maps cleanly into a single declared output."""
+    is metadata for the LLM, not a runtime constraint."""
     from langchain_core.runnables import RunnableConfig
     from langgraph.checkpoint.memory import MemorySaver
 
@@ -1018,7 +1010,7 @@ def test_server_tool_confirmation_with_multi_output_in_flow_tool_node_reject_rai
     config = RunnableConfig({"configurable": {"thread_id": "multi-out-reject-1"}})
     _ = _invoke_until_interrupt(app, {"inputs": {"command": "echo hello"}}, config=config)
 
-    with pytest.raises(Exception, match="denied"):
+    with pytest.raises(RuntimeError, match="denied"):
         app.invoke(_reject_command("nope"), config=config)
 
 
@@ -1051,7 +1043,7 @@ def test_client_tool_confirmation_with_multi_output_in_flow_tool_node_reject_rai
     config = RunnableConfig({"configurable": {"thread_id": "client-multi-out-reject-1"}})
     _ = _invoke_until_interrupt(app, {"inputs": {"command": "echo hello"}}, config=config)
 
-    with pytest.raises(Exception, match="denied"):
+    with pytest.raises(RuntimeError, match="denied"):
         app.invoke(_reject_command("nope"), config=config)
 
 

--- a/pyagentspec/tests/adapters/langgraph/test_tools.py
+++ b/pyagentspec/tests/adapters/langgraph/test_tools.py
@@ -940,7 +940,8 @@ def _make_multi_output_flow_with_tool(tool_node):
     )
 
 
-def _make_multi_output_bash_server_tool():
+@pytest.fixture
+def multi_output_bash_server_tool() -> ServerTool:
     return ServerTool(
         name="bash",
         description="Run a shell command",
@@ -954,7 +955,9 @@ def _make_multi_output_bash_server_tool():
     )
 
 
-def test_server_tool_confirmation_with_multi_output_in_flow_tool_node_approve_executes() -> None:
+def test_server_tool_confirmation_with_multi_output_in_flow_tool_node_approve_executes(
+    multi_output_bash_server_tool: ServerTool,
+) -> None:
     """A ServerTool with multiple outputs and requires_confirmation loads and executes
     correctly when the user approves. The outputs are mapped from the returned dict."""
     from langchain_core.runnables import RunnableConfig
@@ -967,7 +970,7 @@ def test_server_tool_confirmation_with_multi_output_in_flow_tool_node_approve_ex
     def bash_func(command: str) -> dict:
         return bash_result
 
-    server_tool = _make_multi_output_bash_server_tool()
+    server_tool = multi_output_bash_server_tool
     flow = _make_multi_output_flow_with_tool(ToolNode(name="bash_node", tool=server_tool))
 
     app = AgentSpecLoader(
@@ -987,7 +990,9 @@ def test_server_tool_confirmation_with_multi_output_in_flow_tool_node_approve_ex
     assert result["outputs"]["exit_code"] == 0
 
 
-def test_server_tool_confirmation_with_multi_output_in_flow_tool_node_reject_raises() -> None:
+def test_server_tool_confirmation_with_multi_output_in_flow_tool_node_reject_raises(
+    multi_output_bash_server_tool: ServerTool,
+) -> None:
     """When a ServerTool with multiple outputs is denied inside a Flow ToolNode, a
     RuntimeError is raised with a clear message rather than returning an unmappable
     denial string."""
@@ -999,7 +1004,7 @@ def test_server_tool_confirmation_with_multi_output_in_flow_tool_node_reject_rai
     def bash_func(command: str) -> dict:
         return {"stdout": "hello", "stderr": "", "exit_code": 0}
 
-    server_tool = _make_multi_output_bash_server_tool()
+    server_tool = multi_output_bash_server_tool
     flow = _make_multi_output_flow_with_tool(ToolNode(name="bash_node", tool=server_tool))
 
     app = AgentSpecLoader(


### PR DESCRIPTION
Resolves https://github.com/oracle/agent-spec/issues/149

Tools with `requires_confirmation=True` and typed outputs get rejected by `_ensure_checkpointer_and_valid_tool_config`. This forces consumers to strip output schemas before loading, which loses information the LLM could use.

The check exists because `_confirm_then` returns a plain string on rejection, and the worry was it would conflict with a typed schema. It doesn't — `ToolMessage.content` is always a string in LangChain. The schema is never validated at runtime. Both the approved path (normal output) and rejected path (denial string) work fine.

The code already had a TODO acknowledging this was too strict:

```python
# TODO: refine to only raise output property does not support string
```

This PR removes the output schema validation entirely (keeps the checkpointer check) and adds a test with typed outputs to prove it works.