### PR TITLE
refactor(langgraph): simplify node io flow export

### DIFF
--- a/pyagentspec/src/pyagentspec/adapters/langgraph/_agentspec_converter_flow.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/_agentspec_converter_flow.py
@@ -27,6 +27,7 @@ from pydantic import BaseModel, TypeAdapter, create_model
 
 from pyagentspec import Property
 from pyagentspec.adapters.langgraph._types import (
+    BaseChatModel,
     BranchSpec,
     CompiledStateGraph,
     LangGraphComponent,
@@ -40,8 +41,11 @@ from pyagentspec.flows.edges import ControlFlowEdge, DataFlowEdge
 from pyagentspec.flows.flow import Flow as AgentSpecFlow
 from pyagentspec.flows.node import Node as AgentSpecNode
 from pyagentspec.flows.nodes import AgentNode as AgentSpecAgentNode
-from pyagentspec.flows.nodes import BranchingNode, EndNode, FlowNode, StartNode
+from pyagentspec.flows.nodes import BranchingNode, EndNode, FlowNode
+from pyagentspec.flows.nodes import LlmNode as AgentSpecLlmNode
+from pyagentspec.flows.nodes import StartNode
 from pyagentspec.flows.nodes import ToolNode as AgentSpecToolNode
+from pyagentspec.llms import LlmConfig as AgentSpecLlmConfig
 from pyagentspec.property import StringProperty, UnionProperty
 from pyagentspec.templating import get_placeholders_from_json_object
 from pyagentspec.tools.servertool import ServerTool as AgentSpecServerTool
@@ -89,6 +93,8 @@ def _langgraph_graph_convert_to_agentspec(
     exported graph stays structurally valid and internally consistent.
     """
     flow_name, normalized_graph = _prepare_langgraph_graph_for_export(graph)
+    # Build field-wired nodes/edges in an isolated reference map first so a later fallback does
+    # not leave partially converted field-wired objects mixed into the opaque `state` export.
     field_wiring_referenced_objects = dict(referenced_objects)
     try:
         converted_flow = _FieldWiringFlowExporter(
@@ -462,15 +468,11 @@ class _StateWiringFlowExporter(_BaseLangGraphFlowExporter):
             subgraph_flow_name,
             {},
         ).build()
-        opaque_property = _build_opaque_property_from_schema(
-            self._graph.state_schema,
-            title=GRAPH_STATE_PROPERTY_TITLE,
-        )
         return FlowNode(
             name=node_name,
             subflow=subflow,
-            inputs=[opaque_property],
-            outputs=[opaque_property],
+            inputs=[self._build_state_wired_input_property(node.input_schema)],
+            outputs=[self._build_state_wired_output_property(node_name)],
         )
 
     def _build_tool_node(
@@ -478,19 +480,17 @@ class _StateWiringFlowExporter(_BaseLangGraphFlowExporter):
         node_name: str,
         node: "StateNodeSpec[Any]",
     ) -> AgentSpecNode:
-        opaque_property = _build_opaque_property_from_schema(
-            self._graph.state_schema,
-            title=GRAPH_STATE_PROPERTY_TITLE,
-        )
+        input_property = self._build_state_wired_input_property(node.input_schema)
+        output_property = self._build_state_wired_output_property(node_name)
         return AgentSpecToolNode(
             name=node_name,
             tool=AgentSpecServerTool(
                 name=node_name + "_tool",
-                inputs=[opaque_property],
-                outputs=[opaque_property],
+                inputs=[input_property],
+                outputs=[output_property],
             ),
-            inputs=[opaque_property],
-            outputs=[opaque_property],
+            inputs=[input_property],
+            outputs=[output_property],
         )
 
     def _get_start_end_node_properties(
@@ -498,9 +498,10 @@ class _StateWiringFlowExporter(_BaseLangGraphFlowExporter):
         start_end_node_name: str,
         public_schema: Any,
     ) -> List[Property]:
+        schema = public_schema if public_schema is not None else self._graph.state_schema
         return [
             _build_opaque_property_from_schema(
-                self._graph.state_schema,
+                schema,
                 title=GRAPH_STATE_PROPERTY_TITLE,
             )
         ]
@@ -510,12 +511,65 @@ class _StateWiringFlowExporter(_BaseLangGraphFlowExporter):
         source_node_name: str,
         branch: BranchSpec,
     ) -> List[Property]:
+        schema = getattr(branch, "input_schema", None)
+        if schema is None:
+            if source_node_name in self._graph.nodes:
+                schema = self._graph.nodes[source_node_name].input_schema
+            else:
+                schema = self._graph.input_schema or self._graph.state_schema
         return [
             _build_opaque_property_from_schema(
-                self._graph.state_schema,
+                schema,
                 title=GRAPH_STATE_PROPERTY_TITLE,
             )
         ]
+
+    def _build_state_wired_input_property(self, schema: Any) -> Property:
+        return _build_opaque_property_from_schema(
+            schema if schema is not None else self._graph.state_schema,
+            title=GRAPH_STATE_PROPERTY_TITLE,
+        )
+
+    def _build_state_wired_output_property(self, node_name: str) -> Property:
+        target_node_names = [
+            to_node_name
+            for from_node_name, to_node_name in self._graph.edges
+            if from_node_name != to_node_name and from_node_name == node_name
+        ]
+        if target_node_names in ([], [END]):
+            return _build_opaque_property_from_schema(
+                self._graph.output_schema or self._graph.state_schema,
+                title=GRAPH_STATE_PROPERTY_TITLE,
+            )
+        if len(target_node_names) == 1:
+            target_node_name = target_node_names[0]
+            target_schema = (
+                self._graph.output_schema
+                if target_node_name == END
+                else self._graph.nodes[target_node_name].input_schema
+            )
+            return _build_opaque_property_from_schema(
+                target_schema or self._graph.state_schema,
+                title=GRAPH_STATE_PROPERTY_TITLE,
+            )
+
+        target_properties: List[Property] = []
+        for target_node_name in target_node_names:
+            target_schema = (
+                self._graph.output_schema
+                if target_node_name == END
+                else self._graph.nodes[target_node_name].input_schema
+            )
+            target_properties.append(
+                _build_opaque_property_from_schema(
+                    target_schema or self._graph.state_schema,
+                    title=GRAPH_STATE_PROPERTY_TITLE,
+                )
+            )
+        return _build_opaque_union_property(
+            target_properties,
+            title=GRAPH_STATE_PROPERTY_TITLE,
+        )
 
 
 class _FieldWiringFlowExporter(_BaseLangGraphFlowExporter):
@@ -536,6 +590,25 @@ class _FieldWiringFlowExporter(_BaseLangGraphFlowExporter):
                 node,
             )
         )
+        llm_node_export_target = _get_partial_bound_llm_and_prompt_from_node(node)
+        if llm_node_export_target is not None:
+            bound_llm, bound_prompt = llm_node_export_target
+            # Keep Python `str.format(...)` prompts as ToolNodes so export never changes prompt
+            # rendering semantics by silently translating `{field}` into Agent Spec placeholders.
+            if not self._converter._contains_python_format_fields(bound_prompt):
+                try:
+                    return self._build_llm_node(
+                        node_name,
+                        bound_llm,
+                        bound_prompt,
+                        declared_input_properties,
+                        declared_output_properties,
+                    )
+                except ValueError:
+                    # Keep export best-effort: if promotion to a richer LlmNode shape cannot
+                    # preserve the wrapper contract exactly, degrade to a plain ToolNode instead
+                    # of failing the whole flow conversion.
+                    pass
         # A leaf callable can still export as AgentNode when it is a `partial(...)` with one
         # bound react agent and the underlying callable visibly invokes that parameter.
         agent_node_export_target = _get_partial_bound_react_agent_invoke_target_from_node(
@@ -543,12 +616,21 @@ class _FieldWiringFlowExporter(_BaseLangGraphFlowExporter):
             node,
         )
         if agent_node_export_target is not None:
-            return self._build_agent_node(
-                node_name,
-                agent_node_export_target,
-                declared_input_properties,
-                declared_output_properties,
+            wrapped_agent_prompt = self._converter._extract_prompt_from_react_agent(
+                agent_node_export_target
             )
+            if not self._converter._contains_python_format_fields(wrapped_agent_prompt):
+                try:
+                    return self._build_agent_node(
+                        node_name,
+                        agent_node_export_target,
+                        declared_input_properties,
+                        declared_output_properties,
+                    )
+                except ValueError:
+                    # Keep export best-effort: if AgentNode promotion would require a stricter
+                    # interface than the wrapper actually exposes, fall back to ToolNode export.
+                    pass
         return self._build_tool_node(
             node_name,
             node,
@@ -680,6 +762,10 @@ class _FieldWiringFlowExporter(_BaseLangGraphFlowExporter):
             wrapped_react_agent,
             self._referenced_objects,
         )
+        # AgentNode inputs are the wrapped agent's detected Agent Spec prompt variables, so
+        # require the wrapper node's declared input fields to match that double-curly placeholder
+        # contract exactly. Single-curly `{...}` text is ignored here because it is not part of
+        # the exported Agent Spec input interface.
         wrapped_agent_prompt_inputs = set(
             get_placeholders_from_json_object(wrapped_agentspec_agent.system_prompt)
         )
@@ -706,6 +792,52 @@ class _FieldWiringFlowExporter(_BaseLangGraphFlowExporter):
                 inputs=declared_input_properties,
                 outputs=declared_output_properties,
             ),
+        )
+
+    def _build_llm_node(
+        self,
+        node_name: str,
+        bound_llm: BaseChatModel,
+        bound_prompt: str,
+        declared_input_properties: Optional[List[Property]],
+        declared_output_properties: Optional[List[Property]],
+    ) -> AgentSpecLlmNode:
+        prompt_template, prompt_variables = self._converter._normalize_prompt_template_string(
+            bound_prompt
+        )
+        input_properties_by_title = {
+            property_.title: property_ for property_ in declared_input_properties or []
+        }
+        node_input_titles = set(input_properties_by_title)
+        # LlmNode inputs are defined by detected Agent Spec `{{variable}}` placeholders. If the
+        # LangGraph node already declares a named input schema, require it to match that contract
+        # exactly so we do not silently drop wrapper inputs or invent a narrower Agent Spec
+        # interface. Single-curly `{...}` text is preserved as-is and does not participate in the
+        # exported input signature.
+        if declared_input_properties is not None and node_input_titles != set(prompt_variables):
+            raise ValueError(
+                f"Unable to export `{node_name}` as an LlmNode because the wrapper node "
+                f"inputs {sorted(node_input_titles)} do not match the wrapped LLM prompt "
+                f"placeholders {sorted(prompt_variables)}."
+            )
+
+        input_properties: List[Property]
+        if declared_input_properties is None:
+            input_properties = [StringProperty(title=variable) for variable in prompt_variables]
+        else:
+            input_properties = [
+                input_properties_by_title[variable] for variable in prompt_variables
+            ]
+
+        return AgentSpecLlmNode(
+            name=node_name,
+            llm_config=cast(
+                "AgentSpecLlmConfig",
+                self._converter.convert(bound_llm, self._referenced_objects),
+            ),
+            prompt_template=prompt_template,
+            inputs=input_properties,
+            outputs=declared_output_properties,
         )
 
     def _get_start_end_node_properties(
@@ -987,11 +1119,73 @@ def _get_langgraph_node_declared_properties(
     return input_properties, output_properties
 
 
+def _get_partial_bound_llm_and_prompt_from_node(
+    node: "StateNodeSpec[Any]",
+) -> Optional[Tuple[BaseChatModel, str]]:
+    """Return the bound LLM and prompt string when a node is authored as a prompt+model partial."""
+    partial_bound_arguments = _get_partial_bound_arguments_from_node(node)
+    if partial_bound_arguments is None:
+        return None
+
+    unwrapped_callable, bound_arguments = partial_bound_arguments
+
+    bound_llms = [
+        (argument_name, argument_value)
+        for argument_name, argument_value in bound_arguments.arguments.items()
+        if isinstance(argument_value, BaseChatModel)
+    ]
+    if len(bound_llms) != 1:
+        return None
+    llm_parameter_name, bound_llm = bound_llms[0]
+    if not _callable_has_invoke_call_on_parameter(unwrapped_callable, llm_parameter_name):
+        return None
+
+    bound_prompt_arguments = [
+        argument_value
+        for argument_name, argument_value in bound_arguments.arguments.items()
+        if isinstance(argument_value, str)
+        # Treat only explicitly named prompt/template strings as prompt candidates so unrelated
+        # bound strings do not cause a generic partial wrapper to be promoted to LlmNode.
+        and any(token in argument_name.lower() for token in ("prompt", "template"))
+    ]
+    if len(bound_prompt_arguments) != 1:
+        return None
+
+    return bound_llm, bound_prompt_arguments[0]
+
+
 def _get_partial_bound_react_agent_invoke_target_from_node(
     converter: "LangGraphToAgentSpecConverter",
     node: "StateNodeSpec[Any]",
 ) -> Optional[LangGraphComponent]:
     """Return the partial-bound react agent when the callable directly invokes it."""
+    partial_bound_arguments = _get_partial_bound_arguments_from_node(node)
+    if partial_bound_arguments is None:
+        return None
+
+    unwrapped_callable, bound_arguments = partial_bound_arguments
+    react_agent_bound_arguments = [
+        (argument_name, argument_value)
+        for argument_name, argument_value in bound_arguments.arguments.items()
+        if isinstance(argument_value, (StateGraph, CompiledStateGraph))
+        and converter._is_react_agent(argument_value)
+    ]
+    # We only promote the wrapper when exactly one bound argument is a react agent and the
+    # callable visibly invokes that same parameter.
+    if len(react_agent_bound_arguments) != 1:
+        return None
+
+    agent_parameter_name, agent_node_export_target = react_agent_bound_arguments[0]
+    if not _callable_has_invoke_call_on_parameter(unwrapped_callable, agent_parameter_name):
+        return None
+
+    return agent_node_export_target
+
+
+def _get_partial_bound_arguments_from_node(
+    node: "StateNodeSpec[Any]",
+) -> Optional[Tuple[Any, inspect.BoundArguments]]:
+    """Return the unwrapped callable and final bound arguments for a partial-authored node."""
     runnable = getattr(node, "runnable", None)
     wrapped_callable = _get_langgraph_runnable_callable(runnable)
     if not isinstance(wrapped_callable, partial):
@@ -1015,6 +1209,8 @@ def _get_partial_bound_react_agent_invoke_target_from_node(
         bound_arguments_keyword.update(partial_layer.keywords or {})
 
     try:
+        # `bind_partial()` mirrors how nested `partial(...)` objects accumulate arguments without
+        # requiring the wrapper to have already bound every remaining parameter on the callable.
         bound_arguments = inspect.signature(unwrapped_callable).bind_partial(
             *bound_arguments_positional,
             **bound_arguments_keyword,
@@ -1022,22 +1218,7 @@ def _get_partial_bound_react_agent_invoke_target_from_node(
     except (TypeError, ValueError):
         return None
 
-    react_agent_bound_arguments = [
-        (argument_name, argument_value)
-        for argument_name, argument_value in bound_arguments.arguments.items()
-        if isinstance(argument_value, (StateGraph, CompiledStateGraph))
-        and converter._is_react_agent(argument_value)
-    ]
-    # We only promote the wrapper when exactly one bound argument is a react agent and the
-    # callable visibly invokes that same parameter.
-    if len(react_agent_bound_arguments) != 1:
-        return None
-
-    agent_parameter_name, agent_node_export_target = react_agent_bound_arguments[0]
-    if not _callable_has_invoke_call_on_parameter(unwrapped_callable, agent_parameter_name):
-        return None
-
-    return agent_node_export_target
+    return unwrapped_callable, bound_arguments
 
 
 def _callable_has_invoke_call_on_parameter(callable_obj: Any, parameter_name: str) -> bool:
@@ -1130,6 +1311,11 @@ def _build_data_flow_edges_for_node_pair(
 
     source_outputs = source_node.outputs or []
     destination_inputs = destination_node.inputs or []
+
+    # Some nodes legitimately do not consume any data from their predecessor (for example,
+    # static-prompt LlmNodes). In that case we keep only the control-flow edge.
+    if len(destination_inputs) == 0 or len(source_outputs) == 0:
+        return []
 
     # Fall back to one opaque-port edge when both nodes only expose a single opaque port.
     if (

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/_agentspec_converter_flow.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/_agentspec_converter_flow.py
@@ -4,7 +4,10 @@
 # (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 
+import ast
+import dis
 import inspect
+import textwrap
 from dataclasses import is_dataclass
 from functools import partial
 from typing import (
@@ -31,13 +34,16 @@ from pyagentspec.adapters.langgraph._types import (
     StateNodeSpec,
     langgraph_graph,
 )
+from pyagentspec.agent import Agent as AgentSpecAgent
 from pyagentspec.component import Component as AgentSpecComponent
 from pyagentspec.flows.edges import ControlFlowEdge, DataFlowEdge
 from pyagentspec.flows.flow import Flow as AgentSpecFlow
 from pyagentspec.flows.node import Node as AgentSpecNode
+from pyagentspec.flows.nodes import AgentNode as AgentSpecAgentNode
 from pyagentspec.flows.nodes import BranchingNode, EndNode, FlowNode, StartNode
 from pyagentspec.flows.nodes import ToolNode as AgentSpecToolNode
 from pyagentspec.property import StringProperty, UnionProperty
+from pyagentspec.templating import get_placeholders_from_json_object
 from pyagentspec.tools.servertool import ServerTool as AgentSpecServerTool
 
 if TYPE_CHECKING:
@@ -515,6 +521,41 @@ class _StateWiringFlowExporter(_BaseLangGraphFlowExporter):
 class _FieldWiringFlowExporter(_BaseLangGraphFlowExporter):
     """Exporter that preserves direct field wiring only for directly representable flows."""
 
+    def _build_node(
+        self,
+        node_name: str,
+        node: "StateNodeSpec[Any]",
+    ) -> AgentSpecNode:
+        """Dispatch field-wired nodes directly by exported Agent Spec node kind."""
+        if self._is_graph_backed_node(node):
+            return self._build_flow_node(node_name, node)
+
+        declared_input_properties, declared_output_properties = (
+            _get_langgraph_node_declared_properties(
+                self._graph,
+                node,
+            )
+        )
+        # A leaf callable can still export as AgentNode when it is a `partial(...)` with one
+        # bound react agent and the underlying callable visibly invokes that parameter.
+        agent_node_export_target = _get_partial_bound_react_agent_invoke_target_from_node(
+            self._converter,
+            node,
+        )
+        if agent_node_export_target is not None:
+            return self._build_agent_node(
+                node_name,
+                agent_node_export_target,
+                declared_input_properties,
+                declared_output_properties,
+            )
+        return self._build_tool_node(
+            node_name,
+            node,
+            declared_input_properties=declared_input_properties,
+            declared_output_properties=declared_output_properties,
+        )
+
     def _build_flow_node(
         self,
         node_name: str,
@@ -532,13 +573,17 @@ class _FieldWiringFlowExporter(_BaseLangGraphFlowExporter):
         self,
         node_name: str,
         node: "StateNodeSpec[Any]",
+        declared_input_properties: Optional[List[Property]] = None,
+        declared_output_properties: Optional[List[Property]] = None,
     ) -> AgentSpecNode:
-        declared_input_properties, declared_output_properties = (
-            _get_langgraph_node_declared_properties(
-                self._graph,
-                node,
+        if declared_input_properties is None and declared_output_properties is None:
+            declared_input_properties, declared_output_properties = (
+                _get_langgraph_node_declared_properties(
+                    self._graph,
+                    node,
+                )
             )
-        )
+
         input_properties = declared_input_properties or [
             _build_opaque_property_from_schema(
                 node.input_schema,
@@ -608,6 +653,59 @@ class _FieldWiringFlowExporter(_BaseLangGraphFlowExporter):
             ),
             inputs=input_properties,
             outputs=output_properties,
+        )
+
+    def _build_agent_node(
+        self,
+        node_name: str,
+        wrapped_react_agent: LangGraphComponent,
+        declared_input_properties: Optional[List[Property]],
+        declared_output_properties: Optional[List[Property]],
+    ) -> AgentSpecAgentNode:
+        if not declared_input_properties:
+            raise ValueError(
+                f"Unable to export `{node_name}` as an AgentNode because wrapped LangGraph "
+                "agents require named input fields. Define `input_schema=` on the node or "
+                "annotate the callable's `state` parameter with a TypedDict, dataclass, or "
+                "Pydantic model that has named fields."
+            )
+        if not declared_output_properties:
+            raise ValueError(
+                f"Unable to export `{node_name}` as an AgentNode because wrapped LangGraph "
+                "agents require named output fields. Add a return annotation or output schema "
+                "using a TypedDict, dataclass, or Pydantic model with named fields."
+            )
+
+        wrapped_agentspec_agent = self._converter._langgraph_agent_convert_to_agentspec(
+            wrapped_react_agent,
+            self._referenced_objects,
+        )
+        wrapped_agent_prompt_inputs = set(
+            get_placeholders_from_json_object(wrapped_agentspec_agent.system_prompt)
+        )
+        node_input_titles = {property_.title for property_ in declared_input_properties}
+        if wrapped_agent_prompt_inputs != node_input_titles:
+            raise ValueError(
+                f"Unable to export `{node_name}` as an AgentNode because the wrapper node "
+                f"inputs {sorted(node_input_titles)} do not match the wrapped agent prompt "
+                f"placeholders {sorted(wrapped_agent_prompt_inputs)}."
+            )
+
+        return AgentSpecAgentNode(
+            name=node_name,
+            agent=AgentSpecAgent(
+                name=wrapped_agentspec_agent.name,
+                description=wrapped_agentspec_agent.description,
+                metadata=dict(wrapped_agentspec_agent.metadata or {}),
+                llm_config=wrapped_agentspec_agent.llm_config,
+                system_prompt=wrapped_agentspec_agent.system_prompt,
+                tools=list(wrapped_agentspec_agent.tools),
+                toolboxes=list(wrapped_agentspec_agent.toolboxes),
+                human_in_the_loop=wrapped_agentspec_agent.human_in_the_loop,
+                transforms=list(wrapped_agentspec_agent.transforms),
+                inputs=declared_input_properties,
+                outputs=declared_output_properties,
+            ),
         )
 
     def _get_start_end_node_properties(
@@ -784,6 +882,15 @@ def _is_opaque_property(property_: Property) -> bool:
     return isinstance(property_, (_OpaquePortProperty, _OpaqueUnionProperty))
 
 
+def _get_langgraph_runnable_callable(runnable: Any) -> Any:
+    """Return the callable stored on a LangGraph runnable, preferring sync then async wrappers."""
+    if callable(getattr(runnable, "func", None)):
+        return runnable.func
+    if callable(getattr(runnable, "afunc", None)):
+        return runnable.afunc
+    return runnable
+
+
 def _get_named_field_properties_from_schema(schema: Any) -> Optional[List[Property]]:
     """Return one property per schema field when the schema exposes named fields."""
     # Convert a structured schema into one Agent Spec property per field so later conversion
@@ -820,11 +927,15 @@ def _get_langgraph_node_declared_properties(
     # Infer the named-field inputs and outputs a LangGraph node declares so leaf nodes can
     # expose concrete ports like "user_query" or "answer" instead of only the whole graph state.
     runnable = getattr(node, "runnable", None)
-    unwrapped_callable = getattr(runnable, "func", runnable)
+    unwrapped_callable = _get_langgraph_runnable_callable(runnable)
+    bound_positional_arguments = 0
+    bound_keyword_arguments: set[str] = set()
     # LangGraph may store node callables in wrappers or `functools.partial(...)`.
     # We currently unwrap those layers only to recover annotations when an explicit
     # named-field input schema is not already available on the node itself.
     while isinstance(unwrapped_callable, partial):
+        bound_positional_arguments += len(unwrapped_callable.args)
+        bound_keyword_arguments.update((unwrapped_callable.keywords or {}).keys())
         unwrapped_callable = unwrapped_callable.func
 
     type_hints: Dict[str, Any] = {}
@@ -848,11 +959,17 @@ def _get_langgraph_node_declared_properties(
         except (TypeError, ValueError):
             pass
         else:
+            positional_parameter_index = 0
             for parameter in signature.parameters.values():
+                if parameter.name in bound_keyword_arguments:
+                    continue
                 if parameter.kind not in (
                     inspect.Parameter.POSITIONAL_ONLY,
                     inspect.Parameter.POSITIONAL_OR_KEYWORD,
                 ):
+                    continue
+                if positional_parameter_index < bound_positional_arguments:
+                    positional_parameter_index += 1
                     continue
                 annotation = type_hints.get(parameter.name, parameter.annotation)
                 if annotation is not inspect.Signature.empty:
@@ -868,6 +985,108 @@ def _get_langgraph_node_declared_properties(
         )
 
     return input_properties, output_properties
+
+
+def _get_partial_bound_react_agent_invoke_target_from_node(
+    converter: "LangGraphToAgentSpecConverter",
+    node: "StateNodeSpec[Any]",
+) -> Optional[LangGraphComponent]:
+    """Return the partial-bound react agent when the callable directly invokes it."""
+    runnable = getattr(node, "runnable", None)
+    wrapped_callable = _get_langgraph_runnable_callable(runnable)
+    if not isinstance(wrapped_callable, partial):
+        return None
+
+    partial_layers: List[Any] = []
+    unwrapped_callable: Any = wrapped_callable
+    # Flatten nested partials so we can recover the original function signature and the final
+    # set of bound arguments LangGraph will call it with.
+    while isinstance(unwrapped_callable, partial):
+        partial_layers.append(unwrapped_callable)
+        unwrapped_callable = unwrapped_callable.func
+
+    if not callable(unwrapped_callable):
+        return None
+
+    bound_arguments_positional: List[Any] = []
+    bound_arguments_keyword: Dict[str, Any] = {}
+    for partial_layer in reversed(partial_layers):
+        bound_arguments_positional.extend(partial_layer.args)
+        bound_arguments_keyword.update(partial_layer.keywords or {})
+
+    try:
+        bound_arguments = inspect.signature(unwrapped_callable).bind_partial(
+            *bound_arguments_positional,
+            **bound_arguments_keyword,
+        )
+    except (TypeError, ValueError):
+        return None
+
+    react_agent_bound_arguments = [
+        (argument_name, argument_value)
+        for argument_name, argument_value in bound_arguments.arguments.items()
+        if isinstance(argument_value, (StateGraph, CompiledStateGraph))
+        and converter._is_react_agent(argument_value)
+    ]
+    # We only promote the wrapper when exactly one bound argument is a react agent and the
+    # callable visibly invokes that same parameter.
+    if len(react_agent_bound_arguments) != 1:
+        return None
+
+    agent_parameter_name, agent_node_export_target = react_agent_bound_arguments[0]
+    if not _callable_has_invoke_call_on_parameter(unwrapped_callable, agent_parameter_name):
+        return None
+
+    return agent_node_export_target
+
+
+def _callable_has_invoke_call_on_parameter(callable_obj: Any, parameter_name: str) -> bool:
+    """Return whether the callable source contains `<parameter>.invoke(...)` or `.ainvoke(...)`."""
+    try:
+        callable_source = inspect.getsource(callable_obj)
+    except (OSError, TypeError):
+        callable_source = None
+
+    if callable_source is not None:
+        try:
+            parsed_source = ast.parse(textwrap.dedent(callable_source))
+        except SyntaxError:
+            pass
+        else:
+            # Prefer source inspection because it keeps the heuristic straightforward and works
+            # across normal `def`/`async def` wrappers.
+            for ast_node in ast.walk(parsed_source):
+                if not isinstance(ast_node, ast.Call):
+                    continue
+                called_function = ast_node.func
+                if not isinstance(called_function, ast.Attribute):
+                    continue
+                if called_function.attr not in {"invoke", "ainvoke"}:
+                    continue
+                if (
+                    isinstance(called_function.value, ast.Name)
+                    and called_function.value.id == parameter_name
+                ):
+                    return True
+
+    try:
+        instructions = list(dis.get_instructions(callable_obj))
+    except TypeError:
+        return False
+
+    # Some callables do not have retrievable source (for example interactive definitions), so
+    # fall back to bytecode and look for `<parameter>.<invoke-like-attr>` loads there.
+    for current_instruction, next_instruction in zip(instructions, instructions[1:]):
+        if not current_instruction.opname.startswith("LOAD_FAST"):
+            continue
+        if current_instruction.argval != parameter_name:
+            continue
+        if next_instruction.opname not in {"LOAD_ATTR", "LOAD_METHOD"}:
+            continue
+        if next_instruction.argval in {"invoke", "ainvoke"}:
+            return True
+
+    return False
 
 
 def _langgraph_edge_convert_to_agentspec_ctrl_flow(

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/_agentspec_converter_flow.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/_agentspec_converter_flow.py
@@ -1,12 +1,24 @@
-# Copyright © 2025 Oracle and/or its affiliates.
+# Copyright © 2025, 2026 Oracle and/or its affiliates.
 #
 # This software is under the Apache License 2.0
 # (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 
-
+import inspect
 from dataclasses import is_dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Type, cast
+from functools import partial
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Collection,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    cast,
+    get_type_hints,
+)
 
 from pydantic import BaseModel, TypeAdapter, create_model
 
@@ -33,15 +45,29 @@ if TYPE_CHECKING:
 
 END = langgraph_graph.END
 START = langgraph_graph.START
+GRAPH_STATE_PROPERTY_TITLE = "state"
+OPAQUE_INPUT_PROPERTY_TITLE = "input"
+OPAQUE_OUTPUT_PROPERTY_TITLE = "output"
 
 
-def _validate_conditional_edges_support(graph: LangGraphComponent) -> None:
-    if isinstance(graph, CompiledStateGraph):
-        graph = graph.builder
+class _FieldWiringFallbackRequired(ValueError):
+    """Raised when a LangGraph flow is valid but not exactly representable with field wiring."""
+
+
+class _OpaquePortProperty(Property):
+    """Private marker for adapter-generated opaque ports."""
+
+
+class _OpaqueUnionProperty(UnionProperty):
+    """Private marker for opaque union ports."""
+
+
+def _validate_conditional_edges_support(graph: StateGraph[Any, Any, Any]) -> None:
     for branch_specs in graph.branches.values():
         if len(branch_specs) > 1:
             raise ValueError(
-                "Conversion of multiple conditional edges with the same source node is not yet supported"
+                "Conversion of multiple conditional edges with the same source node "
+                "is not yet supported"
             )
 
 
@@ -50,133 +76,276 @@ def _langgraph_graph_convert_to_agentspec(
     graph: LangGraphComponent,
     referenced_objects: Dict[str, AgentSpecComponent],
 ) -> AgentSpecFlow:
-    _validate_conditional_edges_support(graph)
-    nodes: List[AgentSpecNode] = []
+    """Convert a LangGraph state graph into an Agent Spec flow.
+
+    The exporter first tries field wiring. If any required adjacent data edge cannot be
+    represented exactly in Agent Spec, the whole flow falls back to opaque `state` wiring so the
+    exported graph stays structurally valid and internally consistent.
+    """
+    flow_name, normalized_graph = _prepare_langgraph_graph_for_export(graph)
+    field_wiring_referenced_objects = dict(referenced_objects)
+    try:
+        converted_flow = _FieldWiringFlowExporter(
+            converter,
+            normalized_graph,
+            flow_name,
+            field_wiring_referenced_objects,
+        ).build()
+    except _FieldWiringFallbackRequired:
+        return _StateWiringFlowExporter(
+            converter,
+            normalized_graph,
+            flow_name,
+            referenced_objects,
+        ).build()
+
+    referenced_objects.update(field_wiring_referenced_objects)
+    return converted_flow
+
+
+def _prepare_langgraph_graph_for_export(
+    graph: LangGraphComponent,
+) -> Tuple[str, StateGraph[Any, Any, Any]]:
+    """Normalize and validate one LangGraph graph before export."""
     flow_name = graph.name if isinstance(graph, CompiledStateGraph) else "LangGraph Flow"
-    if isinstance(graph, CompiledStateGraph):
-        graph = graph.builder
-    for node_name, node in graph.nodes.items():
-        if node_name in (START, END):
-            continue
-        if isinstance(node.runnable, (StateGraph, CompiledStateGraph)):
-            subgraph_node = cast(AgentSpecFlow, converter.convert(node.runnable, {}))
-            flow_node = FlowNode(
-                name=node_name,
-                subflow=subgraph_node,
-            )
-            referenced_objects[node_name] = flow_node
-            nodes.append(flow_node)
-        else:
-            nodes.append(
-                _langgraph_node_convert_to_agentspec(graph, node_name, node, referenced_objects)
-            )
+    normalized_graph = graph.builder if isinstance(graph, CompiledStateGraph) else graph
+    _validate_conditional_edges_support(normalized_graph)
+    return flow_name, normalized_graph
 
-    start_node, end_node = _get_start_end_nodes(graph, referenced_objects)
-    nodes.append(start_node)
-    nodes.append(end_node)
 
-    control_flow_edges: List[ControlFlowEdge] = []
-    data_flow_edges: List[DataFlowEdge] = []
-    for edge in graph.edges:
-        control_flow_edges.append(
-            _langgraph_edges_convert_to_agentspec_ctrl_flow(edge, referenced_objects)
-        )
-        data_flow_edges.append(
-            _langgraph_edges_convert_to_agentspec_data_flow(graph, edge, referenced_objects)
-        )
+class _BaseLangGraphFlowExporter:
+    """Shared flow assembly for the field-wiring and state-wiring export strategies."""
 
-    for branch in graph.branches.items():
-        source_node, branch_specs = branch
-        additional_nodes, additional_ctrl_flows, additional_data_flows = (
-            _langgraph_branch_convert_to_agentspec(
-                source_node, branch_specs, graph, referenced_objects
-            )
-        )
-        nodes.extend(additional_nodes)
-        control_flow_edges.extend(additional_ctrl_flows)
-        data_flow_edges.extend(additional_data_flows)
+    def __init__(
+        self,
+        converter: "LangGraphToAgentSpecConverter",
+        graph: StateGraph[Any, Any, Any],
+        flow_name: str,
+        referenced_objects: Dict[str, AgentSpecComponent],
+    ) -> None:
+        self._converter = converter
+        self._graph = graph
+        self._flow_name = flow_name
+        self._referenced_objects = referenced_objects
 
-    # Add missing edges towards END nodes for nodes with no outgoing edges
-    for agentspec_node in nodes:
-        if agentspec_node.name == START or agentspec_node.name == END:
-            continue
-        if not any(
-            ctrl_flow.from_node.name == agentspec_node.name for ctrl_flow in control_flow_edges
-        ):
-            edge = agentspec_node.name, END
+    def build(self) -> AgentSpecFlow:
+        nodes: List[AgentSpecNode] = []
+        for node_name, node in self._graph.nodes.items():
+            if node_name in (START, END):
+                continue
+            nodes.append(self._convert_node(node_name, node))
+
+        start_node, end_node = self._build_start_end_nodes()
+        nodes.append(start_node)
+        nodes.append(end_node)
+
+        control_flow_edges: List[ControlFlowEdge] = []
+        data_flow_edges: List[DataFlowEdge] = []
+        for edge in self._graph.edges:
+            from_, to = edge
             control_flow_edges.append(
-                _langgraph_edges_convert_to_agentspec_ctrl_flow(edge, referenced_objects)
+                _langgraph_edge_convert_to_agentspec_ctrl_flow(edge, self._referenced_objects)
             )
-            data_flow_edges.append(
-                _langgraph_edges_convert_to_agentspec_data_flow(graph, edge, referenced_objects)
+            data_flow_edges.extend(
+                _build_data_flow_edges_for_node_pair(
+                    source_node=cast(AgentSpecNode, self._referenced_objects[from_]),
+                    destination_node=cast(AgentSpecNode, self._referenced_objects[to]),
+                    edge_name_prefix=f"{from_}_to_{to}",
+                )
             )
 
-    return AgentSpecFlow(
-        name=flow_name,
-        start_node=start_node,
-        nodes=nodes,
-        control_flow_connections=control_flow_edges,
-        data_flow_connections=data_flow_edges,
-    )
+        for source_node_name, branch_specs in self._graph.branches.items():
+            for conditional_node_name, branch in branch_specs.items():
+                additional_nodes, additional_ctrl_flows, additional_data_flows = (
+                    self._build_conditional_branch(
+                        source_node_name,
+                        conditional_node_name,
+                        branch,
+                    )
+                )
+                nodes.extend(additional_nodes)
+                control_flow_edges.extend(additional_ctrl_flows)
+                data_flow_edges.extend(additional_data_flows)
 
+        # Add missing edges towards END nodes for nodes with no outgoing edges.
+        for agentspec_node in nodes:
+            if agentspec_node.name == START or agentspec_node.name == END:
+                continue
+            if not any(
+                ctrl_flow.from_node.name == agentspec_node.name for ctrl_flow in control_flow_edges
+            ):
+                edge = agentspec_node.name, END
+                from_, to = edge
+                control_flow_edges.append(
+                    _langgraph_edge_convert_to_agentspec_ctrl_flow(
+                        edge,
+                        self._referenced_objects,
+                    )
+                )
+                data_flow_edges.extend(
+                    _build_data_flow_edges_for_node_pair(
+                        source_node=cast(AgentSpecNode, self._referenced_objects[from_]),
+                        destination_node=cast(AgentSpecNode, self._referenced_objects[to]),
+                        edge_name_prefix=f"{from_}_to_{to}",
+                    )
+                )
 
-def _langgraph_branch_convert_to_agentspec(
-    source_node: str,
-    branch_specs: Dict[str, BranchSpec],
-    graph: StateGraph[Any, Any, Any, Any],
-    referenced_objects: Dict[str, AgentSpecComponent],
-) -> Tuple[List[AgentSpecNode], List[ControlFlowEdge], List[DataFlowEdge]]:
-    additional_nodes: List[AgentSpecNode] = []
-    additional_ctrl_flows: List[ControlFlowEdge] = []
-    additional_data_flows: List[DataFlowEdge] = []
+        self._validate_data_flow_edges(nodes, data_flow_edges)
 
-    for conditional_node_name, branch_spec in branch_specs.items():
-        mapping: Dict[str, str]
-        if branch_spec.ends is None:
+        return AgentSpecFlow(
+            name=self._flow_name,
+            start_node=start_node,
+            nodes=nodes,
+            control_flow_connections=control_flow_edges,
+            data_flow_connections=data_flow_edges,
+        )
+
+    def _convert_node(
+        self,
+        node_name: str,
+        node: "StateNodeSpec[Any]",
+    ) -> AgentSpecNode:
+        """Convert one LangGraph node under the current private export strategy."""
+        converted_node = self._referenced_objects.get(node_name)
+        if converted_node is not None:
+            if not isinstance(converted_node, AgentSpecNode):
+                raise TypeError(
+                    f"expected node {converted_node} to be of type {AgentSpecNode}, "
+                    f"got: {converted_node.__class__}"
+                )
+            return converted_node
+
+        converted_node = self._build_node(node_name, node)
+        self._referenced_objects[node_name] = converted_node
+        return converted_node
+
+    def _build_node(
+        self,
+        node_name: str,
+        node: "StateNodeSpec[Any]",
+    ) -> AgentSpecNode:
+        """Dispatch one LangGraph node to the corresponding Agent Spec node kind."""
+        if self._is_graph_backed_node(node):
+            return self._build_flow_node(node_name, node)
+        return self._build_tool_node(node_name, node)
+
+    def _is_graph_backed_node(self, node: "StateNodeSpec[Any]") -> bool:
+        """Return whether the LangGraph node wraps another graph-backed component."""
+        return isinstance(node.runnable, (StateGraph, CompiledStateGraph))
+
+    def _build_start_end_nodes(self) -> Tuple[AgentSpecNode, AgentSpecNode]:
+        """Return the exported START and END nodes under the current export strategy."""
+        return (
+            self._get_or_build_start_end_node(
+                START,
+                self._graph.input_schema,
+                StartNode,
+            ),
+            self._get_or_build_start_end_node(
+                END,
+                self._graph.output_schema,
+                EndNode,
+            ),
+        )
+
+    def _get_or_build_start_end_node(
+        self,
+        start_end_node_name: str,
+        public_schema: Any,
+        start_end_node_class: Type[Any],
+    ) -> AgentSpecNode:
+        """Return the exported START/END node, building it on first use."""
+        converted_node = self._referenced_objects.get(start_end_node_name)
+        if converted_node is not None:
+            if not isinstance(converted_node, AgentSpecNode):
+                raise TypeError(
+                    f"expected node {converted_node} to be of type {AgentSpecNode}, "
+                    f"got: {converted_node.__class__}"
+                )
+            return converted_node
+        if start_end_node_name in self._graph.nodes:
+            return self._convert_node(
+                start_end_node_name,
+                self._graph.nodes[start_end_node_name],
+            )
+
+        start_end_node_properties = self._get_start_end_node_properties(
+            start_end_node_name,
+            public_schema,
+        )
+        start_end_node = cast(
+            AgentSpecNode,
+            start_end_node_class(
+                name=start_end_node_name,
+                inputs=start_end_node_properties,
+                outputs=list(start_end_node_properties),
+            ),
+        )
+        self._referenced_objects[start_end_node_name] = start_end_node
+        return start_end_node
+
+    def _build_conditional_branch(
+        self,
+        source_node_name: str,
+        conditional_node_name: str,
+        branch: BranchSpec,
+    ) -> Tuple[List[AgentSpecNode], List[ControlFlowEdge], List[DataFlowEdge]]:
+        """Build the Agent Spec helper nodes and edges for one LangGraph conditional branch."""
+        additional_nodes: List[AgentSpecNode] = []
+        additional_ctrl_flows: List[ControlFlowEdge] = []
+        additional_data_flows: List[DataFlowEdge] = []
+
+        if branch.ends is None:
             raise TypeError(f"""Mapping for {conditional_node_name} not found.
-            Make sure to add proper return type hints to the branching function.""")
-        mapping = {str(k): v for k, v in branch_spec.ends.items()}
+                Make sure to add proper return type hints to the branching function.""")
 
-        # Create the conditional node to compute which branch to go to
-        conditional_node_input = _resolve_output_properties(graph, [source_node])
+        mapping = {
+            str(route_token): target_node_name
+            for route_token, target_node_name in branch.ends.items()
+        }
+        source_node = cast(AgentSpecNode, self._referenced_objects[source_node_name])
+        conditional_node_name = _dedupe_name(
+            conditional_node_name,
+            self._referenced_objects.keys(),
+        )
+
         conditional_node = AgentSpecToolNode(
             name=conditional_node_name,
             tool=AgentSpecServerTool(
                 name=f"{conditional_node_name}_tool",
-                inputs=[conditional_node_input],
+                inputs=self._resolve_conditional_node_inputs(source_node_name, branch),
                 outputs=[StringProperty(title=BranchingNode.DEFAULT_INPUT)],
             ),
         )
         additional_nodes.append(conditional_node)
-        referenced_objects[conditional_node_name] = conditional_node
+        self._referenced_objects[conditional_node_name] = conditional_node
 
-        # The source node goes to the conditional node to compute which
-        # branch to go to
-        source_node_to_conditional_node_ctrl_flow = ControlFlowEdge(
-            name=f"{source_node}_to_{conditional_node_name}",
-            from_node=cast(AgentSpecNode, referenced_objects[source_node]),
-            to_node=conditional_node,
+        additional_ctrl_flows.append(
+            ControlFlowEdge(
+                name=f"{source_node_name}_to_{conditional_node_name}",
+                from_node=source_node,
+                to_node=conditional_node,
+            )
         )
-        additional_ctrl_flows.append(source_node_to_conditional_node_ctrl_flow)
-        source_node_to_conditional_node_data_flow = DataFlowEdge(
-            name=f"{source_node}_to_{conditional_node_name}_data_edge",
-            source_node=cast(AgentSpecNode, referenced_objects[source_node]),
-            source_output=conditional_node_input.title,
-            destination_node=conditional_node,
-            destination_input=conditional_node_input.title,
+        additional_data_flows.extend(
+            _build_data_flow_edges_for_node_pair(
+                source_node=source_node,
+                destination_node=conditional_node,
+                edge_name_prefix=f"{source_node_name}_to_{conditional_node_name}",
+            )
         )
-        additional_data_flows.append(source_node_to_conditional_node_data_flow)
 
-        # Create the branching node for the current conditional edge
-        branching_node_name = f"{conditional_node_name}_branching_node"
+        branching_node_name = _dedupe_name(
+            f"{conditional_node_name}_branching_node",
+            self._referenced_objects.keys(),
+        )
         branching_node = BranchingNode(
             name=branching_node_name,
             mapping=mapping,
         )
         additional_nodes.append(branching_node)
-        referenced_objects[branching_node_name] = branching_node
+        self._referenced_objects[branching_node_name] = branching_node
 
-        # Create ControlFlowEdge to go from the conditional node to the branching node
         additional_ctrl_flows.append(
             ControlFlowEdge(
                 name=f"{conditional_node_name}_to_{branching_node_name}",
@@ -194,206 +363,573 @@ def _langgraph_branch_convert_to_agentspec(
             )
         )
 
-        # For each different target node, we create a control flow edge
-        # that goes from the branching node to the target node if `from_branch == branch_name`
-        for branch_name, target_node_name in mapping.items():
+        # BranchingNode selects the mapping value as the outgoing Agent Spec branch name, so we
+        # materialize one explicit edge per distinct target node, not per route token.
+        for target_node_name in dict.fromkeys(mapping.values()):
             additional_ctrl_flows.append(
                 ControlFlowEdge(
-                    name=f"{branching_node_name}_to_{target_node_name}",
+                    name=f"{branching_node_name}_branch_{target_node_name}",
                     from_node=branching_node,
-                    to_node=cast(AgentSpecNode, referenced_objects[target_node_name]),
-                    from_branch=branch_name,
+                    to_node=cast(AgentSpecNode, self._referenced_objects[target_node_name]),
+                    from_branch=target_node_name,
                 )
             )
-            additional_data_flows.append(
-                DataFlowEdge(
-                    name=f"data_{source_node}_to_{target_node_name}",
-                    source_node=cast(AgentSpecNode, referenced_objects[source_node]),
-                    source_output=_resolve_output_properties(graph, [target_node_name]).title,
-                    destination_node=cast(AgentSpecNode, referenced_objects[target_node_name]),
-                    destination_input=_resolve_output_properties(graph, [target_node_name]).title,
+            additional_data_flows.extend(
+                _build_data_flow_edges_for_node_pair(
+                    source_node=source_node,
+                    destination_node=cast(
+                        AgentSpecNode,
+                        self._referenced_objects[target_node_name],
+                    ),
+                    edge_name_prefix=f"data_{source_node_name}_to_{target_node_name}",
                 ),
             )
 
-        # We create an edge for the default case, that goes straight to the end node
-        # This should "in practice" never be reached
-        name = f"{branching_node_name}_to_{END}"
-        if not any(flow.name == name for flow in additional_ctrl_flows):
-            additional_ctrl_flows.append(
-                ControlFlowEdge(
-                    name=name,
-                    from_node=branching_node,
-                    to_node=cast(AgentSpecNode, referenced_objects[END]),
-                    from_branch=BranchingNode.DEFAULT_BRANCH,
+        # Always keep an explicit default edge to END, even if another mapped branch also targets
+        # END, because the default branch is a distinct Agent Spec branch.
+        additional_ctrl_flows.append(
+            ControlFlowEdge(
+                name=f"{branching_node_name}_default_to_{END}",
+                from_node=branching_node,
+                to_node=cast(AgentSpecNode, self._referenced_objects[END]),
+                from_branch=BranchingNode.DEFAULT_BRANCH,
+            )
+        )
+
+        return (additional_nodes, additional_ctrl_flows, additional_data_flows)
+
+    def _validate_data_flow_edges(
+        self,
+        nodes: List[AgentSpecNode],
+        data_flow_edges: List[DataFlowEdge],
+    ) -> None:
+        """Allow concrete strategies to validate assembled data edges."""
+
+    def _build_flow_node(
+        self,
+        node_name: str,
+        node: "StateNodeSpec[Any]",
+    ) -> FlowNode:
+        """Convert a graph-backed LangGraph node that exports as an Agent Spec FlowNode."""
+        raise NotImplementedError
+
+    def _build_tool_node(
+        self,
+        node_name: str,
+        node: "StateNodeSpec[Any]",
+    ) -> AgentSpecNode:
+        """Convert a LangGraph leaf runnable that should export as an Agent Spec ToolNode."""
+        raise NotImplementedError
+
+    def _get_start_end_node_properties(
+        self,
+        start_end_node_name: str,
+        public_schema: Any,
+    ) -> List[Property]:
+        """Return the START/END node properties for the current export strategy."""
+        raise NotImplementedError
+
+    def _resolve_conditional_node_inputs(
+        self,
+        source_node_name: str,
+        branch: BranchSpec,
+    ) -> List[Property]:
+        """Return the synthetic route-node inputs for the current export strategy."""
+        raise NotImplementedError
+
+
+class _StateWiringFlowExporter(_BaseLangGraphFlowExporter):
+    """Exporter that uses a single opaque `state` interface throughout the flow."""
+
+    def _build_flow_node(
+        self,
+        node_name: str,
+        node: "StateNodeSpec[Any]",
+    ) -> FlowNode:
+        subgraph_runnable = cast(LangGraphComponent, node.runnable)
+        subgraph_flow_name, normalized_subgraph = _prepare_langgraph_graph_for_export(
+            subgraph_runnable
+        )
+        subflow = _StateWiringFlowExporter(
+            self._converter,
+            normalized_subgraph,
+            subgraph_flow_name,
+            {},
+        ).build()
+        opaque_property = _build_opaque_property_from_schema(
+            self._graph.state_schema,
+            title=GRAPH_STATE_PROPERTY_TITLE,
+        )
+        return FlowNode(
+            name=node_name,
+            subflow=subflow,
+            inputs=[opaque_property],
+            outputs=[opaque_property],
+        )
+
+    def _build_tool_node(
+        self,
+        node_name: str,
+        node: "StateNodeSpec[Any]",
+    ) -> AgentSpecNode:
+        opaque_property = _build_opaque_property_from_schema(
+            self._graph.state_schema,
+            title=GRAPH_STATE_PROPERTY_TITLE,
+        )
+        return AgentSpecToolNode(
+            name=node_name,
+            tool=AgentSpecServerTool(
+                name=node_name + "_tool",
+                inputs=[opaque_property],
+                outputs=[opaque_property],
+            ),
+            inputs=[opaque_property],
+            outputs=[opaque_property],
+        )
+
+    def _get_start_end_node_properties(
+        self,
+        start_end_node_name: str,
+        public_schema: Any,
+    ) -> List[Property]:
+        return [
+            _build_opaque_property_from_schema(
+                self._graph.state_schema,
+                title=GRAPH_STATE_PROPERTY_TITLE,
+            )
+        ]
+
+    def _resolve_conditional_node_inputs(
+        self,
+        source_node_name: str,
+        branch: BranchSpec,
+    ) -> List[Property]:
+        return [
+            _build_opaque_property_from_schema(
+                self._graph.state_schema,
+                title=GRAPH_STATE_PROPERTY_TITLE,
+            )
+        ]
+
+
+class _FieldWiringFlowExporter(_BaseLangGraphFlowExporter):
+    """Exporter that preserves direct field wiring only for directly representable flows."""
+
+    def _build_flow_node(
+        self,
+        node_name: str,
+        node: "StateNodeSpec[Any]",
+    ) -> FlowNode:
+        subgraph_runnable = cast(LangGraphComponent, node.runnable)
+        subflow = _langgraph_graph_convert_to_agentspec(
+            self._converter,
+            subgraph_runnable,
+            {},
+        )
+        return FlowNode(name=node_name, subflow=subflow)
+
+    def _build_tool_node(
+        self,
+        node_name: str,
+        node: "StateNodeSpec[Any]",
+    ) -> AgentSpecNode:
+        declared_input_properties, declared_output_properties = (
+            _get_langgraph_node_declared_properties(
+                self._graph,
+                node,
+            )
+        )
+        input_properties = declared_input_properties or [
+            _build_opaque_property_from_schema(
+                node.input_schema,
+                title=OPAQUE_INPUT_PROPERTY_TITLE,
+            )
+        ]
+
+        output_properties = declared_output_properties
+        if output_properties is None:
+            target_nodes = [
+                to for from_, to in self._graph.edges if from_ != to and from_ == node_name
+            ]
+            # When a leaf node does not declare outputs, export the state shape expected by its
+            # downstream consumers. This is an adapter approximation: Agent Spec needs an explicit
+            # output port, while LangGraph lets the node return a patch that is interpreted in the
+            # context of the next node(s).
+            if target_nodes in ([], [END]):
+                # No explicit outgoing edge means LangGraph implicitly routes this node to END.
+                # An explicit edge to END has the same exported output shape.
+                output_properties = [
+                    _build_opaque_property_from_schema(
+                        self._graph.output_schema,
+                        title=OPAQUE_OUTPUT_PROPERTY_TITLE,
+                    )
+                ]
+            elif len(target_nodes) == 1:
+                target_node_name = target_nodes[0]
+                # With one downstream node, export the state shape that node reads.
+                output_properties = [
+                    _build_opaque_property_from_schema(
+                        self._graph.nodes[target_node_name].input_schema,
+                        title=OPAQUE_OUTPUT_PROPERTY_TITLE,
+                    )
+                ]
+            else:
+                # With multiple downstream nodes, export a union of the state shapes each
+                # possible target expects to read.
+                target_properties: List[Property] = []
+                for target_node_name in target_nodes:
+                    if target_node_name == END:
+                        target_properties.append(
+                            _build_opaque_property_from_schema(
+                                self._graph.output_schema,
+                                title=OPAQUE_OUTPUT_PROPERTY_TITLE,
+                            )
+                        )
+                    else:
+                        target_properties.append(
+                            _build_opaque_property_from_schema(
+                                self._graph.nodes[target_node_name].input_schema,
+                                title=OPAQUE_OUTPUT_PROPERTY_TITLE,
+                            )
+                        )
+                output_properties = [
+                    _build_opaque_union_property(
+                        target_properties,
+                        title=OPAQUE_OUTPUT_PROPERTY_TITLE,
+                    )
+                ]
+
+        return AgentSpecToolNode(
+            name=node_name,
+            tool=AgentSpecServerTool(
+                name=node_name + "_tool",
+                inputs=input_properties,
+                outputs=output_properties,
+            ),
+            inputs=input_properties,
+            outputs=output_properties,
+        )
+
+    def _get_start_end_node_properties(
+        self,
+        start_end_node_name: str,
+        public_schema: Any,
+    ) -> List[Property]:
+        opaque_boundary_title = (
+            OPAQUE_INPUT_PROPERTY_TITLE
+            if start_end_node_name == START
+            else OPAQUE_OUTPUT_PROPERTY_TITLE
+        )
+        # Only expose named-field boundary ports when the public boundary schema is
+        # narrower than the internal graph state. Otherwise we keep one opaque boundary port.
+        if public_schema is self._graph.state_schema:
+            return [
+                _build_opaque_property_from_schema(
+                    public_schema,
+                    title=GRAPH_STATE_PROPERTY_TITLE,
                 )
+            ]
+        return _get_named_field_properties_from_schema(public_schema) or [
+            _build_opaque_property_from_schema(
+                public_schema,
+                title=opaque_boundary_title,
             )
+        ]
 
-    return (additional_nodes, additional_ctrl_flows, additional_data_flows)
-
-
-def _get_start_end_nodes(
-    graph: StateGraph[Any, Any, Any],
-    referenced_objects: Dict[str, AgentSpecComponent],
-) -> Tuple[AgentSpecNode, AgentSpecNode]:
-    if START not in referenced_objects:
-        if START not in graph.nodes:
-            referenced_objects[START] = StartNode(
-                name=START,
-                inputs=[_get_property_from_schema(graph.input_schema)],
-                outputs=[_get_property_from_schema(graph.input_schema)],
+    def _resolve_conditional_node_inputs(
+        self,
+        source_node_name: str,
+        branch: BranchSpec,
+    ) -> List[Property]:
+        if named_field_properties := _get_named_field_properties_from_schema(branch.input_schema):
+            return named_field_properties
+        if source_node_name in self._graph.nodes:
+            return [
+                _build_opaque_property_from_schema(
+                    self._graph.nodes[source_node_name].input_schema,
+                    title=OPAQUE_INPUT_PROPERTY_TITLE,
+                )
+            ]
+        return [
+            _build_opaque_property_from_schema(
+                self._graph.state_schema,
+                title=OPAQUE_INPUT_PROPERTY_TITLE,
             )
-        else:
-            referenced_objects[START] = _langgraph_node_convert_to_agentspec(
-                graph,
-                START,
-                graph.nodes[START],
-                referenced_objects,
-            )
+        ]
 
-    if END not in referenced_objects:
-        if END not in graph.nodes:
-            referenced_objects[END] = EndNode(
-                name=END,
-                inputs=[_get_property_from_schema(graph.output_schema)],
-                outputs=[_get_property_from_schema(graph.output_schema)],
-            )
-        else:
-            referenced_objects[END] = _langgraph_node_convert_to_agentspec(
-                graph,
-                END,
-                graph.nodes[END],
-                referenced_objects,
-            )
+    def _validate_data_flow_edges(
+        self,
+        nodes: List[AgentSpecNode],
+        data_flow_edges: List[DataFlowEdge],
+    ) -> None:
+        """Require every named input in field-wiring mode to be satisfied locally."""
+        for destination_node in nodes:
+            if destination_node.name == START:
+                continue
 
-    return (
-        cast(AgentSpecNode, referenced_objects[START]),
-        cast(AgentSpecNode, referenced_objects[END]),
-    )
+            required_input_titles = [
+                property_.title
+                for property_ in destination_node.inputs or []
+                if not _is_opaque_property(property_)
+                and property_.default is Property.empty_default
+            ]
+            if not required_input_titles:
+                continue
+
+            provided_input_titles = {
+                edge.destination_input
+                for edge in data_flow_edges
+                if edge.destination_node.name == destination_node.name
+            }
+            missing_input_titles = [
+                title for title in required_input_titles if title not in provided_input_titles
+            ]
+            if missing_input_titles:
+                raise _FieldWiringFallbackRequired(
+                    f"Unable to represent data flow into `{destination_node.name}` for fields: "
+                    f"{', '.join(missing_input_titles)}."
+                )
 
 
-def _get_property_from_schema(schema: Type[Any]) -> Property:
+def _dedupe_name(
+    name_candidate: str,
+    referenced_object_names: Collection[str],
+) -> str:
+    """Return a unique component name by appending a numeric suffix when needed."""
+    if name_candidate not in referenced_object_names:
+        return name_candidate
+
+    name_suffix = 1
+    deduped_name = f"{name_candidate}_{name_suffix}"
+    while deduped_name in referenced_object_names:
+        name_suffix += 1
+        deduped_name = f"{name_candidate}_{name_suffix}"
+    return deduped_name
+
+
+def _build_json_schema_from_schema_type(schema: Type[Any]) -> Optional[Dict[str, Any]]:
+    """Build a raw JSON schema dictionary from a Python schema type."""
     if issubclass(schema, BaseModel):
-        json_schema = schema.model_json_schema()
-    elif is_dataclass(schema):
-        json_schema = TypeAdapter(schema).json_schema()
-    else:
-        try:
-            input_model = create_model(schema.__name__, **schema.__annotations__)
-            json_schema = input_model.model_json_schema()
-        except Exception:
-            return Property(json_schema={}, title="state")  # "Any" property
-
-    properties = json_schema["properties"]
-
-    # Pydantic keeps changing the title of the fields to PascalCase
-    # We overwrite the title with the proper field name
-    for field in schema.__annotations__:
-        if field in properties:
-            properties[field]["title"] = field
-
-    input_property = Property(json_schema=json_schema, title="state")
-    return input_property
+        return schema.model_json_schema()
+    if is_dataclass(schema):
+        return TypeAdapter(schema).json_schema()
+    try:
+        return cast(
+            Dict[str, Any],
+            create_model(schema.__name__, **schema.__annotations__).model_json_schema(),
+        )
+    except Exception:
+        return None
 
 
-def _resolve_output_properties(
-    graph: StateGraph[Any, Any, Any],
-    target_nodes: List[str],
+def _rename_top_level_property_titles(
+    json_schema: Dict[str, Any],
+    field_names: Collection[str],
+) -> Dict[str, Any]:
+    """Rewrite top-level property titles to their field names."""
+    properties = json_schema.get("properties")
+    if not isinstance(properties, dict):
+        return json_schema
+
+    normalized_properties = dict(properties)
+    updated = False
+    for field_name in field_names:
+        field_schema = properties.get(field_name)
+        if isinstance(field_schema, dict) and field_schema.get("title") != field_name:
+            normalized_properties[field_name] = {**field_schema, "title": field_name}
+            updated = True
+
+    if not updated:
+        return json_schema
+    return {**json_schema, "properties": normalized_properties}
+
+
+def _build_opaque_property_from_schema(
+    schema: Type[Any],
+    title: str,
 ) -> Property:
-    match target_nodes:
-        case []:
-            # This case handles nodes that don't have an explicit outgoing edge
-            # They are then routed to the end node automatically
-            # And thus the property is the output schema of the entire graph
-            return _get_property_from_schema(graph.output_schema)
-        case [node_name]:
-            # This case is used to get the output property for going from a node to a target node
-            if node_name == START:
-                return _get_property_from_schema(graph.input_schema)
-            if node_name == END:
-                return _get_property_from_schema(graph.output_schema)
-            return _get_property_from_schema(graph.nodes[node_name].input_schema)
-        case nodes:
-            # This case is used to get a union property of all the target nodes
-            properties: List[Property] = []
-            for node_name in nodes:
-                properties.append(_resolve_output_properties(graph, [node_name]))
-            union_property = UnionProperty(any_of=properties)
-            return union_property
+    """Build one opaque property from a schema type."""
+    json_schema = _build_json_schema_from_schema_type(schema)
+    if json_schema is None:
+        # Some class-like schemas expose annotations that we cannot turn into a valid Pydantic
+        # model/json schema. In that case we still export the port as one opaque property rather
+        # than failing the whole graph conversion.
+        return _OpaquePortProperty(json_schema={}, title=title)
+
+    # Agent Spec validates nested schema titles too. Pydantic generates display titles such
+    # as "Weather Data", which makes the opaque property invalid, so rewrite the
+    # top-level field titles back to their schema field names before constructing `Property`.
+    return _OpaquePortProperty(
+        json_schema=_rename_top_level_property_titles(
+            json_schema,
+            getattr(schema, "__annotations__", {}),
+        ),
+        title=title,
+    )
 
 
-def _langgraph_node_convert_to_agentspec(
+def _build_opaque_union_property(
+    properties: List[Property],
+    title: str,
+) -> Property:
+    """Build one opaque union port from multiple opaque fallback shapes."""
+    return _OpaqueUnionProperty(
+        any_of=properties,
+        title=title,
+    )
+
+
+def _is_opaque_property(property_: Property) -> bool:
+    """Return whether a property is one of the adapter's opaque fallback ports."""
+    return isinstance(property_, (_OpaquePortProperty, _OpaqueUnionProperty))
+
+
+def _get_named_field_properties_from_schema(schema: Any) -> Optional[List[Property]]:
+    """Return one property per schema field when the schema exposes named fields."""
+    # Convert a structured schema into one Agent Spec property per field so later conversion
+    # steps can wire nodes by field name instead of falling back to a single opaque port. If the
+    # schema does not expose named fields, return None and let callers use opaque state-level
+    # wiring instead.
+    annotations = getattr(schema, "__annotations__", None)
+    if not annotations:
+        return None
+
+    json_schema = _build_json_schema_from_schema_type(cast(Type[Any], schema))
+    if json_schema is None:
+        return None
+    properties = json_schema.get("properties")
+    if not isinstance(properties, dict) or not properties:
+        return None
+
+    result: List[Property] = []
+    for field_name in list(annotations) + [name for name in properties if name not in annotations]:
+        # Rebuild the field properties from the JSON schema so titles stay aligned with the
+        # original field names rather than Pydantic-generated display names.
+        field_schema = properties.get(field_name)
+        if not isinstance(field_schema, dict):
+            continue
+        result.append(Property(title=field_name, json_schema={**field_schema, "title": field_name}))
+    return result or None
+
+
+def _get_langgraph_node_declared_properties(
     graph: StateGraph[Any, Any, Any],
-    node_name: str,
     node: "StateNodeSpec[Any]",
-    referenced_objects: Dict[str, AgentSpecComponent],
-) -> AgentSpecNode:
-    if node_name in referenced_objects:
-        converted_node = referenced_objects[node_name]
-        if not isinstance(converted_node, AgentSpecNode):
-            raise TypeError(
-                f"expected node {converted_node} to be of type {AgentSpecNode}, got: {converted_node.__class__}"
-            )
-        return converted_node
+) -> Tuple[Optional[List[Property]], Optional[List[Property]]]:
+    """Infer the declared named-field inputs and outputs for a LangGraph node."""
+    # Infer the named-field inputs and outputs a LangGraph node declares so leaf nodes can
+    # expose concrete ports like "user_query" or "answer" instead of only the whole graph state.
+    runnable = getattr(node, "runnable", None)
+    unwrapped_callable = getattr(runnable, "func", runnable)
+    # LangGraph may store node callables in wrappers or `functools.partial(...)`.
+    # We currently unwrap those layers only to recover annotations when an explicit
+    # named-field input schema is not already available on the node itself.
+    while isinstance(unwrapped_callable, partial):
+        unwrapped_callable = unwrapped_callable.func
 
-    input_property = _get_property_from_schema(node.input_schema)
+    type_hints: Dict[str, Any] = {}
+    if callable(unwrapped_callable):
+        try:
+            type_hints = get_type_hints(unwrapped_callable)
+        except Exception:
+            raw_annotations = getattr(unwrapped_callable, "__annotations__", {}) or {}
+            if isinstance(raw_annotations, dict):
+                type_hints = raw_annotations
 
-    target_nodes: List[str] = []
-    for from_, to in graph.edges:
-        if from_ != to and from_ == node_name:
-            target_nodes.append(to)
-    output_property = _resolve_output_properties(graph, target_nodes)
+    input_properties: Optional[List[Property]] = None
+    if node.input_schema is not graph.state_schema:
+        # Prefer the explicit node input schema when LangGraph narrowed it below the graph state.
+        input_properties = _get_named_field_properties_from_schema(node.input_schema)
 
-    tool = AgentSpecServerTool(
-        name=node_name + "_tool",
-        inputs=[input_property],
-        outputs=[output_property],
-    )
-    referenced_objects[node_name] = AgentSpecToolNode(
-        name=node_name,
-        tool=tool,
-        inputs=[input_property],
-        outputs=[output_property],
-    )
-    return cast(AgentSpecNode, referenced_objects[node_name])
+    if input_properties is None and callable(unwrapped_callable):
+        # Otherwise fall back to the first positional parameter annotation on the callable.
+        try:
+            signature = inspect.signature(unwrapped_callable)
+        except (TypeError, ValueError):
+            pass
+        else:
+            for parameter in signature.parameters.values():
+                if parameter.kind not in (
+                    inspect.Parameter.POSITIONAL_ONLY,
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                ):
+                    continue
+                annotation = type_hints.get(parameter.name, parameter.annotation)
+                if annotation is not inspect.Signature.empty:
+                    input_properties = _get_named_field_properties_from_schema(annotation)
+                break
+
+    # Outputs come from the declared return type first, then from runnable.output_schema when
+    # LangGraph wrapped the callable and kept the schema there instead.
+    output_properties = _get_named_field_properties_from_schema(type_hints.get("return"))
+    if output_properties is None:
+        output_properties = _get_named_field_properties_from_schema(
+            getattr(runnable, "output_schema", None)
+        )
+
+    return input_properties, output_properties
 
 
-def _langgraph_edges_convert_to_agentspec_ctrl_flow(
+def _langgraph_edge_convert_to_agentspec_ctrl_flow(
     edge: Tuple[str, str],
     referenced_objects: Dict[str, AgentSpecComponent],
 ) -> ControlFlowEdge:
+    """Convert a LangGraph control edge into an Agent Spec control edge."""
     from_, to = edge
-    name = f"{from_}_to_{to}"
 
     return ControlFlowEdge(
-        name=name,
+        name=f"{from_}_to_{to}",
         from_node=cast(AgentSpecNode, referenced_objects[from_]),
         to_node=cast(AgentSpecNode, referenced_objects[to]),
     )
 
 
-def _langgraph_edges_convert_to_agentspec_data_flow(
-    graph: StateGraph[Any, Any, Any],
-    edge: Tuple[str, str],
-    referenced_objects: Dict[str, AgentSpecComponent],
-) -> DataFlowEdge:
-    from_, to = edge
-    name = f"{from_}_to_{to}_data_edge"
+def _build_data_flow_edges_for_node_pair(
+    source_node: AgentSpecNode,
+    destination_node: AgentSpecNode,
+    edge_name_prefix: str,
+) -> List[DataFlowEdge]:
+    """Build all Agent Spec data edges for one converted source/destination node pair."""
+    # Prefer explicit field-to-field data edges when both nodes expose named ports.
+    destination_input_titles = {property_.title for property_ in destination_node.inputs or []}
+    shared_titles = [
+        property_.title
+        for property_ in source_node.outputs or []
+        if property_.title in destination_input_titles
+    ]
+    if shared_titles:
+        return [
+            DataFlowEdge(
+                name=f"{edge_name_prefix}_{title}_data_edge",
+                source_node=source_node,
+                destination_node=destination_node,
+                source_output=title,
+                destination_input=title,
+            )
+            for title in shared_titles
+        ]
 
-    if from_ == START:
-        internal_state_property = _get_property_from_schema(graph.input_schema)
-    else:
-        internal_state_property = _get_property_from_schema(graph.state_schema)
+    source_outputs = source_node.outputs or []
+    destination_inputs = destination_node.inputs or []
 
-    destination_input_property = _resolve_output_properties(graph, [to])
+    # Fall back to one opaque-port edge when both nodes only expose a single opaque port.
+    if (
+        len(source_outputs) == 1
+        and len(destination_inputs) == 1
+        and _is_opaque_property(source_outputs[0])
+        and _is_opaque_property(destination_inputs[0])
+    ):
+        return [
+            DataFlowEdge(
+                name=f"{edge_name_prefix}_data_edge",
+                source_node=source_node,
+                destination_node=destination_node,
+                source_output=source_outputs[0].title,
+                destination_input=destination_inputs[0].title,
+            )
+        ]
 
-    source_node = cast(AgentSpecNode, referenced_objects[from_])
-    destination_node = cast(AgentSpecNode, referenced_objects[to])
-
-    data_flow_edge = DataFlowEdge(
-        name=name,
-        source_node=source_node,
-        destination_node=destination_node,
-        source_output=internal_state_property.title,
-        destination_input=destination_input_property.title,
+    raise _FieldWiringFallbackRequired(
+        f"Unable to represent data flow between `{source_node.name}` and "
+        f"`{destination_node.name}` without mixing opaque-port wiring and named field wiring."
     )
-    return data_flow_edge

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/_agentspecconverter.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/_agentspecconverter.py
@@ -5,6 +5,7 @@
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 
 import datetime
+import string
 from types import FunctionType, UnionType
 from typing import (
     TYPE_CHECKING,
@@ -44,6 +45,7 @@ from pyagentspec.agent import Agent as AgentSpecAgent
 from pyagentspec.agenticcomponent import AgenticComponent as AgentSpecAgenticComponent
 from pyagentspec.component import Component as AgentSpecComponent
 from pyagentspec.llms import LlmConfig as AgentSpecLlmConfig
+from pyagentspec.llms import LlmGenerationConfig as AgentSpecLlmGenerationConfig
 from pyagentspec.llms import OllamaConfig as AgentSpecOllamaConfig
 from pyagentspec.llms import OpenAiCompatibleConfig as AgentSpecOpenAiCompatibleConfig
 from pyagentspec.llms import OpenAiConfig as AgentSpecOpenAiConfig
@@ -73,6 +75,7 @@ from pyagentspec.mcp.clienttransport import (
 )
 from pyagentspec.swarm import HandoffMode as AgentSpecHandoffMode
 from pyagentspec.swarm import Swarm as AgentSpecSwarm
+from pyagentspec.templating import get_placeholders_from_string
 from pyagentspec.tools import ServerTool
 from pyagentspec.tools import Tool as AgentSpecTool
 
@@ -227,6 +230,8 @@ class LangGraphToAgentSpecConverter:
         except ImportError:
             _ChatOCIGenAI = None
 
+        generation_parameters = self._extract_generation_parameters_from_model(model)
+
         if _ChatOCIGenAI is not None and isinstance(model, _ChatOCIGenAI):
             auth_type = model.auth_type
             service_endpoint = model.service_endpoint
@@ -262,12 +267,14 @@ class LangGraphToAgentSpecConverter:
                 client_config=client_cfg,
                 provider=AgentSpecModelProvider(model.provider.upper()) if model.provider else None,
                 api_type=AgentSpecOciAPIType.OCI,
+                default_generation_parameters=generation_parameters,
             )
         if isinstance(model, langchain_ollama.ChatOllama):
             return AgentSpecOllamaConfig(
                 name=model.model,
                 url=model.base_url or "",
                 model_id=model.model,
+                default_generation_parameters=generation_parameters,
             )
         if isinstance(model, langchain_openai.ChatOpenAI):
             api_type = (
@@ -277,7 +284,10 @@ class LangGraphToAgentSpecConverter:
             )
             if (model.openai_api_base or "").startswith("https://api.openai.com"):
                 return AgentSpecOpenAiConfig(
-                    name=model.model_name, model_id=model.model_name, api_type=api_type
+                    name=model.model_name,
+                    model_id=model.model_name,
+                    api_type=api_type,
+                    default_generation_parameters=generation_parameters,
                 )
             else:
                 return AgentSpecOpenAiCompatibleConfig(
@@ -285,8 +295,62 @@ class LangGraphToAgentSpecConverter:
                     url=model.openai_api_base or "",
                     model_id=model.model_name,
                     api_type=api_type,
+                    default_generation_parameters=generation_parameters,
                 )
         raise ValueError(f"The LLM instance provided is of an unsupported type `{type(model)}`.")
+
+    def _extract_generation_parameters_from_model(
+        self,
+        model: BaseChatModel,
+    ) -> Optional[AgentSpecLlmGenerationConfig]:
+        model_kwargs = cast(Dict[str, Any], getattr(model, "model_kwargs", {}) or {})
+        max_tokens = getattr(model, "max_tokens", None)
+        if max_tokens is None:
+            max_tokens = getattr(model, "num_predict", None)
+        if max_tokens is None:
+            max_tokens = model_kwargs.get("max_tokens", model_kwargs.get("max_completion_tokens"))
+
+        generation_parameters = AgentSpecLlmGenerationConfig(
+            temperature=getattr(model, "temperature", model_kwargs.get("temperature")),
+            max_tokens=max_tokens,
+            top_p=getattr(model, "top_p", model_kwargs.get("top_p")),
+        )
+        if (
+            generation_parameters.temperature is None
+            and generation_parameters.max_tokens is None
+            and generation_parameters.top_p is None
+        ):
+            return None
+        return generation_parameters
+
+    def _normalize_prompt_template_string(self, template: str) -> Tuple[str, List[str]]:
+        # Do not rewrite the prompt here. Promotion to LlmNode/AgentNode is only allowed when the
+        # original prompt already uses Agent Spec-compatible `{{variable}}` placeholders. Single-
+        # curly `{...}` segments stay as literal prompt text in this narrow export contract.
+        return template, get_placeholders_from_string(template)
+
+    def _contains_python_format_fields(self, template: str) -> bool:
+        """Return whether the prompt contains Python `{field}` format placeholders."""
+        # `string.Formatter` already understands escaped braces, so `{{variable}}` stays literal
+        # while mixed templates like `{{variable}} ... {other}` still report the single-curly
+        # Python format field. The exporter treats any real Python format field conservatively and
+        # keeps the wrapper as a ToolNode rather than changing prompt rendering semantics.
+        formatter = string.Formatter()
+        try:
+            return any(field_name is not None for _, field_name, _, _ in formatter.parse(template))
+        except ValueError:
+            # Be conservative around malformed Python format strings and avoid exporting them as
+            # Agent Spec LlmNodes/AgentNodes.
+            return True
+
+    def _extract_prompt_from_react_agent(
+        self,
+        langgraph_component: LangGraphComponent,
+    ) -> str:
+        """Extract the system prompt string from a LangGraph react agent component."""
+        if isinstance(langgraph_component, CompiledStateGraph):
+            langgraph_component = langgraph_component.builder
+        return self._extract_prompt_from_model_node(langgraph_component.nodes["model"])
 
     def _langgraph_agent_convert_to_agentspec(
         self,
@@ -309,7 +373,7 @@ class LangGraphToAgentSpecConverter:
         return AgentSpecAgent(
             name=agent_name,
             llm_config=cast(AgentSpecLlmConfig, self.convert(basechatmodel, referenced_objects)),
-            system_prompt=self._extract_prompt_from_model_node(model_node),
+            system_prompt=self._extract_prompt_from_react_agent(langgraph_component),
             tools=tools,
         )
 

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/_agentspecconverter.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/_agentspecconverter.py
@@ -131,7 +131,9 @@ class LangGraphToAgentSpecConverter:
             )
         else:
             agentspec_component = _langgraph_graph_convert_to_agentspec(
-                self, langgraph_component, referenced_objects
+                self,
+                langgraph_component,
+                referenced_objects,
             )
         if agentspec_component is None:
             raise NotImplementedError(f"Conversion for {langgraph_component} not implemented yet")

--- a/pyagentspec/src/pyagentspec/templating.py
+++ b/pyagentspec/src/pyagentspec/templating.py
@@ -18,10 +18,10 @@ TEMPLATE_PLACEHOLDER_REGEXP = r"{{\s*(\w+)\s*}}"
 def get_placeholders_from_string(string_with_placeholders: str) -> List[str]:
     """Extract the placeholder names from a string."""
     return list(
-        {
+        dict.fromkeys(
             match.strip()
             for match in re.findall(TEMPLATE_PLACEHOLDER_REGEXP, string_with_placeholders)
-        }
+        )
     )
 
 

--- a/pyagentspec/tests/adapters/langgraph/test_langgraph_to_agentspec.py
+++ b/pyagentspec/tests/adapters/langgraph/test_langgraph_to_agentspec.py
@@ -6,6 +6,7 @@
 
 
 from dataclasses import dataclass
+from functools import partial
 from typing import TYPE_CHECKING, Any, Literal, TypeAlias, TypedDict, cast
 
 import pytest
@@ -14,7 +15,7 @@ from pydantic import BaseModel, SecretStr
 from pyagentspec.agent import Agent as AgentSpecAgent
 from pyagentspec.component import Component
 from pyagentspec.flows.flow import Flow as AgentSpecFlow
-from pyagentspec.flows.nodes import BranchingNode, FlowNode, ToolNode
+from pyagentspec.flows.nodes import AgentNode, BranchingNode, FlowNode, ToolNode
 from pyagentspec.llms import OpenAiCompatibleConfig
 
 from .conftest import get_weather
@@ -358,6 +359,365 @@ def test_convert_graph_flow_to_agentspec_multi_schemas(
         ("get_weather", "weather_data", "llm_node", "weather_data"),
         ("llm_node", "response", "__end__", "response"),
     }
+
+
+def test_convert_graph_flow_wrapped_react_agent_node_to_agentspec_agent_node(
+    agentspec_exporter: "AgentSpecExporter",
+) -> None:
+    from langchain.agents import create_agent
+    from langchain_openai.chat_models import ChatOpenAI
+    from langgraph.graph import END, START, StateGraph
+
+    class InputState(TypedDict):
+        topic: str
+
+    class OutputState(TypedDict):
+        answer: str
+
+    class GraphState(TypedDict, total=False):
+        topic: str
+        answer: str
+
+    class InternalState(TypedDict):
+        messages: list[dict[str, str]]
+        remaining_steps: int
+
+    wrapped_agent = create_agent(
+        model=ChatOpenAI(
+            base_url="http://example.invalid/v1",
+            model="openai/gpt-oss-test",
+            api_key=SecretStr("t"),
+        ),
+        tools=[],
+        state_schema=InternalState,
+        system_prompt="You are helpful about {{topic}}.",
+        name="subagent",
+    )
+
+    def run_agent(_agent: Any, state: InputState) -> OutputState:
+        _agent.invoke(
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": state["topic"],
+                    }
+                ]
+            }
+        )
+        return {"answer": state["topic"]}
+
+    graph = StateGraph(
+        GraphState,
+        input_schema=InputState,
+        output_schema=OutputState,
+    )
+    graph.add_node(
+        "call_agent",
+        partial(run_agent, wrapped_agent),
+        input_schema=InputState,
+    )
+    graph.add_edge(START, "call_agent")
+    graph.add_edge("call_agent", END)
+
+    flow = cast(
+        AgentSpecFlow,
+        agentspec_exporter.to_component(graph.compile(name="Wrapped Agent Flow")),
+    )
+
+    assert _property_titles(flow.inputs) == ["topic"]
+    assert _property_titles(flow.outputs) == ["answer"]
+
+    start_node = _find_node(flow, "__start__")
+    end_node = _find_node(flow, "__end__")
+    agent_node = _find_node(flow, "call_agent")
+
+    assert _property_titles(start_node.outputs) == ["topic"]
+    assert _property_titles(end_node.inputs) == ["answer"]
+    assert isinstance(agent_node, AgentNode)
+    assert isinstance(agent_node.agent, AgentSpecAgent)
+    assert agent_node.agent.name == "subagent"
+    assert _property_titles(agent_node.inputs) == ["topic"]
+    assert _property_titles(agent_node.outputs) == ["answer"]
+    assert _property_titles(agent_node.agent.inputs) == ["topic"]
+    assert _property_titles(agent_node.agent.outputs) == ["answer"]
+    assert _data_edge_signatures(flow) == {
+        ("__start__", "topic", "call_agent", "topic"),
+        ("call_agent", "answer", "__end__", "answer"),
+    }
+
+
+def test_convert_graph_flow_wrapped_react_agent_node_with_ainvoke_to_agentspec_agent_node(
+    agentspec_exporter: "AgentSpecExporter",
+) -> None:
+    from langchain.agents import create_agent
+    from langchain_openai.chat_models import ChatOpenAI
+    from langgraph.graph import END, START, StateGraph
+
+    class InputState(TypedDict):
+        topic: str
+
+    class OutputState(TypedDict):
+        answer: str
+
+    class GraphState(TypedDict, total=False):
+        topic: str
+        answer: str
+
+    class InternalState(TypedDict):
+        messages: list[dict[str, str]]
+        remaining_steps: int
+
+    wrapped_agent = create_agent(
+        model=ChatOpenAI(
+            base_url="http://example.invalid/v1",
+            model="openai/gpt-oss-test",
+            api_key=SecretStr("t"),
+        ),
+        tools=[],
+        state_schema=InternalState,
+        system_prompt="You are helpful about {{topic}}.",
+        name="subagent",
+    )
+
+    async def run_agent(_agent: Any, state: InputState) -> OutputState:
+        await _agent.ainvoke(
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": state["topic"],
+                    }
+                ]
+            }
+        )
+        return {"answer": state["topic"]}
+
+    graph = StateGraph(
+        GraphState,
+        input_schema=InputState,
+        output_schema=OutputState,
+    )
+    graph.add_node(
+        "call_agent",
+        partial(run_agent, wrapped_agent),
+        input_schema=InputState,
+    )
+    graph.add_edge(START, "call_agent")
+    graph.add_edge("call_agent", END)
+
+    flow = cast(
+        AgentSpecFlow,
+        agentspec_exporter.to_component(graph.compile(name="Wrapped Async Agent Flow")),
+    )
+    agent_node = _find_node(flow, "call_agent")
+
+    assert isinstance(agent_node, AgentNode)
+    assert isinstance(agent_node.agent, AgentSpecAgent)
+    assert agent_node.agent.name == "subagent"
+    assert _property_titles(agent_node.inputs) == ["topic"]
+    assert _property_titles(agent_node.outputs) == ["answer"]
+
+
+def test_convert_graph_flow_wrapped_react_agent_node_with_keyword_bound_partial_to_agentspec_agent_node(
+    agentspec_exporter: "AgentSpecExporter",
+) -> None:
+    from langchain.agents import create_agent
+    from langchain_openai.chat_models import ChatOpenAI
+    from langgraph.graph import END, START, StateGraph
+
+    class InputState(TypedDict):
+        topic: str
+
+    class OutputState(TypedDict):
+        answer: str
+
+    class GraphState(TypedDict, total=False):
+        topic: str
+        answer: str
+
+    class InternalState(TypedDict):
+        messages: list[dict[str, str]]
+        remaining_steps: int
+
+    wrapped_agent = create_agent(
+        model=ChatOpenAI(
+            base_url="http://example.invalid/v1",
+            model="openai/gpt-oss-test",
+            api_key=SecretStr("t"),
+        ),
+        tools=[],
+        state_schema=InternalState,
+        system_prompt="You are helpful about {{topic}}.",
+        name="subagent",
+    )
+
+    def run_agent(state: InputState, _agent: Any) -> OutputState:
+        _agent.invoke(
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": state["topic"],
+                    }
+                ]
+            }
+        )
+        return {"answer": state["topic"]}
+
+    graph = StateGraph(
+        GraphState,
+        input_schema=InputState,
+        output_schema=OutputState,
+    )
+    graph.add_node("call_agent", partial(run_agent, _agent=wrapped_agent))
+    graph.add_edge(START, "call_agent")
+    graph.add_edge("call_agent", END)
+
+    flow = cast(
+        AgentSpecFlow,
+        agentspec_exporter.to_component(graph.compile(name="Wrapped Agent Flow Keyword Partial")),
+    )
+    agent_node = _find_node(flow, "call_agent")
+
+    assert isinstance(agent_node, AgentNode)
+    assert isinstance(agent_node.agent, AgentSpecAgent)
+    assert agent_node.agent.name == "subagent"
+    assert _property_titles(agent_node.inputs) == ["topic"]
+    assert _property_titles(agent_node.outputs) == ["answer"]
+    assert _property_titles(agent_node.agent.inputs) == ["topic"]
+    assert _property_titles(agent_node.agent.outputs) == ["answer"]
+    assert _data_edge_signatures(flow) == {
+        ("__start__", "topic", "call_agent", "topic"),
+        ("call_agent", "answer", "__end__", "answer"),
+    }
+
+
+def test_convert_graph_flow_wrapped_react_agent_node_requires_matching_prompt_inputs(
+    agentspec_exporter: "AgentSpecExporter",
+) -> None:
+    from langchain.agents import create_agent
+    from langchain_openai.chat_models import ChatOpenAI
+    from langgraph.graph import END, START, StateGraph
+
+    class InputState(TypedDict):
+        topic: str
+
+    class OutputState(TypedDict):
+        answer: str
+
+    class GraphState(TypedDict, total=False):
+        topic: str
+        answer: str
+
+    class InternalState(TypedDict):
+        messages: list[dict[str, str]]
+        remaining_steps: int
+
+    wrapped_agent = create_agent(
+        model=ChatOpenAI(
+            base_url="http://example.invalid/v1",
+            model="openai/gpt-oss-test",
+            api_key=SecretStr("t"),
+        ),
+        tools=[],
+        state_schema=InternalState,
+        system_prompt="You are helpful.",
+        name="subagent",
+    )
+
+    def run_agent(_agent: Any, state: InputState) -> OutputState:
+        _agent.invoke(
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": state["topic"],
+                    }
+                ]
+            }
+        )
+        return {"answer": state["topic"]}
+
+    graph = StateGraph(
+        GraphState,
+        input_schema=InputState,
+        output_schema=OutputState,
+    )
+    graph.add_node(
+        "call_agent",
+        partial(run_agent, wrapped_agent),
+        input_schema=InputState,
+    )
+    graph.add_edge(START, "call_agent")
+    graph.add_edge("call_agent", END)
+
+    with pytest.raises(
+        ValueError,
+        match=r"wrapper node inputs \['topic'\] do not match the wrapped agent prompt placeholders \[\]",
+    ):
+        agentspec_exporter.to_component(graph.compile(name="Wrapped Agent Flow"))
+
+
+def test_convert_graph_flow_wrapped_react_agent_node_without_invoke_stays_tool_node(
+    agentspec_exporter: "AgentSpecExporter",
+) -> None:
+    from langchain.agents import create_agent
+    from langchain_openai.chat_models import ChatOpenAI
+    from langgraph.graph import END, START, StateGraph
+
+    class InputState(TypedDict):
+        topic: str
+
+    class OutputState(TypedDict):
+        answer: str
+
+    class GraphState(TypedDict, total=False):
+        topic: str
+        answer: str
+
+    class InternalState(TypedDict):
+        messages: list[dict[str, str]]
+        remaining_steps: int
+
+    wrapped_agent = create_agent(
+        model=ChatOpenAI(
+            base_url="http://example.invalid/v1",
+            model="openai/gpt-oss-test",
+            api_key=SecretStr("t"),
+        ),
+        tools=[],
+        state_schema=InternalState,
+        system_prompt="You are helpful about {{topic}}.",
+        name="subagent",
+    )
+
+    def run_agent(_agent: Any, state: InputState) -> OutputState:
+        return {"answer": state["topic"]}
+
+    graph = StateGraph(
+        GraphState,
+        input_schema=InputState,
+        output_schema=OutputState,
+    )
+    graph.add_node(
+        "call_agent",
+        partial(run_agent, wrapped_agent),
+        input_schema=InputState,
+    )
+    graph.add_edge(START, "call_agent")
+    graph.add_edge("call_agent", END)
+
+    flow = cast(
+        AgentSpecFlow,
+        agentspec_exporter.to_component(graph.compile(name="Wrapped Agent Flow")),
+    )
+    node = _find_node(flow, "call_agent")
+
+    assert isinstance(node, ToolNode)
+    assert not isinstance(node, AgentNode)
+    assert _property_titles(node.inputs) == ["topic"]
+    assert _property_titles(node.outputs) == ["answer"]
 
 
 def test_convert_graph_flow_falls_back_to_state_for_shared_state_dependency(

--- a/pyagentspec/tests/adapters/langgraph/test_langgraph_to_agentspec.py
+++ b/pyagentspec/tests/adapters/langgraph/test_langgraph_to_agentspec.py
@@ -5,7 +5,6 @@
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 
 
-import typing
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, TypeAlias, TypedDict, cast
 
@@ -15,7 +14,7 @@ from pydantic import BaseModel, SecretStr
 from pyagentspec.agent import Agent as AgentSpecAgent
 from pyagentspec.component import Component
 from pyagentspec.flows.flow import Flow as AgentSpecFlow
-from pyagentspec.flows.nodes import BranchingNode, FlowNode
+from pyagentspec.flows.nodes import BranchingNode, FlowNode, ToolNode
 from pyagentspec.llms import OpenAiCompatibleConfig
 
 from .conftest import get_weather
@@ -29,6 +28,55 @@ def agentspec_exporter() -> "AgentSpecExporter":
     from pyagentspec.adapters.langgraph import AgentSpecExporter
 
     return AgentSpecExporter()
+
+
+def _property_titles(properties: list[Any] | None) -> list[str]:
+    """Return the exported property titles in declaration order."""
+    return [property_.title for property_ in properties or []]
+
+
+def _data_edge_signatures(flow: AgentSpecFlow) -> set[tuple[str, str, str, str]]:
+    """Return a stable signature for each exported data edge."""
+    return {
+        (
+            edge.source_node.name,
+            edge.source_output,
+            edge.destination_node.name,
+            edge.destination_input,
+        )
+        for edge in flow.data_flow_connections or []
+    }
+
+
+def _find_node(flow: AgentSpecFlow, node_name: str) -> Any:
+    """Return the exported node with the given name."""
+    return next(node for node in flow.nodes if node.name == node_name)
+
+
+def _assert_state_wired_flow(flow: AgentSpecFlow) -> None:
+    """Assert that a flow falls back to opaque `state` wiring."""
+    assert _property_titles(flow.inputs) == ["state"]
+    assert _property_titles(flow.outputs) == ["state"]
+
+
+def _assert_state_wired_nodes(flow: AgentSpecFlow, *node_names: str) -> None:
+    """Assert that the named nodes expose only the opaque `state` interface."""
+    for node_name in node_names:
+        node = _find_node(flow, node_name)
+        assert _property_titles(node.inputs) == ["state"]
+        assert _property_titles(node.outputs) == ["state"]
+
+
+def _assert_state_wired_edges(
+    flow: AgentSpecFlow,
+    edge_pairs: set[tuple[str, str]],
+    extra_edges: set[tuple[str, str, str, str]] | None = None,
+) -> None:
+    """Assert the exported data edges for a state-wired flow."""
+    expected_edges = {(source, "state", destination, "state") for source, destination in edge_pairs}
+    if extra_edges is not None:
+        expected_edges.update(extra_edges)
+    assert _data_edge_signatures(flow) == expected_edges
 
 
 def test_convert_react_agent_with_tools_to_agentspec(
@@ -287,56 +335,177 @@ def test_convert_graph_flow_to_agentspec_multi_schemas(
     assert isinstance(flow, AgentSpecFlow)
     assert len(flow.nodes) == len(graph.nodes) + 2  # get_weather + llm_node + __start__ + __end__
     assert len(flow.control_flow_connections) == len(graph.edges)
-    assert flow.data_flow_connections and len(flow.data_flow_connections) == len(
-        graph.edges
-    )  # Not always true but for this case yes
     assert flow.name == assistant_name
-    # TODO: assert input and output properties of the various nodes
+    assert [property_.title for property_ in flow.inputs or []] == ["city"]
+    assert [property_.title for property_ in flow.outputs or []] == ["response"]
+
+    start_node = next(node for node in flow.nodes if node.name == "__start__")
+    end_node = next(node for node in flow.nodes if node.name == "__end__")
+    get_weather_node = next(node for node in flow.nodes if node.name == "get_weather")
+    llm_node = next(node for node in flow.nodes if node.name == "llm_node")
+
+    assert [property_.title for property_ in start_node.outputs or []] == ["city"]
+    assert [property_.title for property_ in end_node.inputs or []] == ["response"]
+    assert isinstance(get_weather_node, ToolNode)
+    assert [property_.title for property_ in get_weather_node.inputs or []] == ["city"]
+    assert [property_.title for property_ in get_weather_node.outputs or []] == ["weather_data"]
+    assert isinstance(llm_node, ToolNode)
+    assert [property_.title for property_ in llm_node.inputs or []] == ["weather_data"]
+    assert [property_.title for property_ in llm_node.outputs or []] == ["response"]
+
+    assert _data_edge_signatures(flow) == {
+        ("__start__", "city", "get_weather", "city"),
+        ("get_weather", "weather_data", "llm_node", "weather_data"),
+        ("llm_node", "response", "__end__", "response"),
+    }
+
+
+def test_convert_graph_flow_falls_back_to_state_for_shared_state_dependency(
+    agentspec_exporter: "AgentSpecExporter",
+) -> None:
+    from langgraph.graph import END, START, StateGraph
+
+    class OutputSchema(TypedDict):
+        response: str
+
+    class InputSchema(TypedDict):
+        city: str
+
+    class SharedState(TypedDict, total=False):
+        city: str
+        weather_data: str
+        response: str
+
+    class WeatherPatch(TypedDict):
+        weather_data: str
+
+    class FormatterInput(TypedDict):
+        city: str
+        weather_data: str
+
+    def patch_weather(state: InputSchema) -> WeatherPatch:
+        return {"weather_data": f"The weather in {state['city']} is sunny."}
+
+    def format_with_city(state: FormatterInput) -> OutputSchema:
+        return {"response": f"{state['city']}: {state['weather_data']}"}
+
+    shared_state_graph = StateGraph(
+        SharedState,
+        input_schema=InputSchema,
+        output_schema=OutputSchema,
+    )
+    shared_state_graph.add_node("get_weather", patch_weather)
+    shared_state_graph.add_node("format_weather", format_with_city)
+    shared_state_graph.add_edge(START, "get_weather")
+    shared_state_graph.add_edge("get_weather", "format_weather")
+    shared_state_graph.add_edge("format_weather", END)
+
+    shared_state_flow = cast(
+        AgentSpecFlow,
+        agentspec_exporter.to_component(shared_state_graph.compile(name="Shared State Flow")),
+    )
+    _assert_state_wired_flow(shared_state_flow)
+    _assert_state_wired_nodes(
+        shared_state_flow,
+        "__start__",
+        "get_weather",
+        "format_weather",
+        "__end__",
+    )
+    _assert_state_wired_edges(
+        shared_state_flow,
+        {
+            ("__start__", "get_weather"),
+            ("get_weather", "format_weather"),
+            ("format_weather", "__end__"),
+        },
+    )
 
 
 def test_convert_graph_with_subgraph_flow_to_agentspec(
     agentspec_exporter: "AgentSpecExporter",
 ) -> None:
-    from langgraph.graph import START, StateGraph
+    from langgraph.graph import END, START, StateGraph
 
-    class State(TypedDict):
+    class ParentState(TypedDict, total=False):
+        foo: str
+        bar: str
+
+    class ParentInput(TypedDict):
         foo: str
 
-    # Subgraph
+    class ParentOutput(TypedDict):
+        bar: str
 
-    def subgraph_node_1(state: State):
-        return {"foo": "hi! " + state["foo"]}
+    class SubgraphState(TypedDict, total=False):
+        foo: str
+        bar: str
 
-    subgraph_builder = StateGraph(State)
-    subgraph_builder.add_node(subgraph_node_1)
+    class SubgraphInput(TypedDict):
+        foo: str
+
+    class SubgraphOutput(TypedDict):
+        bar: str
+
+    def subgraph_node_1(state: SubgraphInput) -> SubgraphOutput:
+        return {"bar": "hi! " + state["foo"]}
+
+    # Keep both parent and subgraph field-addressable so this test covers nested subgraph export
+    # on the direct field-wiring path, not the separate opaque `state` fallback behavior.
+    subgraph_builder = StateGraph(
+        SubgraphState,
+        input_schema=SubgraphInput,
+        output_schema=SubgraphOutput,
+    )
+    subgraph_builder.add_node("subgraph_node_1", subgraph_node_1)
     subgraph_builder.add_edge(START, "subgraph_node_1")
+    subgraph_builder.add_edge("subgraph_node_1", END)
     subgraph = subgraph_builder.compile()
 
-    # Parent graph
-
-    builder = StateGraph(State)
+    builder = StateGraph(
+        ParentState,
+        input_schema=ParentInput,
+        output_schema=ParentOutput,
+    )
     builder.add_node("node_1", subgraph)
     builder.add_edge(START, "node_1")
+    builder.add_edge("node_1", END)
     assistant_name = "GraphWithSubgraph"
     compiled_graph = builder.compile(name=assistant_name)
     exporter = agentspec_exporter
-    flow = exporter.to_component(compiled_graph)
+    flow = cast(AgentSpecFlow, exporter.to_component(compiled_graph))
     assert isinstance(flow, AgentSpecFlow)
-    subflows = [node.subflow for node in flow.nodes if isinstance(node, FlowNode)]
-    assert len(subflows) == 1
-    subflow_nodes = [node for subflow in subflows for node in subflow.nodes]
-    subflow_control_flow_edges = [
-        edge for subflow in subflows for edge in subflow.control_flow_connections
-    ]
-
-    # __start__ + node_1 + __end__ + __start__ + subgraph_node1 + __end__
-    assert len(flow.nodes) + len(subflow_nodes) == len(compiled_graph.nodes) + 2 + 2
-    implicit_edges_to_end_nodes = 2
-    assert (
-        len(flow.control_flow_connections) + len(subflow_control_flow_edges)
-        == len(builder.edges) + len(subgraph_builder.edges) + implicit_edges_to_end_nodes
-    )
     assert flow.name == assistant_name
+    assert _property_titles(flow.inputs) == ["foo"]
+    assert _property_titles(flow.outputs) == ["bar"]
+
+    start_node = _find_node(flow, "__start__")
+    end_node = _find_node(flow, "__end__")
+    flow_node = _find_node(flow, "node_1")
+    assert isinstance(flow_node, FlowNode)
+    assert _property_titles(start_node.outputs) == ["foo"]
+    assert _property_titles(end_node.inputs) == ["bar"]
+    assert _property_titles(flow_node.inputs) == ["foo"]
+    assert _property_titles(flow_node.outputs) == ["bar"]
+    assert _data_edge_signatures(flow) == {
+        ("__start__", "foo", "node_1", "foo"),
+        ("node_1", "bar", "__end__", "bar"),
+    }
+
+    subflow = flow_node.subflow
+    assert _property_titles(subflow.inputs) == ["foo"]
+    assert _property_titles(subflow.outputs) == ["bar"]
+    subflow_start_node = _find_node(subflow, "__start__")
+    subflow_end_node = _find_node(subflow, "__end__")
+    subgraph_node = _find_node(subflow, "subgraph_node_1")
+    assert _property_titles(subflow_start_node.outputs) == ["foo"]
+    assert _property_titles(subflow_end_node.inputs) == ["bar"]
+    assert _property_titles(subgraph_node.inputs) == ["foo"]
+    assert _property_titles(subgraph_node.outputs) == ["bar"]
+    assert _data_edge_signatures(subflow) == {
+        ("__start__", "foo", "subgraph_node_1", "foo"),
+        ("subgraph_node_1", "bar", "__end__", "bar"),
+    }
 
 
 Conditionals: TypeAlias = Literal["lowercase", "uppercase", "messycase"]
@@ -372,25 +541,53 @@ def test_conditional_graph(agentspec_exporter: "AgentSpecExporter") -> None:
         return {"response": "The sentence you gave me is messy."}
 
     graph = StateGraph(InternalState, input_schema=InputSchema, output_schema=OutputSchema)
-    graph.add_node(lowercase)
-    graph.add_node(uppercase)
-    graph.add_node(messycase)
-    graph.add_conditional_edges(START, check_capitalized)
+    graph.add_node("lowercase_node", lowercase)
+    graph.add_node("uppercase_node", uppercase)
+    graph.add_node("messycase_node", messycase)
+    graph.add_conditional_edges(
+        START,
+        check_capitalized,
+        {
+            "lowercase": "lowercase_node",
+            "uppercase": "uppercase_node",
+            "messycase": "messycase_node",
+        },
+    )
 
     graph_name = "Casecheck Flow"
     flow = graph.compile(name=graph_name)
-    exporter = agentspec_exporter
-    agentspec_flow = cast(AgentSpecFlow, exporter.to_component(flow))
+    agentspec_flow = cast(AgentSpecFlow, agentspec_exporter.to_component(flow))
 
     branching_node = next(
         (node for node in agentspec_flow.nodes if isinstance(node, BranchingNode)), None
     )
-    langgraph_mapping = {v: v for v in {*typing.get_args(Conditionals)}}
+    branch_edges = {
+        (
+            edge.to_node.name,
+            edge.from_branch,
+        )
+        for edge in agentspec_flow.control_flow_connections
+        if edge.from_node is branching_node
+    }
 
     assert agentspec_flow.name == graph_name
     assert branching_node is not None
-    assert branching_node.mapping == langgraph_mapping
+    assert branching_node.mapping == {
+        "lowercase": "lowercase_node",
+        "uppercase": "uppercase_node",
+        "messycase": "messycase_node",
+    }
     assert set(branching_node.branches) == {
         BranchingNode.DEFAULT_BRANCH,
-        *typing.get_args(Conditionals),
+        "lowercase_node",
+        "uppercase_node",
+        "messycase_node",
+    }
+    # Compare `(destination node name, from_branch)` pairs. BranchingNode branches are the mapped
+    # target names in Agent Spec, so the non-default branch labels match their destination nodes.
+    assert branch_edges == {
+        ("lowercase_node", "lowercase_node"),
+        ("uppercase_node", "uppercase_node"),
+        ("messycase_node", "messycase_node"),
+        ("__end__", BranchingNode.DEFAULT_BRANCH),
     }

--- a/pyagentspec/tests/adapters/langgraph/test_langgraph_to_agentspec.py
+++ b/pyagentspec/tests/adapters/langgraph/test_langgraph_to_agentspec.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, SecretStr
 from pyagentspec.agent import Agent as AgentSpecAgent
 from pyagentspec.component import Component
 from pyagentspec.flows.flow import Flow as AgentSpecFlow
-from pyagentspec.flows.nodes import AgentNode, BranchingNode, FlowNode, ToolNode
+from pyagentspec.flows.nodes import AgentNode, BranchingNode, FlowNode, LlmNode, ToolNode
 from pyagentspec.llms import OpenAiCompatibleConfig
 
 from .conftest import get_weather
@@ -34,6 +34,11 @@ def agentspec_exporter() -> "AgentSpecExporter":
 def _property_titles(properties: list[Any] | None) -> list[str]:
     """Return the exported property titles in declaration order."""
     return [property_.title for property_ in properties or []]
+
+
+def _json_schema_property_titles(property_: Any) -> list[str]:
+    """Return the top-level field titles exposed by one exported property schema."""
+    return list((property_.json_schema.get("properties") or {}).keys())
 
 
 def _data_edge_signatures(flow: AgentSpecFlow) -> set[tuple[str, str, str, str]]:
@@ -447,153 +452,7 @@ def test_convert_graph_flow_wrapped_react_agent_node_to_agentspec_agent_node(
     }
 
 
-def test_convert_graph_flow_wrapped_react_agent_node_with_ainvoke_to_agentspec_agent_node(
-    agentspec_exporter: "AgentSpecExporter",
-) -> None:
-    from langchain.agents import create_agent
-    from langchain_openai.chat_models import ChatOpenAI
-    from langgraph.graph import END, START, StateGraph
-
-    class InputState(TypedDict):
-        topic: str
-
-    class OutputState(TypedDict):
-        answer: str
-
-    class GraphState(TypedDict, total=False):
-        topic: str
-        answer: str
-
-    class InternalState(TypedDict):
-        messages: list[dict[str, str]]
-        remaining_steps: int
-
-    wrapped_agent = create_agent(
-        model=ChatOpenAI(
-            base_url="http://example.invalid/v1",
-            model="openai/gpt-oss-test",
-            api_key=SecretStr("t"),
-        ),
-        tools=[],
-        state_schema=InternalState,
-        system_prompt="You are helpful about {{topic}}.",
-        name="subagent",
-    )
-
-    async def run_agent(_agent: Any, state: InputState) -> OutputState:
-        await _agent.ainvoke(
-            {
-                "messages": [
-                    {
-                        "role": "user",
-                        "content": state["topic"],
-                    }
-                ]
-            }
-        )
-        return {"answer": state["topic"]}
-
-    graph = StateGraph(
-        GraphState,
-        input_schema=InputState,
-        output_schema=OutputState,
-    )
-    graph.add_node(
-        "call_agent",
-        partial(run_agent, wrapped_agent),
-        input_schema=InputState,
-    )
-    graph.add_edge(START, "call_agent")
-    graph.add_edge("call_agent", END)
-
-    flow = cast(
-        AgentSpecFlow,
-        agentspec_exporter.to_component(graph.compile(name="Wrapped Async Agent Flow")),
-    )
-    agent_node = _find_node(flow, "call_agent")
-
-    assert isinstance(agent_node, AgentNode)
-    assert isinstance(agent_node.agent, AgentSpecAgent)
-    assert agent_node.agent.name == "subagent"
-    assert _property_titles(agent_node.inputs) == ["topic"]
-    assert _property_titles(agent_node.outputs) == ["answer"]
-
-
-def test_convert_graph_flow_wrapped_react_agent_node_with_keyword_bound_partial_to_agentspec_agent_node(
-    agentspec_exporter: "AgentSpecExporter",
-) -> None:
-    from langchain.agents import create_agent
-    from langchain_openai.chat_models import ChatOpenAI
-    from langgraph.graph import END, START, StateGraph
-
-    class InputState(TypedDict):
-        topic: str
-
-    class OutputState(TypedDict):
-        answer: str
-
-    class GraphState(TypedDict, total=False):
-        topic: str
-        answer: str
-
-    class InternalState(TypedDict):
-        messages: list[dict[str, str]]
-        remaining_steps: int
-
-    wrapped_agent = create_agent(
-        model=ChatOpenAI(
-            base_url="http://example.invalid/v1",
-            model="openai/gpt-oss-test",
-            api_key=SecretStr("t"),
-        ),
-        tools=[],
-        state_schema=InternalState,
-        system_prompt="You are helpful about {{topic}}.",
-        name="subagent",
-    )
-
-    def run_agent(state: InputState, _agent: Any) -> OutputState:
-        _agent.invoke(
-            {
-                "messages": [
-                    {
-                        "role": "user",
-                        "content": state["topic"],
-                    }
-                ]
-            }
-        )
-        return {"answer": state["topic"]}
-
-    graph = StateGraph(
-        GraphState,
-        input_schema=InputState,
-        output_schema=OutputState,
-    )
-    graph.add_node("call_agent", partial(run_agent, _agent=wrapped_agent))
-    graph.add_edge(START, "call_agent")
-    graph.add_edge("call_agent", END)
-
-    flow = cast(
-        AgentSpecFlow,
-        agentspec_exporter.to_component(graph.compile(name="Wrapped Agent Flow Keyword Partial")),
-    )
-    agent_node = _find_node(flow, "call_agent")
-
-    assert isinstance(agent_node, AgentNode)
-    assert isinstance(agent_node.agent, AgentSpecAgent)
-    assert agent_node.agent.name == "subagent"
-    assert _property_titles(agent_node.inputs) == ["topic"]
-    assert _property_titles(agent_node.outputs) == ["answer"]
-    assert _property_titles(agent_node.agent.inputs) == ["topic"]
-    assert _property_titles(agent_node.agent.outputs) == ["answer"]
-    assert _data_edge_signatures(flow) == {
-        ("__start__", "topic", "call_agent", "topic"),
-        ("call_agent", "answer", "__end__", "answer"),
-    }
-
-
-def test_convert_graph_flow_wrapped_react_agent_node_requires_matching_prompt_inputs(
+def test_convert_graph_flow_wrapped_react_agent_node_falls_back_to_tool_node_on_prompt_input_mismatch(
     agentspec_exporter: "AgentSpecExporter",
 ) -> None:
     from langchain.agents import create_agent
@@ -652,11 +511,93 @@ def test_convert_graph_flow_wrapped_react_agent_node_requires_matching_prompt_in
     graph.add_edge(START, "call_agent")
     graph.add_edge("call_agent", END)
 
-    with pytest.raises(
-        ValueError,
-        match=r"wrapper node inputs \['topic'\] do not match the wrapped agent prompt placeholders \[\]",
-    ):
-        agentspec_exporter.to_component(graph.compile(name="Wrapped Agent Flow"))
+    flow = cast(
+        AgentSpecFlow,
+        agentspec_exporter.to_component(graph.compile(name="Wrapped Agent Flow")),
+    )
+    node = _find_node(flow, "call_agent")
+
+    assert isinstance(node, ToolNode)
+    assert not isinstance(node, AgentNode)
+    assert _property_titles(node.inputs) == ["topic"]
+    assert _property_titles(node.outputs) == ["answer"]
+
+
+def test_convert_graph_flow_wrapped_react_agent_node_with_python_format_prompt_stays_tool_node(
+    agentspec_exporter: "AgentSpecExporter",
+) -> None:
+    from langchain.agents import create_agent
+    from langchain_openai.chat_models import ChatOpenAI
+    from langgraph.graph import END, START, StateGraph
+
+    class InputState(TypedDict):
+        topic: str
+
+    class OutputState(TypedDict):
+        answer: str
+
+    class GraphState(TypedDict, total=False):
+        topic: str
+        answer: str
+
+    class InternalState(TypedDict):
+        messages: list[dict[str, str]]
+        remaining_steps: int
+
+    wrapped_agent = create_agent(
+        model=ChatOpenAI(
+            base_url="http://example.invalid/v1",
+            model="openai/gpt-oss-test",
+            api_key=SecretStr("t"),
+        ),
+        tools=[],
+        state_schema=InternalState,
+        system_prompt="You are helpful about {topic}.",
+        name="subagent",
+    )
+
+    def run_agent(_agent: Any, state: InputState) -> OutputState:
+        _agent.invoke(
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": state["topic"],
+                    }
+                ]
+            }
+        )
+        return {"answer": state["topic"]}
+
+    graph = StateGraph(
+        GraphState,
+        input_schema=InputState,
+        output_schema=OutputState,
+    )
+    graph.add_node(
+        "call_agent",
+        partial(run_agent, wrapped_agent),
+        input_schema=InputState,
+    )
+    graph.add_edge(START, "call_agent")
+    graph.add_edge("call_agent", END)
+
+    flow = cast(
+        AgentSpecFlow,
+        agentspec_exporter.to_component(
+            graph.compile(name="Wrapped Agent Flow Python Format Prompt")
+        ),
+    )
+    node = _find_node(flow, "call_agent")
+
+    assert isinstance(node, ToolNode)
+    assert not isinstance(node, AgentNode)
+    assert _property_titles(node.inputs) == ["topic"]
+    assert _property_titles(node.outputs) == ["answer"]
+    assert _data_edge_signatures(flow) == {
+        ("__start__", "topic", "call_agent", "topic"),
+        ("call_agent", "answer", "__end__", "answer"),
+    }
 
 
 def test_convert_graph_flow_wrapped_react_agent_node_without_invoke_stays_tool_node(
@@ -720,6 +661,454 @@ def test_convert_graph_flow_wrapped_react_agent_node_without_invoke_stays_tool_n
     assert _property_titles(node.outputs) == ["answer"]
 
 
+def test_convert_graph_flow_wrapped_llm_node_to_agentspec_llm_node(
+    agentspec_exporter: "AgentSpecExporter",
+) -> None:
+    from langchain_openai.chat_models import ChatOpenAI
+    from langgraph.graph import END, START, StateGraph
+
+    from pyagentspec.adapters._utils import render_template
+
+    class InputState(TypedDict):
+        user_query: str
+
+    class OutputState(TypedDict):
+        semantic_request: str
+
+    class GraphState(TypedDict, total=False):
+        user_query: str
+        semantic_request: str
+
+    prompt = "Extract structured search parameters.\nQuery: {{user_query}}"
+    llm = ChatOpenAI(
+        model="openai/gpt-oss-test",
+        api_key=SecretStr("EMPTY"),
+        base_url="http://example.invalid/v1",
+        temperature=0.25,
+        max_tokens=123,
+    )
+
+    def run_llm(state: InputState, *, _llm: Any, _prompt: Any) -> OutputState:
+        rendered_prompt = render_template(_prompt, state)
+        _llm.invoke([("user", rendered_prompt)])
+        return {"semantic_request": state["user_query"]}
+
+    graph = StateGraph(
+        GraphState,
+        input_schema=InputState,
+        output_schema=OutputState,
+    )
+    graph.add_node(
+        "parse_query",
+        partial(run_llm, _llm=llm, _prompt=prompt),
+        input_schema=InputState,
+    )
+    graph.add_edge(START, "parse_query")
+    graph.add_edge("parse_query", END)
+
+    flow = cast(
+        AgentSpecFlow,
+        agentspec_exporter.to_component(graph.compile(name="Wrapped Llm Flow")),
+    )
+    llm_node = _find_node(flow, "parse_query")
+
+    assert isinstance(llm_node, LlmNode)
+    assert _property_titles(llm_node.inputs) == ["user_query"]
+    assert _property_titles(llm_node.outputs) == ["semantic_request"]
+    assert llm_node.prompt_template == (
+        "Extract structured search parameters.\nQuery: {{user_query}}"
+    )
+    assert isinstance(llm_node.llm_config, OpenAiCompatibleConfig)
+    assert llm_node.llm_config.model_id == "openai/gpt-oss-test"
+    assert llm_node.llm_config.url == "http://example.invalid/v1"
+    assert llm_node.llm_config.default_generation_parameters is not None
+    assert llm_node.llm_config.default_generation_parameters.temperature == 0.25
+    assert llm_node.llm_config.default_generation_parameters.max_tokens == 123
+    assert _data_edge_signatures(flow) == {
+        ("__start__", "user_query", "parse_query", "user_query"),
+        ("parse_query", "semantic_request", "__end__", "semantic_request"),
+    }
+
+
+def test_convert_graph_flow_wrapped_llm_node_with_python_format_prompt_stays_tool_node(
+    agentspec_exporter: "AgentSpecExporter",
+) -> None:
+    from langchain_openai.chat_models import ChatOpenAI
+    from langgraph.graph import END, START, StateGraph
+
+    class InputState(TypedDict):
+        user_query: str
+
+    class OutputState(TypedDict):
+        semantic_request: str
+
+    class GraphState(TypedDict, total=False):
+        user_query: str
+        semantic_request: str
+
+    prompt = "Extract structured search parameters.\nQuery: {user_query}"
+    llm = ChatOpenAI(
+        model="openai/gpt-oss-test",
+        api_key=SecretStr("EMPTY"),
+        base_url="http://example.invalid/v1",
+    )
+
+    def run_llm(state: InputState, *, _llm: Any, _prompt: Any) -> OutputState:
+        rendered_prompt = _prompt.format(user_query=state["user_query"])
+        _llm.invoke([("user", rendered_prompt)])
+        return {"semantic_request": state["user_query"]}
+
+    graph = StateGraph(
+        GraphState,
+        input_schema=InputState,
+        output_schema=OutputState,
+    )
+    graph.add_node(
+        "parse_query",
+        partial(run_llm, _llm=llm, _prompt=prompt),
+        input_schema=InputState,
+    )
+    graph.add_edge(START, "parse_query")
+    graph.add_edge("parse_query", END)
+
+    flow = cast(
+        AgentSpecFlow,
+        agentspec_exporter.to_component(
+            graph.compile(name="Wrapped Llm Flow Python Format Prompt")
+        ),
+    )
+    node = _find_node(flow, "parse_query")
+
+    assert isinstance(node, ToolNode)
+    assert not isinstance(node, LlmNode)
+    assert _property_titles(node.inputs) == ["user_query"]
+    assert _property_titles(node.outputs) == ["semantic_request"]
+    assert _data_edge_signatures(flow) == {
+        ("__start__", "user_query", "parse_query", "user_query"),
+        ("parse_query", "semantic_request", "__end__", "semantic_request"),
+    }
+
+
+def test_convert_graph_flow_wrapped_llm_node_without_invoke_stays_tool_node(
+    agentspec_exporter: "AgentSpecExporter",
+) -> None:
+    from langchain_openai.chat_models import ChatOpenAI
+    from langgraph.graph import END, START, StateGraph
+
+    class InputState(TypedDict):
+        user_query: str
+
+    class OutputState(TypedDict):
+        semantic_request: str
+
+    class GraphState(TypedDict, total=False):
+        user_query: str
+        semantic_request: str
+
+    prompt = "Extract structured search parameters.\nQuery: {user_query}"
+    llm = ChatOpenAI(
+        model="openai/gpt-oss-test",
+        api_key=SecretStr("EMPTY"),
+        base_url="http://example.invalid/v1",
+    )
+
+    def run_llm(state: InputState, *, _llm: Any, _prompt: Any) -> OutputState:
+        _ = _llm
+        _ = _prompt
+        return {"semantic_request": state["user_query"]}
+
+    graph = StateGraph(
+        GraphState,
+        input_schema=InputState,
+        output_schema=OutputState,
+    )
+    graph.add_node(
+        "parse_query",
+        partial(run_llm, _llm=llm, _prompt=prompt),
+        input_schema=InputState,
+    )
+    graph.add_edge(START, "parse_query")
+    graph.add_edge("parse_query", END)
+
+    flow = cast(
+        AgentSpecFlow,
+        agentspec_exporter.to_component(graph.compile(name="Wrapped Tool Flow No Invoke")),
+    )
+    node = _find_node(flow, "parse_query")
+
+    assert isinstance(node, ToolNode)
+    assert not isinstance(node, LlmNode)
+    assert _property_titles(node.inputs) == ["user_query"]
+    assert _property_titles(node.outputs) == ["semantic_request"]
+
+
+def test_convert_graph_flow_wrapped_llm_node_without_prompt_stays_tool_node(
+    agentspec_exporter: "AgentSpecExporter",
+) -> None:
+    from langchain_openai.chat_models import ChatOpenAI
+    from langgraph.graph import END, START, StateGraph
+
+    class InputState(TypedDict):
+        user_query: str
+
+    class OutputState(TypedDict):
+        semantic_request: str
+
+    class GraphState(TypedDict, total=False):
+        user_query: str
+        semantic_request: str
+
+    llm = ChatOpenAI(
+        model="openai/gpt-oss-test",
+        api_key=SecretStr("EMPTY"),
+        base_url="http://example.invalid/v1",
+    )
+
+    def run_llm(state: InputState, *, _llm: Any) -> OutputState:
+        _llm.invoke([("user", state["user_query"])])
+        return {"semantic_request": state["user_query"]}
+
+    graph = StateGraph(
+        GraphState,
+        input_schema=InputState,
+        output_schema=OutputState,
+    )
+    graph.add_node("parse_query", partial(run_llm, _llm=llm), input_schema=InputState)
+    graph.add_edge(START, "parse_query")
+    graph.add_edge("parse_query", END)
+
+    flow = cast(
+        AgentSpecFlow,
+        agentspec_exporter.to_component(graph.compile(name="Wrapped Tool Flow")),
+    )
+    node = _find_node(flow, "parse_query")
+
+    assert isinstance(node, ToolNode)
+    assert not isinstance(node, LlmNode)
+    assert _property_titles(node.inputs) == ["user_query"]
+    assert _property_titles(node.outputs) == ["semantic_request"]
+
+
+def test_convert_graph_flow_wrapped_llm_node_falls_back_to_tool_node_on_prompt_input_mismatch(
+    agentspec_exporter: "AgentSpecExporter",
+) -> None:
+    from langchain_openai.chat_models import ChatOpenAI
+    from langgraph.graph import END, START, StateGraph
+
+    from pyagentspec.adapters._utils import render_template
+
+    class InputState(TypedDict):
+        user_query: str
+
+    class OutputState(TypedDict):
+        semantic_request: str
+
+    class GraphState(TypedDict, total=False):
+        user_query: str
+        semantic_request: str
+
+    prompt = "Extract structured search parameters.\nQuery: {{topic}}"
+    llm = ChatOpenAI(
+        model="openai/gpt-oss-test",
+        api_key=SecretStr("EMPTY"),
+        base_url="http://example.invalid/v1",
+    )
+
+    def run_llm(state: InputState, *, _llm: Any, _prompt: Any) -> OutputState:
+        rendered_prompt = render_template(_prompt, {"topic": state["user_query"]})
+        _llm.invoke([("user", rendered_prompt)])
+        return {"semantic_request": state["user_query"]}
+
+    graph = StateGraph(
+        GraphState,
+        input_schema=InputState,
+        output_schema=OutputState,
+    )
+    graph.add_node(
+        "parse_query",
+        partial(run_llm, _llm=llm, _prompt=prompt),
+        input_schema=InputState,
+    )
+    graph.add_edge(START, "parse_query")
+    graph.add_edge("parse_query", END)
+
+    flow = cast(
+        AgentSpecFlow,
+        agentspec_exporter.to_component(graph.compile(name="Wrapped Llm Flow")),
+    )
+    node = _find_node(flow, "parse_query")
+
+    assert isinstance(node, ToolNode)
+    assert not isinstance(node, LlmNode)
+    assert _property_titles(node.inputs) == ["user_query"]
+    assert _property_titles(node.outputs) == ["semantic_request"]
+
+
+def test_convert_graph_flow_wrapped_llm_node_supports_static_prompt_without_inputs(
+    agentspec_exporter: "AgentSpecExporter",
+) -> None:
+    from langchain_openai.chat_models import ChatOpenAI
+    from langgraph.graph import END, START, StateGraph
+
+    class GraphState(TypedDict, total=False):
+        generated_text: str
+
+    class OutputState(TypedDict):
+        generated_text: str
+
+    prompt = "Write a haiku about exports.\nRespond with just the poem."
+    llm = ChatOpenAI(
+        model="openai/gpt-oss-test",
+        api_key=SecretStr("EMPTY"),
+        base_url="http://example.invalid/v1",
+    )
+
+    def run_llm(state: dict[str, Any], *, _llm: Any, _prompt: Any) -> dict[str, str]:
+        _ = state
+        rendered_prompt = _prompt.format()
+        _llm.invoke([("user", rendered_prompt)])
+        return {"generated_text": "poem"}
+
+    graph = StateGraph(
+        GraphState,
+        output_schema=OutputState,
+    )
+    graph.add_node("parse_query", partial(run_llm, _llm=llm, _prompt=prompt))
+    graph.add_edge(START, "parse_query")
+    graph.add_edge("parse_query", END)
+
+    flow = cast(
+        AgentSpecFlow,
+        agentspec_exporter.to_component(graph.compile(name="Wrapped Llm Flow Static Prompt")),
+    )
+    llm_node = _find_node(flow, "parse_query")
+
+    assert isinstance(llm_node, LlmNode)
+    assert _property_titles(llm_node.inputs) == []
+    assert _property_titles(llm_node.outputs) == ["generated_text"]
+    assert llm_node.prompt_template == "Write a haiku about exports.\nRespond with just the poem."
+    assert _data_edge_signatures(flow) == {
+        ("parse_query", "generated_text", "__end__", "generated_text"),
+    }
+
+
+def test_convert_graph_flow_wrapped_llm_node_defaults_unstructured_output_name(
+    agentspec_exporter: "AgentSpecExporter",
+) -> None:
+    from langchain_openai.chat_models import ChatOpenAI
+    from langgraph.graph import END, START, StateGraph
+
+    from pyagentspec.adapters._utils import render_template
+
+    class InputState(TypedDict):
+        user_query: str
+
+    class GraphState(TypedDict, total=False):
+        user_query: str
+        generated_text: str
+
+    class OutputState(TypedDict):
+        generated_text: str
+
+    prompt = "Extract structured search parameters.\nQuery: {{user_query}}"
+    llm = ChatOpenAI(
+        model="openai/gpt-oss-test",
+        api_key=SecretStr("EMPTY"),
+        base_url="http://example.invalid/v1",
+    )
+
+    def run_llm(state: InputState, *, _llm: Any, _prompt: Any) -> dict[str, str]:
+        rendered_prompt = render_template(_prompt, state)
+        _llm.invoke([("user", rendered_prompt)])
+        return {"generated_text": state["user_query"]}
+
+    graph = StateGraph(
+        GraphState,
+        input_schema=InputState,
+        output_schema=OutputState,
+    )
+    graph.add_node(
+        "parse_query",
+        partial(run_llm, _llm=llm, _prompt=prompt),
+        input_schema=InputState,
+    )
+    graph.add_edge(START, "parse_query")
+    graph.add_edge("parse_query", END)
+
+    flow = cast(
+        AgentSpecFlow,
+        agentspec_exporter.to_component(graph.compile(name="Wrapped Llm Flow Default Output")),
+    )
+    llm_node = _find_node(flow, "parse_query")
+
+    assert isinstance(llm_node, LlmNode)
+    assert _property_titles(llm_node.inputs) == ["user_query"]
+    assert _property_titles(llm_node.outputs) == ["generated_text"]
+    assert _data_edge_signatures(flow) == {
+        ("__start__", "user_query", "parse_query", "user_query"),
+        ("parse_query", "generated_text", "__end__", "generated_text"),
+    }
+
+
+def test_convert_graph_flow_wrapped_llm_node_with_chat_prompt_template_stays_tool_node(
+    agentspec_exporter: "AgentSpecExporter",
+) -> None:
+    from langchain_core.prompts import ChatPromptTemplate
+    from langchain_openai.chat_models import ChatOpenAI
+    from langgraph.graph import END, START, StateGraph
+
+    class InputState(TypedDict):
+        user_query: str
+
+    class OutputState(TypedDict):
+        semantic_request: str
+
+    class GraphState(TypedDict, total=False):
+        user_query: str
+        semantic_request: str
+
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            ("system", "Extract structured search parameters."),
+            ("human", "Query: {user_query}"),
+        ]
+    )
+    llm = ChatOpenAI(
+        model="openai/gpt-oss-test",
+        api_key=SecretStr("EMPTY"),
+        base_url="http://example.invalid/v1",
+    )
+
+    def run_llm(state: InputState, *, _llm: Any, _prompt: Any) -> OutputState:
+        messages = _prompt.format_messages(user_query=state["user_query"])
+        _llm.invoke(messages)
+        return {"semantic_request": state["user_query"]}
+
+    graph = StateGraph(
+        GraphState,
+        input_schema=InputState,
+        output_schema=OutputState,
+    )
+    graph.add_node(
+        "parse_query",
+        partial(run_llm, _llm=llm, _prompt=prompt),
+        input_schema=InputState,
+    )
+    graph.add_edge(START, "parse_query")
+    graph.add_edge("parse_query", END)
+
+    flow = cast(
+        AgentSpecFlow,
+        agentspec_exporter.to_component(graph.compile(name="Wrapped Tool Flow Chat Prompt")),
+    )
+    node = _find_node(flow, "parse_query")
+
+    assert isinstance(node, ToolNode)
+    assert not isinstance(node, LlmNode)
+    assert _property_titles(node.inputs) == ["user_query"]
+    assert _property_titles(node.outputs) == ["semantic_request"]
+
+
 def test_convert_graph_flow_falls_back_to_state_for_shared_state_dependency(
     agentspec_exporter: "AgentSpecExporter",
 ) -> None:
