### PR TITLE
feat: add max character trigger to summarization transform

### DIFF
--- a/docs/pyagentspec/source/agentspec/json_spec/agentspec_json_spec_26_2_0.json
+++ b/docs/pyagentspec/source/agentspec/json_spec/agentspec_json_spec_26_2_0.json
@@ -2398,7 +2398,7 @@
     },
     "BaseConversationSummarizationTransform": {
       "additionalProperties": false,
-      "description": "Summarizes conversations exceeding a given number of messages using an LLM and caches conversation summaries in a ``Datastore``.\n\nThis is useful to reduce long conversation history into a concise context for downstream LLM calls.\n\nExamples\n--------\n>>> from pyagentspec.transforms import ConversationSummarizationTransform\n>>> summarization_transform = ConversationSummarizationTransform(\n...     name=\"conversation-summarizer\",\n...     llm=llm_config,\n...     max_num_messages=30,\n...     min_num_messages=10\n... )",
+      "description": "Summarizes conversations exceeding a configured size threshold using an LLM and caches\nconversation summaries in a ``Datastore``.\n\nThis is useful to reduce long conversation history into a concise context for downstream LLM calls.\n\nExamples\n--------\n>>> from pyagentspec.transforms import ConversationSummarizationTransform\n>>> summarization_transform = ConversationSummarizationTransform(\n...     name=\"conversation-summarizer\",\n...     llm=llm_config,\n...     max_num_messages=30,\n...     min_num_messages=10\n... )",
       "properties": {
         "id": {
           "title": "Id",
@@ -2436,12 +2436,34 @@
           "$ref": "#/$defs/LlmConfig"
         },
         "max_num_messages": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
           "default": 50,
-          "title": "Max Num Messages",
-          "type": "integer"
+          "title": "Max Num Messages"
+        },
+        "max_num_characters": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Num Characters"
         },
         "min_num_messages": {
           "default": 10,
+          "exclusiveMinimum": 0,
           "title": "Min Num Messages",
           "type": "integer"
         },
