### PR TITLE
Improve HTTPS handling for LangGraph MCP remote transports

### DIFF
--- a/docs/pyagentspec/source/changelog.rst
+++ b/docs/pyagentspec/source/changelog.rst
@@ -7,6 +7,12 @@ Agent Spec |release|
 Improvements
 ^^^^^^^^^^^^
 
+* **Improved HTTPS handling for LangGraph MCP remote transports**
+
+  Non-mTLS LangGraph MCP SSE and Streamable HTTP transports now use the standard
+  system trust store for server certificate checks, while mTLS transports continue
+  to use explicit client certificate configuration.
+
 * **More reliable tool payload tracing in LangGraph adapter**
 
   The LangGraph adapter now normalizes tool callback inputs before emitting tracing events,
@@ -194,6 +200,14 @@ New features
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 
+* **HTTPS certificate validation for LangGraph MCP remote transports**
+
+  Non-mTLS LangGraph MCP SSE and Streamable HTTP transports now validate the
+  server certificate using the system trust store by default. Connections that
+  previously relied on self-signed, privately issued, expired, or hostname-mismatched
+  certificates may now require updating the certificate setup, trusting the CA in
+  the system store, or switching to the mTLS transport configuration.
+
 * **Numeric model settings in OpenAI Agents code generation**
 
   ``temperature`` and ``top_p`` must now be numeric values, and ``max_tokens``
@@ -204,9 +218,9 @@ Breaking Changes
 
 * **Empty titles in properties**
 
-Property titles in Agent Spec must not be empty. This is now enforced by validation in the pyagentspec SDK.
+  Property titles in Agent Spec must not be empty. This is now enforced by validation in the pyagentspec SDK.
 
-Migration: If your YAML/JSON configurations have properties without titles, you’ll need to set a non-empty, descriptive title for those properties to pass validation. If you generate Agent Spec configurations via the SDK, your code may still work, but we recommend explicitly setting property titles to ensure forward compatibility.
+  Migration: If your YAML/JSON configurations have properties without titles, you’ll need to set a non-empty, descriptive title for those properties to pass validation. If you generate Agent Spec configurations via the SDK, your code may still work, but we recommend explicitly setting property titles to ensure forward compatibility.
 
 * **MCP stdio transport is blocked by default in Agent Spec loaders**
 

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/_langgraphconverter.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/_langgraphconverter.py
@@ -1363,7 +1363,7 @@ class AgentSpecToLangGraphConverter:
                 transport="sse",
                 url=agentspec_component.url,
                 headers=agentspec_component.headers,
-                httpx_client_factory=_HttpxClientFactory(verify=False),
+                httpx_client_factory=_HttpxClientFactory(verify=True),
             )
         if isinstance(agentspec_component, AgentSpecStreamableHTTPmTLSTransport):
             return StreamableHttpConnection(
@@ -1381,7 +1381,7 @@ class AgentSpecToLangGraphConverter:
                 transport="streamable_http",
                 url=agentspec_component.url,
                 headers=agentspec_component.headers,
-                httpx_client_factory=_HttpxClientFactory(verify=False),
+                httpx_client_factory=_HttpxClientFactory(verify=True),
             )
         raise ValueError(
             f"Agent Spec ClientTransport '{agentspec_component.__class__.__name__}' is not supported yet."

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/mcp_utils.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/mcp_utils.py
@@ -5,6 +5,7 @@
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 
 import ssl
+import warnings
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from typing import Any, Awaitable, Callable, Optional, TypeVar
@@ -31,21 +32,26 @@ class _HttpxClientFactory:
     ):
         self.verify: bool | ssl.SSLContext
         if verify:
-            if key_file or cert_file or ssl_ca_cert:
-                # mTLS requires the full client certificate configuration.
-                if not (key_file and cert_file and ssl_ca_cert):
+            ssl_ctx = ssl.create_default_context()
+            if ssl_ca_cert:
+                ssl_ctx.load_verify_locations(cafile=ssl_ca_cert)
+
+            if key_file or cert_file:
+                # Client authentication requires both pieces of certificate material.
+                if not (key_file and cert_file):
                     raise ValueError(
-                        "When verify=True and certificate files are provided, all "
-                        "`key_file`, `cert_file` and `ssl_ca_cert` must be defined."
+                        "When client certificates are provided, both `key_file` and "
+                        "`cert_file` must be defined."
                     )
-                ssl_ctx = ssl.create_default_context(cafile=ssl_ca_cert)
                 ssl_ctx.load_cert_chain(certfile=cert_file, keyfile=key_file)
