### PR TITLE
Clean up LangGraph dependency imports in _types.py

### DIFF
--- a/pyagentspec/setup.py
+++ b/pyagentspec/setup.py
@@ -34,6 +34,9 @@ LANGGRAPH_DEPS = [
     "anyio>=4.10.0,<4.12.0",
     "langgraph-swarm>=0.1.0",
     # 4rth party dependencies
+    # langgraph-prebuilt 1.0.9 imports runtime symbols that are not present in
+    # the langgraph 1.0.x series we currently support.
+    "langgraph-prebuilt<1.0.9",
     "langgraph-checkpoint>=3.0.1,<4.0.0",  # To mitigate CVE-2025-64439
 ]
 

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/_types.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/_types.py
@@ -4,7 +4,7 @@
 # (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 
-from typing import TYPE_CHECKING, Any, Callable, Dict, Tuple, TypedDict, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Hashable, Tuple, TypedDict, Union
 
 from typing_extensions import TypeAlias
 
@@ -99,7 +99,10 @@ class FlowOutputSchema(TypedDict):
     node_execution_details: NodeExecutionDetails
 
 
-ControlFlow: TypeAlias = Dict[str, Dict[Any, str]]
+SourceNodeId: TypeAlias = str
+BranchName: TypeAlias = Hashable
+TargetNodeId: TypeAlias = str
+ControlFlow: TypeAlias = Dict[SourceNodeId, Dict[BranchName, TargetNodeId]]
 
 
 __all__ = [
@@ -116,6 +119,9 @@ __all__ = [
     "FlowStateSchema",
     "FlowInputSchema",
     "FlowOutputSchema",
+    "SourceNodeId",
+    "BranchName",
+    "TargetNodeId",
     "ControlFlow",
     "NodeOutputsType",
     "ExecuteOutput",

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/_types.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/_types.py
@@ -78,17 +78,18 @@ class NodeExecutionDetails(TypedDict, total=False):
 
 NodeOutputsType: TypeAlias = Dict[str, Any]
 ExecuteOutput: TypeAlias = Tuple[NodeOutputsType, NodeExecutionDetails]
+NextNodeInputs: TypeAlias = Dict[str, Dict[str, Any]]
 
 
 class FlowStateSchema(TypedDict):
-    inputs: Dict[str, Dict[str, Any]]
+    inputs: NextNodeInputs
     outputs: NodeOutputsType
     messages: Messages
     node_execution_details: NodeExecutionDetails
 
 
 class FlowInputSchema(TypedDict):
-    inputs: Dict[str, Dict[str, Any]]
+    inputs: NextNodeInputs
     messages: Messages
 
 
@@ -118,6 +119,7 @@ __all__ = [
     "ControlFlow",
     "NodeOutputsType",
     "ExecuteOutput",
+    "NextNodeInputs",
     "CompiledStateGraph",
     "StateGraph",
     "StateNodeSpec",

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/_types.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/_types.py
@@ -4,13 +4,11 @@
 # (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, Dict, Hashable, Tuple, TypedDict, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Tuple, TypedDict, Union
 
 from typing_extensions import TypeAlias
 
 from pyagentspec._lazy_loader import LazyLoader
-from pyagentspec.llms.openaicompatibleconfig import OpenAIAPIType
 
 if TYPE_CHECKING:
     # Important: do not move this import out of the TYPE_CHECKING block so long as langgraph is an optional dependency.
@@ -20,36 +18,27 @@ if TYPE_CHECKING:
     import langchain_core.messages.content as langchain_core_messages_content
     import langchain_ollama
     import langchain_openai
-    import langgraph
     import langgraph.graph as langgraph_graph
-    import langgraph.graph.state as langgraph_graph_state
-    import langgraph.prebuilt as langgraph_prebuilt
-    import langgraph.types as langgraph_types
     import langgraph_swarm
     from langchain.agents.middleware.types import AgentState
     from langchain_core.callbacks import BaseCallbackHandler
     from langchain_core.language_models import BaseChatModel
     from langchain_core.messages import BaseMessage, SystemMessage, ToolMessage
     from langchain_core.outputs import ChatGenerationChunk, GenerationChunk, LLMResult
-    from langchain_core.runnables import RunnableBinding, RunnableConfig, RunnableLambda
+    from langchain_core.runnables import RunnableConfig, RunnableLambda
     from langchain_core.tools import BaseTool, StructuredTool
     from langgraph.graph import StateGraph
     from langgraph.graph._branch import BranchSpec
     from langgraph.graph._node import StateNodeSpec
     from langgraph.graph.message import Messages
     from langgraph.graph.state import CompiledStateGraph
-    from langgraph.store.base import BaseStore
     from langgraph.types import Checkpointer, interrupt
 
 else:
-    langgraph = LazyLoader("langgraph")
     langgraph_swarm = LazyLoader("langgraph_swarm")
     langchain_ollama = LazyLoader("langchain_ollama")
     langchain_openai = LazyLoader("langchain_openai")
     langgraph_graph = LazyLoader("langgraph.graph")
-    langgraph_types = LazyLoader("langgraph.types")
-    langgraph_prebuilt = LazyLoader("langgraph.prebuilt")
-    langgraph_graph_state = LazyLoader("langgraph.graph.state")
     langchain_agents = LazyLoader("langchain.agents")
     langchain_core_messages_content = LazyLoader("langchain_core.messages.content")
     # We need to import the classes this way because it's the only one accepted by the lazy loader
@@ -61,18 +50,14 @@ else:
     Messages = LazyLoader("langgraph.graph.message").Messages
     CompiledStateGraph = LazyLoader("langgraph.graph.state").CompiledStateGraph
     BaseCallbackHandler = LazyLoader("langchain_core.callbacks").BaseCallbackHandler
-    AsyncCallbackHandler = LazyLoader("langchain_core.callbacks").AsyncCallbackHandler
-    RunnableBinding = LazyLoader("langchain_core.runnables").RunnableBinding
     RunnableConfig = LazyLoader("langchain_core.runnables").RunnableConfig
     RunnableLambda = LazyLoader("langchain_core.runnables").RunnableLambda
     StateNodeSpec = LazyLoader("langgraph.graph._node").StateNodeSpec
-    StateNode = LazyLoader("langgraph.graph._node").StateNode
     BranchSpec = LazyLoader("langgraph.graph._branch").BranchSpec
     SystemMessage = LazyLoader("langchain_core.messages").SystemMessage
     BaseMessage = LazyLoader("langchain_core.messages").BaseMessage
     ToolMessage = LazyLoader("langchain_core.messages").ToolMessage
     BaseChatModel = LazyLoader("langchain_core.language_models").BaseChatModel
-    BaseStore = LazyLoader("langgraph.store.base").BaseStore
     ChatGenerationChunk = LazyLoader("langchain_core.outputs").ChatGenerationChunk
     GenerationChunk = LazyLoader("langchain_core.outputs").GenerationChunk
     LLMResult = LazyLoader("langchain_core.outputs").LLMResult
@@ -85,14 +70,6 @@ LangGraphRuntimeComponent: TypeAlias = Union[LangGraphComponent, BaseChatModel, 
 LangGraphComponentsRegistryT: TypeAlias = Dict[str, Union[LangGraphRuntimeComponent, Any]]
 
 
-@dataclass
-class LangGraphLlmConfig:
-    model_type: str
-    model_name: str
-    base_url: str
-    api_type: OpenAIAPIType = OpenAIAPIType.CHAT_COMPLETIONS
-
-
 class NodeExecutionDetails(TypedDict, total=False):
     should_finish: bool
     branch: str
@@ -101,18 +78,17 @@ class NodeExecutionDetails(TypedDict, total=False):
 
 NodeOutputsType: TypeAlias = Dict[str, Any]
 ExecuteOutput: TypeAlias = Tuple[NodeOutputsType, NodeExecutionDetails]
-NextNodeInputs: TypeAlias = Dict[str, Dict[str, Any]]
 
 
 class FlowStateSchema(TypedDict):
-    inputs: NextNodeInputs
+    inputs: Dict[str, Dict[str, Any]]
     outputs: NodeOutputsType
     messages: Messages
     node_execution_details: NodeExecutionDetails
 
 
 class FlowInputSchema(TypedDict):
-    inputs: NextNodeInputs
+    inputs: Dict[str, Dict[str, Any]]
     messages: Messages
 
 
@@ -122,19 +98,12 @@ class FlowOutputSchema(TypedDict):
     node_execution_details: NodeExecutionDetails
 
 
-SourceNodeId: TypeAlias = str
-BranchName: TypeAlias = Hashable
-TargetNodeId: TypeAlias = str
-ControlFlow: TypeAlias = Dict[SourceNodeId, Dict[BranchName, TargetNodeId]]
+ControlFlow: TypeAlias = Dict[str, Dict[Any, str]]
 
 
 __all__ = [
-    "langgraph",
     "langgraph_graph",
-    "langgraph_graph_state",
-    "langgraph_types",
     "langchain_core_messages_content",
-    "langgraph_prebuilt",
     "langchain_agents",
     "langchain_ollama",
     "langchain_openai",
@@ -142,22 +111,16 @@ __all__ = [
     "LangGraphComponent",
     "LangGraphRuntimeComponent",
     "LangGraphComponentsRegistryT",
-    "LangGraphLlmConfig",
     "NodeExecutionDetails",
     "FlowStateSchema",
     "FlowInputSchema",
     "FlowOutputSchema",
-    "SourceNodeId",
-    "BranchName",
-    "TargetNodeId",
     "ControlFlow",
     "NodeOutputsType",
     "ExecuteOutput",
-    "NextNodeInputs",
     "CompiledStateGraph",
     "StateGraph",
     "StateNodeSpec",
-    "RunnableBinding",
     "StructuredTool",
     "BaseTool",
     "RunnableLambda",
@@ -165,7 +128,6 @@ __all__ = [
     "BaseMessage",
     "ToolMessage",
     "BaseChatModel",
-    "BaseStore",
     "AgentState",
     "Checkpointer",
     "interrupt",
@@ -173,7 +135,6 @@ __all__ = [
     "Messages",
     "BranchSpec",
     "BaseCallbackHandler",
-    "AsyncCallbackHandler",
     "ChatGenerationChunk",
     "GenerationChunk",
     "LLMResult",


### PR DESCRIPTION
- Delete unused langgraph/langchain imports in pyagentspec.adapters.langgraph._types
- Upper bound langgraph-prebuilt in setup.py to avoid incompatibility with langgraph 1.0.5

Context: some langgraph-prebuilt update broke our setup, we need to upper bound it, otherwise it is incompatible with out langgraph 1.0.5 constraint