@@ -765,6 +1154,10 @@ def test_convert_graph_flow_falls_back_to_state_for_shared_state_dependency(
         agentspec_exporter.to_component(shared_state_graph.compile(name="Shared State Flow")),
     )
     _assert_state_wired_flow(shared_state_flow)
+    assert shared_state_flow.inputs is not None
+    assert shared_state_flow.outputs is not None
+    assert _json_schema_property_titles(shared_state_flow.inputs[0]) == ["city"]
+    assert _json_schema_property_titles(shared_state_flow.outputs[0]) == ["response"]
     _assert_state_wired_nodes(
         shared_state_flow,
         "__start__",
@@ -772,6 +1165,12 @@ def test_convert_graph_flow_falls_back_to_state_for_shared_state_dependency(
         "format_weather",
         "__end__",
     )
+    start_node = _find_node(shared_state_flow, "__start__")
+    end_node = _find_node(shared_state_flow, "__end__")
+    assert start_node.outputs is not None
+    assert end_node.inputs is not None
+    assert _json_schema_property_titles(start_node.outputs[0]) == ["city"]
+    assert _json_schema_property_titles(end_node.inputs[0]) == ["response"]
     _assert_state_wired_edges(
         shared_state_flow,
         {


### PR DESCRIPTION
## Summary
- refactor LangGraph flow export around explicit node-kind dispatch
- preserve node I/O inference and whole-flow fallback to state wiring when exact field wiring is not representable
- tighten conditional, subflow, and node-I/O export coverage

## Out of scope
- no broader partial-wrapped callable support beyond annotation recovery for node I/O inference

## Testing
- pytest -q pyagentspec/tests/adapters/langgraph/test_langgraph_to_agentspec.py -q
- pytest -q pyagentspec/tests/adapters/langgraph -q