@@ -2458,6 +2480,7 @@
         "max_cache_size": {
           "anyOf": [
             {
+              "exclusiveMinimum": 0,
               "type": "integer"
             },
             {
@@ -2470,6 +2493,7 @@
         "max_cache_lifetime": {
           "anyOf": [
             {
+              "exclusiveMinimum": 0,
               "type": "integer"
             },
             {

--- a/docs/pyagentspec/source/agentspec/language_spec_nightly.rst
+++ b/docs/pyagentspec/source/agentspec/language_spec_nightly.rst
@@ -2277,8 +2277,9 @@ Summarizes conversations exceeding a given number of messages using an LLM and c
 
     class ConversationSummarizationTransform(MessageTransform):
         llm: LlmConfig  # LLM to use for the summarization.
-        max_num_messages: int  # Number of message after which we trigger summarization.
-        min_num_messages: int  # Number of recent messages to keep from summarizing.
+        max_num_messages: Optional[int]  # Conversation-level message-count threshold. Mutually exclusive with ``max_num_characters``.
+        max_num_characters: Optional[int]  # Total number of characters in the conversation after which we trigger summarization. Can be used together with ``min_num_messages``, but not with ``max_num_messages``.
+        min_num_messages: int  # Number of recent messages to keep from summarizing, regardless of whether summarization is triggered by ``max_num_messages`` or ``max_num_characters``.
         summarization_instructions: str  # Instruction for the LLM on how to summarize the conversation.
         summarized_conversation_template: str  # Jinja2 template on how to present the summary (with variable ``summary``) to the agent using the transform.
         datastore: Optional[Datastore]  # Datastore on which to store the cache. If None, no caching happens.

--- a/docs/pyagentspec/source/code_examples/howto_summarization_transforms.py
+++ b/docs/pyagentspec/source/code_examples/howto_summarization_transforms.py
@@ -39,6 +39,19 @@ conversation_summarizer = ConversationSummarizationTransform(
 )
 # .. end-transforms
 
+# .. start-conversation-character-threshold
+conversation_summarizer_by_characters = ConversationSummarizationTransform(
+    id="conversation_summarizer_by_characters",
+    name="conversation_summarizer_by_characters",
+    llm=llm_config,
+    max_num_messages=None,  # Explicitly disable the message-count threshold
+    max_num_characters=20_000,  # Summarize once the total conversation size gets too large in characters
+    min_num_messages=10,  # Still keep the latest 10 messages unsummarized
+    summarization_instructions="Summarize this conversation thread once its character footprint grows too large.",
+    summarized_conversation_template="Conversation summary: {{summary}}",
+)
+# .. end-conversation-character-threshold
+
 # .. start-agent-with-transforms
 from pyagentspec.agent import Agent
 

--- a/docs/pyagentspec/source/conf.py
+++ b/docs/pyagentspec/source/conf.py
@@ -221,6 +221,9 @@ nitpick_ignore_regex = [
     ("py:class", r"pyagentspec.serialization.serializationcontext.FieldInfoTypeT"),
     ("py:class", r"pyagentspec.serialization.serializationcontext.T"),
     ("py:class", r"pyagentspec.property._empty_default"),
+    # Internal typing aliases/typevars used in Component signatures are not public API targets
+    ("py:class", r"ComponentAsDictT|DisaggregatedComponentsAsDictT|DisaggregatedComponentsConfigT"),
+    ("py:class", r"ComponentT|pyagentspec\.component\.ComponentT"),
     # Private adapter internals used in type annotations and inheritance docs
     ("py:.*", r"pyagentspec\.adapters\._agentspecexporter\..*"),
     ("py:.*", r"pyagentspec\.adapters\._agentspecloader\..*"),

--- a/docs/pyagentspec/source/howtoguides/howto_summarization_transforms.rst
+++ b/docs/pyagentspec/source/howtoguides/howto_summarization_transforms.rst
@@ -18,7 +18,7 @@ Agent Spec supports **Summarization Transforms** that help manage long conversat
 There are two types of summarization transforms:
 
 - :ref:`MessageSummarizationTransform <messagesummarizationtransform>`: Summarizes individual messages that exceed a specified character limit
-- :ref:`ConversationSummarizationTransform <conversationsummarizationtransform>`: Summarizes conversation history when the total number of messages exceeds a threshold
+- :ref:`ConversationSummarizationTransform <conversationsummarizationtransform>`: Summarizes conversation history when the total number of messages or total number of characters exceeds a threshold
 
 .. note::
     By default, summarization transforms use an in-memory datastore for caching summarized content. You can specify your own datastore by providing a ``Datastore`` parameter. For information on how to configure different types of datastores such as :ref:`Oracle <oracledatabasedatastore>` or :ref:`PostgreSQL <postgresdatabasedatastore>`, see :doc:`How to Use Datastores <howto_datastores>`.
@@ -57,6 +57,16 @@ In this section, we will create both transforms with appropriate thresholds and 
     :end-before: .. end-transforms
 
 API Reference: :ref:`MessageSummarizationTransform <messagesummarizationtransform>`, :ref:`ConversationSummarizationTransform <conversationsummarizationtransform>`
+
+If you prefer a character-based threshold for conversations, set ``max_num_messages=None``
+explicitly and use ``max_num_characters`` instead. ``max_num_characters`` measures the total
+number of characters in the conversation, can still be combined with ``min_num_messages`` to keep
+the latest messages unsummarized, and cannot be used at the same time as ``max_num_messages``:
+
+.. literalinclude:: ../code_examples/howto_summarization_transforms.py
+    :language: python
+    :start-after: .. start-conversation-character-threshold
+    :end-before: .. end-conversation-character-threshold
 
 
 3. Use transforms in agents

--- a/pyagentspec/src/pyagentspec/transforms/summarization.py
+++ b/pyagentspec/src/pyagentspec/transforms/summarization.py
@@ -7,7 +7,7 @@
 
 from typing import ClassVar, Optional, Union
 
-from pydantic import Field, ValidationInfo, field_validator
+from pydantic import Field, ValidationInfo, field_validator, model_validator
 
 from pyagentspec.datastores.datastore import Entity, InMemoryCollectionDatastore
 from pyagentspec.datastores.oracle import OracleDatabaseDatastore
@@ -175,7 +175,8 @@ class MessageSummarizationTransform(MessageTransform):
 
 class ConversationSummarizationTransform(MessageTransform):
     """
-    Summarizes conversations exceeding a given number of messages using an LLM and caches conversation summaries in a ``Datastore``.
+    Summarizes conversations exceeding a configured size threshold using an LLM and caches
+    conversation summaries in a ``Datastore``.
 
     This is useful to reduce long conversation history into a concise context for downstream LLM calls.
 
@@ -196,19 +197,31 @@ class ConversationSummarizationTransform(MessageTransform):
     llm: LlmConfig
     """LLM configuration for conversation summarization."""
 
-    max_num_messages: int = 50
+    max_num_messages: Optional[int] = Field(default=50, gt=0)
     """Maximum number of messages before triggering summarization.
 
     When the conversation exceeds this number of messages, the older messages will be summarized,
-    except the most recent ``min_num_messages`` ones who are kept unsummarized.
+    except the most recent ``min_num_messages`` ones who are kept unsummarized. Set this to
+    ``None`` when using ``max_num_characters`` instead. This threshold is mutually exclusive with
+    ``max_num_characters``.
     """
 
-    min_num_messages: int = 10
+    max_num_characters: Optional[int] = Field(default=None, gt=0)
+    """Maximum total number of characters in the conversation before triggering summarization.
+
+    This is a conversation-level threshold, not a per-message threshold. It can be used together
+    with ``min_num_messages`` to keep the most recent messages unsummarized, but it is mutually
+    exclusive with ``max_num_messages``. To use a character-based threshold, set
+    ``max_num_messages=None`` explicitly.
+    """
+
+    min_num_messages: int = Field(default=10, gt=0)
     """Minimum number of recent messages to keep unsummarized.
 
     For example, if ``min_num_messages`` is 10 and ``max_num_messages`` is 50, then with a conversation
     of 20 messages, the conversation will not be summarized, but if the conversation has 51 messages,
     the last 10 won't be summarized, the 41 others will (in one or more summarization messages).
+    The same rule applies when ``max_num_characters`` is used instead of ``max_num_messages``.
     """
 
     summarization_instructions: str = (
@@ -220,10 +233,10 @@ class ConversationSummarizationTransform(MessageTransform):
     summarized_conversation_template: str = "Summarized conversation: {{summary}}"
     """Template for formatting the summarized conversation output."""
 
-    max_cache_size: Optional[int] = 10_000
+    max_cache_size: Optional[int] = Field(default=10_000, gt=0)
     """Maximum number of cache entries to keep."""
 
-    max_cache_lifetime: Optional[int] = 4 * 3600
+    max_cache_lifetime: Optional[int] = Field(default=4 * 3600, gt=0)
     """Maximum lifetime of cache entries in seconds."""
 
     cache_collection_name: str = DEFAULT_COLLECTION_NAME
@@ -248,41 +261,19 @@ class ConversationSummarizationTransform(MessageTransform):
             }
         )
 
-    @field_validator("max_num_messages", mode="before")
-    @classmethod
-    def _validate_max_num_messages(cls, value: int) -> int:
-        if value <= 0:
-            raise ValueError("max_num_messages must be greater than 0")
-        return value
-
-    @field_validator("min_num_messages", mode="before")
-    @classmethod
-    def _validate_min_num_messages(cls, value: int) -> int:
-        if value <= 0:
-            raise ValueError("min_num_messages must be greater than 0")
-        return value
-
-    @field_validator("max_cache_size", mode="before")
-    @classmethod
-    def _validate_max_cache_size(cls, value: Optional[int]) -> Optional[int]:
-        if value is not None and value <= 0:
-            raise ValueError("max_cache_size must be greater than 0")
-        return value
-
-    @field_validator("max_cache_lifetime", mode="before")
-    @classmethod
-    def _validate_max_cache_lifetime(cls, value: Optional[int]) -> Optional[int]:
-        if value is not None and value <= 0:
-            raise ValueError("max_cache_lifetime must be greater than 0")
-        return value
-
-    @field_validator("max_num_messages", mode="after")
-    @classmethod
-    def _validate_max_greater_than_min(cls, value: int, info: ValidationInfo) -> int:
-        min_num_messages = info.data.get("min_num_messages")
-        if min_num_messages is not None and value <= min_num_messages:
+    @model_validator(mode="after")
+    def _validate_conversation_thresholds(self) -> "ConversationSummarizationTransform":
+        if self.max_num_messages is not None and self.max_num_characters is not None:
+            raise ValueError("max_num_messages and max_num_characters cannot both be provided")
+        if self.max_num_messages is None and self.max_num_characters is None:
+            raise ValueError("One of max_num_messages or max_num_characters must be provided")
+        if (
+            self.max_num_messages is not None
+            and self.min_num_messages is not None
+            and self.max_num_messages <= self.min_num_messages
+        ):
             raise ValueError("max_num_messages must be greater than min_num_messages")
-        return value
+        return self
 
     @field_validator("datastore", mode="after")
     @classmethod

--- a/pyagentspec/tests/conftest.py
+++ b/pyagentspec/tests/conftest.py
@@ -179,9 +179,11 @@ def get_directory_allowlist_read(tmp_path: str, session_tmp_path: str) -> List[U
         # Crew AI sometimes attempts to read in some folders, we need to take that into account
         from crewai.cli.shared.token_manager import TokenManager
 
-        crewai_read_dirs = [
-            TokenManager.get_secure_storage_path(),
-        ]
+        # crewai may have either method depending on the version
+        crewai_read_dirs_method = getattr(TokenManager, "get_secure_storage_path", None) or getattr(
+            TokenManager, "_get_secure_storage_path"
+        )
+        crewai_read_dirs = [crewai_read_dirs_method()]
     except ImportError:
         crewai_read_dirs = []
     return (

--- a/pyagentspec/tests/serialization/transforms/conftest.py
+++ b/pyagentspec/tests/serialization/transforms/conftest.py
@@ -59,6 +59,25 @@ def create_conversation_summarization_transform(datastore):
     )
 
 
+def create_conversation_summarization_transform_with_character_limit(datastore):
+    return ConversationSummarizationTransform(
+        id="test_conv_summarizer_by_characters",
+        name="test_conversation_summarizer_by_characters",
+        llm=create_test_llm_config(),
+        max_num_messages=None,
+        max_num_characters=20_000,
+        min_num_messages=25,
+        summarization_instructions=(
+            "Summarize this conversation once the accumulated character count gets too large."
+        ),
+        summarized_conversation_template="Character-based conversation summary: {{summary}}",
+        datastore=datastore,
+        max_cache_size=5_000,
+        max_cache_lifetime=12 * 3600,
+        cache_collection_name=TESTING_CONVERSATIONS_COLLECTION,
+    )
+
+
 def parametrize_transform_and_datastore(f):
     f = pytest.mark.parametrize(
         "datastore, sensitive_fields",
@@ -69,6 +88,7 @@ def parametrize_transform_and_datastore(f):
         [
             create_message_summarization_transform,
             create_conversation_summarization_transform,
+            create_conversation_summarization_transform_with_character_limit,
         ],
     )(f)
     return f

--- a/pyagentspec/tests/serialization/transforms/test_summarization_transforms.py
+++ b/pyagentspec/tests/serialization/transforms/test_summarization_transforms.py
@@ -6,6 +6,7 @@
 
 
 import pytest
+from pydantic import ValidationError
 
 from pyagentspec.datastores.datastore import InMemoryCollectionDatastore
 from pyagentspec.property import ObjectProperty, StringProperty
@@ -94,3 +95,46 @@ def test_transforms_with_incorrect_schema_raises(transform_cls):
     )
     with pytest.raises(ValueError):
         transform_cls(id="test", name="test", llm=create_test_llm_config(), datastore=datastore)
+
+
+def test_conversation_summarization_transform_requires_explicit_message_threshold_disable():
+    with pytest.raises(
+        ValueError, match="max_num_messages and max_num_characters cannot both be provided"
+    ):
+        ConversationSummarizationTransform(
+            id="test",
+            name="test",
+            llm=create_test_llm_config(),
+            max_num_characters=20_000,
+        )
+
+
+def test_conversation_summarization_transform_requires_one_threshold():
+    with pytest.raises(
+        ValueError, match="One of max_num_messages or max_num_characters must be provided"
+    ):
+        ConversationSummarizationTransform(
+            id="test",
+            name="test",
+            llm=create_test_llm_config(),
+            max_num_messages=None,
+            max_num_characters=None,
+        )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"max_num_messages": 0},
+        {"max_num_messages": None, "max_num_characters": 0},
+        {"min_num_messages": 0},
+    ],
+)
+def test_conversation_summarization_transform_positive_threshold_constraints(kwargs):
+    with pytest.raises(ValidationError):
+        ConversationSummarizationTransform(
+            id="test",
+            name="test",
+            llm=create_test_llm_config(),
+            **kwargs,
+        )


### PR DESCRIPTION
This PR introduces a new `max_num_characters` parameter to `ConversationSummarizationTransform` as a new way to trigger conversation summarization.