### PR TITLE
Use langchain tool inputs parameter in LangGraph tracing

### DIFF
--- a/docs/pyagentspec/source/changelog.rst
+++ b/docs/pyagentspec/source/changelog.rst
@@ -7,6 +7,11 @@ Agent Spec |release|
 Improvements
 ^^^^^^^^^^^^
 
+* **More reliable tool payload tracing in LangGraph adapter**
+
+  The LangGraph adapter now normalizes tool callback inputs before emitting tracing events,
+  preserving structured tool execution payloads more reliably in traced agents and flows.
+
 * **New xAI model provider for OciGenAiConfig**
 
   Introduced a new provider `XAI` for ``OciGenAiConfig`` LLMs.

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/tracing.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/tracing.py
@@ -571,6 +571,7 @@ class AgentSpecToolCallbackHandler(AgentSpecCallbackHandler):
         request_event = AgentSpecToolExecutionRequest(
             request_id=run_id_str,
             tool=self.tool,
+            # LangChain should provide structured `inputs` in the `kwargs`, the others are fallback options
             inputs=_normalize_tool_inputs(self.tool, input_str, kwargs.get("inputs")),
         )
         # starting a tool span for this tool
@@ -667,6 +668,7 @@ class AgentSpecToolCallbackHandler(AgentSpecCallbackHandler):
         request_event = AgentSpecToolExecutionRequest(
             request_id=run_id_str,
             tool=self.tool,
+            # LangChain should provide structured `inputs` in the `kwargs`, the others are fallback options
             inputs=_normalize_tool_inputs(self.tool, input_str, kwargs.get("inputs")),
         )
         # starting a tool span for this tool

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/tracing.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/tracing.py
@@ -4,7 +4,6 @@
 # (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 
-import ast
 import json
 import logging
 import typing
@@ -74,6 +73,26 @@ LANGCHAIN_ROLES_TO_OPENAI_ROLES = {
 T = TypeVar("T")
 
 logger = logging.getLogger(__file__)
+
+
+def _normalize_tool_inputs(
+    tool: AgentSpecTool, input_value: Any, callback_inputs: Any
+) -> Dict[str, Any]:
+    """Normalize LangChain callback tool inputs into the mapping expected by trace events."""
+    if isinstance(callback_inputs, dict):
+        return callback_inputs
+
+    if isinstance(input_value, dict):
+        return input_value
+
+    if tool.inputs and len(tool.inputs) == 1:
+        return {tool.inputs[0].title: input_value}
+
+    if isinstance(input_value, str):
+        return {"value": input_value}
+
+    return {"value": str(input_value)}
+
 
 # NOTE ABOUT CONTEXTVARS AND THE ACTIVE SPAN STACK
 #
@@ -552,7 +571,7 @@ class AgentSpecToolCallbackHandler(AgentSpecCallbackHandler):
         request_event = AgentSpecToolExecutionRequest(
             request_id=run_id_str,
             tool=self.tool,
-            inputs=ast.literal_eval(input_str) if isinstance(input_str, str) else input_str,
+            inputs=_normalize_tool_inputs(self.tool, input_str, kwargs.get("inputs")),
         )
         # starting a tool span for this tool
         span_name = f"ToolExecution[{self.tool.name}]"
@@ -648,7 +667,7 @@ class AgentSpecToolCallbackHandler(AgentSpecCallbackHandler):
         request_event = AgentSpecToolExecutionRequest(
             request_id=run_id_str,
             tool=self.tool,
-            inputs=ast.literal_eval(input_str) if isinstance(input_str, str) else input_str,
+            inputs=_normalize_tool_inputs(self.tool, input_str, kwargs.get("inputs")),
         )
         # starting a tool span for this tool
         span_name = f"ToolExecution[{self.tool.name}]"

--- a/pyagentspec/tests/adapters/langgraph/test_tracing.py
+++ b/pyagentspec/tests/adapters/langgraph/test_tracing.py
@@ -336,3 +336,79 @@ def test_langgraph_agent_emits_tool_calls_and_results_with_consistent_ids(json_s
     assert executed_tool_call_ids
 
     # TODO: Add robust event id matching asserts
+
+
+def test_langgraph_flow_tracing_collects_tool_inputs() -> None:
+    from pyagentspec.adapters.langgraph import AgentSpecLoader
+    from pyagentspec.flows.edges import ControlFlowEdge, DataFlowEdge
+    from pyagentspec.flows.flow import Flow
+    from pyagentspec.flows.nodes import EndNode, StartNode, ToolNode
+    from pyagentspec.property import ObjectProperty, StringProperty
+    from pyagentspec.tools import ServerTool
+
+    city_property = StringProperty(title="city")
+    forecast_property = ObjectProperty(
+        title="forecast",
+        properties={
+            "city": StringProperty(title="city"),
+            "condition": StringProperty(title="condition"),
+        },
+    )
+    weather_tool = ServerTool(
+        name="get_weather",
+        description="Retrieves the weather in a city",
+        inputs=[city_property],
+        outputs=[forecast_property],
+    )
+
+    start_node = StartNode(name="start", inputs=[city_property])
+    tool_node = ToolNode(name="tool", tool=weather_tool)
+    end_node = EndNode(name="end", outputs=[forecast_property])
+
+    flow = Flow(
+        name="weather_flow",
+        start_node=start_node,
+        nodes=[start_node, tool_node, end_node],
+        control_flow_connections=[
+            ControlFlowEdge(name="start_to_tool", from_node=start_node, to_node=tool_node),
+            ControlFlowEdge(name="tool_to_end", from_node=tool_node, to_node=end_node),
+        ],
+        data_flow_connections=[
+            DataFlowEdge(
+                name="city_edge",
+                source_node=start_node,
+                source_output="city",
+                destination_node=tool_node,
+                destination_input="city",
+            ),
+            DataFlowEdge(
+                name="forecast_edge",
+                source_node=tool_node,
+                source_output="forecast",
+                destination_node=end_node,
+                destination_input="forecast",
+            ),
+        ],
+    )
+
+    def get_weather(city: str) -> dict[str, str]:
+        return {"city": city, "condition": "sunny"}
+
+    app = AgentSpecLoader(tool_registry={"get_weather": get_weather}).load_component(flow)
+
+    proc = DummySpanProcessor()
+    with Trace(name="langgraph_tool_input_trace_test", span_processors=[proc]):
+        response = app.invoke({"inputs": {"city": "Agadir"}})
+
+    tool_request_events = [
+        event for (event, _span) in proc.events if isinstance(event, ToolExecutionRequest)
+    ]
+    tool_response_events = [
+        event for (event, _span) in proc.events if isinstance(event, ToolExecutionResponse)
+    ]
+
+    assert response["outputs"] == {"forecast": {"city": "Agadir", "condition": "sunny"}}
+    assert len(tool_request_events) == 1
+    assert tool_request_events[0].inputs == {"city": "Agadir"}
+    assert len(tool_response_events) == 1
+    assert tool_response_events[0].outputs == {"forecast": {"city": "Agadir", "condition": "sunny"}}


### PR DESCRIPTION
This updates LangGraph tool tracing to normalize callback inputs and use the LangChain inputs parameter by default, so traced tool requests preserve the original structured arguments more reliably.