-                ssl_ctx.check_hostname = check_hostname
-                self.verify = ssl_ctx
-            else:
-                # Standard HTTPS verification without client certificates uses the
-                # system trust store.
-                self.verify = True
+            ssl_ctx.check_hostname = check_hostname
+            if not check_hostname:
+                warnings.warn(
+                    "TLS hostname verification is disabled for this MCP HTTP client.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            self.verify = ssl_ctx
         else:
             # If verify=False the cert/key files should not be specified
             if key_file or cert_file or ssl_ca_cert:

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/mcp_utils.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/mcp_utils.py
@@ -18,6 +18,8 @@ T = TypeVar("T")
 
 
 class _HttpxClientFactory:
+    """Build HTTPX async clients for MCP transports with explicit TLS verification."""
+
     def __init__(
         self,
         verify: bool = True,
@@ -29,16 +31,21 @@ class _HttpxClientFactory:
     ):
         self.verify: bool | ssl.SSLContext
         if verify:
-            # Default behaviour: Client verification
-            if not (key_file and cert_file and ssl_ca_cert):
-                raise ValueError(
-                    "When verify=True, all `key_file`, `cert_file` and `ssl_ca_cert` "
-                    "must be defined."
-                )
-            ssl_ctx = ssl.create_default_context(cafile=ssl_ca_cert)
-            ssl_ctx.load_cert_chain(certfile=cert_file, keyfile=key_file)
-            ssl_ctx.check_hostname = check_hostname
-            self.verify = ssl_ctx
+            if key_file or cert_file or ssl_ca_cert:
+                # mTLS requires the full client certificate configuration.
+                if not (key_file and cert_file and ssl_ca_cert):
+                    raise ValueError(
+                        "When verify=True and certificate files are provided, all "
+                        "`key_file`, `cert_file` and `ssl_ca_cert` must be defined."
+                    )
+                ssl_ctx = ssl.create_default_context(cafile=ssl_ca_cert)
+                ssl_ctx.load_cert_chain(certfile=cert_file, keyfile=key_file)
+                ssl_ctx.check_hostname = check_hostname
+                self.verify = ssl_ctx
+            else:
+                # Standard HTTPS verification without client certificates uses the
+                # system trust store.
+                self.verify = True
         else:
             # If verify=False the cert/key files should not be specified
             if key_file or cert_file or ssl_ca_cert:

--- a/pyagentspec/tests/adapters/langgraph/mcp/test_mcp.py
+++ b/pyagentspec/tests/adapters/langgraph/mcp/test_mcp.py
@@ -4,6 +4,7 @@
 # (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 
+import ssl
 import sys
 from contextlib import nullcontext
 
@@ -101,15 +102,31 @@ def loaded_langgraph_agent(client_transport_name, big_llama, request):
 def test_httpx_client_factory_uses_system_ca_store_for_server_only_tls():
     factory = _HttpxClientFactory(verify=True)
 
-    assert factory.verify is True
+    assert isinstance(factory.verify, ssl.SSLContext)
+    assert factory.verify.check_hostname is True
+
+
+def test_httpx_client_factory_accepts_custom_ca_without_client_certificates(ca_cert_path):
+    factory = _HttpxClientFactory(verify=True, ssl_ca_cert=ca_cert_path)
+
+    assert isinstance(factory.verify, ssl.SSLContext)
+    assert factory.verify.check_hostname is True
 
 
 def test_httpx_client_factory_requires_complete_mtls_configuration():
     with pytest.raises(
         ValueError,
-        match="When verify=True and certificate files are provided",
+        match="both `key_file` and `cert_file` must be defined",
     ):
         _HttpxClientFactory(verify=True, key_file="client.key")
+
+
+def test_httpx_client_factory_warns_when_hostname_checks_are_disabled():
+    with pytest.warns(UserWarning, match="hostname verification is disabled"):
+        factory = _HttpxClientFactory(verify=True, check_hostname=False)
+
+    assert isinstance(factory.verify, ssl.SSLContext)
+    assert factory.verify.check_hostname is False
 
 
 @pytest.mark.parametrize(
@@ -132,7 +149,8 @@ def test_non_mtls_remote_connections_enable_tls_verification(client_transport, e
 
     assert connection["transport"] == expected_transport
     assert isinstance(connection["httpx_client_factory"], _HttpxClientFactory)
-    assert connection["httpx_client_factory"].verify is True
+    assert isinstance(connection["httpx_client_factory"].verify, ssl.SSLContext)
+    assert connection["httpx_client_factory"].verify.check_hostname is True
 
 
 @pytest.fixture(scope="function")

--- a/pyagentspec/tests/adapters/langgraph/mcp/test_mcp.py
+++ b/pyagentspec/tests/adapters/langgraph/mcp/test_mcp.py
@@ -15,6 +15,8 @@ from langgraph.types import Command
 from pydantic import SecretStr
 
 from pyagentspec.adapters.langgraph import AgentSpecExporter, AgentSpecLoader
+from pyagentspec.adapters.langgraph._langgraphconverter import AgentSpecToLangGraphConverter
+from pyagentspec.adapters.langgraph.mcp_utils import _HttpxClientFactory
 from pyagentspec.agent import Agent
 from pyagentspec.llms import OpenAiCompatibleConfig
 from pyagentspec.mcp.clienttransport import (
@@ -28,10 +30,8 @@ from pyagentspec.property import IntegerProperty
 
 CLIENT_TRANSPORT_NAMES = [
     "sse_client_transport",
-    "sse_client_transport_https",
     "sse_client_transport_mtls",
     "streamablehttp_client_transport",
-    "streamablehttp_client_transport_https",
     "streamablehttp_client_transport_mtls",
 ]
 
@@ -39,11 +39,6 @@ CLIENT_TRANSPORT_NAMES = [
 @pytest.fixture
 def sse_client_transport(sse_mcp_server_http):
     return SSETransport(name="my server 1", url=sse_mcp_server_http)
-
-
-@pytest.fixture
-def sse_client_transport_https(sse_mcp_server_https):
-    return SSETransport(name="my server 2", url=sse_mcp_server_https)
 
 
 @pytest.fixture
@@ -60,11 +55,6 @@ def sse_client_transport_mtls(sse_mcp_server_mtls, client_cert_path, client_key_
 @pytest.fixture
 def streamablehttp_client_transport(streamablehttp_mcp_server_http):
     return StreamableHTTPTransport(name="my server 4", url=streamablehttp_mcp_server_http)
-
-
-@pytest.fixture
-def streamablehttp_client_transport_https(streamablehttp_mcp_server_https):
-    return StreamableHTTPTransport(name="my server 5", url=streamablehttp_mcp_server_https)
 
 
 @pytest.fixture
@@ -90,6 +80,43 @@ def loaded_langgraph_agent(client_transport_name, big_llama, request):
         system_prompt="be kind and stay frosty",
     )
     return AgentSpecLoader().load_component(agentspec_agent)
+
+
+def test_httpx_client_factory_uses_system_ca_store_for_server_only_tls():
+    factory = _HttpxClientFactory(verify=True)
+
+    assert factory.verify is True
+
+
+def test_httpx_client_factory_requires_complete_mtls_configuration():
+    with pytest.raises(
+        ValueError,
+        match="When verify=True and certificate files are provided",
+    ):
+        _HttpxClientFactory(verify=True, key_file="client.key")
+
+
+@pytest.mark.parametrize(
+    ("client_transport", "expected_transport"),
+    [
+        (
+            SSETransport(name="my server 2", url="https://example.com/sse"),
+            "sse",
+        ),
+        (
+            StreamableHTTPTransport(name="my server 5", url="https://example.com/mcp"),
+            "streamable_http",
+        ),
+    ],
+)
+def test_non_mtls_remote_connections_enable_tls_verification(client_transport, expected_transport):
+    connection = AgentSpecToLangGraphConverter()._client_transport_convert_to_langgraph(
+        client_transport
+    )
+
+    assert connection["transport"] == expected_transport
+    assert isinstance(connection["httpx_client_factory"], _HttpxClientFactory)
+    assert connection["httpx_client_factory"].verify is True
 
 
 @pytest.fixture(scope="function")

--- a/pyagentspec/tests/adapters/langgraph/mcp/test_mcp.py
+++ b/pyagentspec/tests/adapters/langgraph/mcp/test_mcp.py
@@ -30,8 +30,10 @@ from pyagentspec.property import IntegerProperty
 
 CLIENT_TRANSPORT_NAMES = [
     "sse_client_transport",
+    "sse_client_transport_https",
     "sse_client_transport_mtls",
     "streamablehttp_client_transport",
+    "streamablehttp_client_transport_https",
     "streamablehttp_client_transport_mtls",
 ]
 
@@ -39,6 +41,12 @@ CLIENT_TRANSPORT_NAMES = [
 @pytest.fixture
 def sse_client_transport(sse_mcp_server_http):
     return SSETransport(name="my server 1", url=sse_mcp_server_http)
+
+
+@pytest.fixture
+def sse_client_transport_https(monkeypatch, ca_cert_path, sse_mcp_server_https):
+    monkeypatch.setenv("SSL_CERT_FILE", ca_cert_path)
+    return SSETransport(name="my server 2", url=sse_mcp_server_https)
 
 
 @pytest.fixture
@@ -55,6 +63,14 @@ def sse_client_transport_mtls(sse_mcp_server_mtls, client_cert_path, client_key_
 @pytest.fixture
 def streamablehttp_client_transport(streamablehttp_mcp_server_http):
     return StreamableHTTPTransport(name="my server 4", url=streamablehttp_mcp_server_http)
+
+
+@pytest.fixture
+def streamablehttp_client_transport_https(
+    monkeypatch, ca_cert_path, streamablehttp_mcp_server_https
+):
+    monkeypatch.setenv("SSL_CERT_FILE", ca_cert_path)
+    return StreamableHTTPTransport(name="my server 5", url=streamablehttp_mcp_server_https)
 
 
 @pytest.fixture


### PR DESCRIPTION
This improves LangGraph MCP remote transport handling by using the standard system trust store for non-mTLS SSE and Streamable HTTP connections, while preserving the existing mTLS configuration flow. It also adds regression tests for the updated HTTPS behavior.