### PR TITLE
Add includeSensitiveFields opt-in to serializers (TS + Python)

### DIFF
--- a/docs/pyagentspec/source/agentspec/language_spec_nightly.rst
+++ b/docs/pyagentspec/source/agentspec/language_spec_nightly.rst
@@ -2858,7 +2858,10 @@ as part of the main assistant's configuration. For example when:
   without duplicating the configuration for every Component's version.
 
 .. important::
-    Agent Spec exported configurations should never contain sensitive information.
+    Agent Spec configurations intended for storage, sharing, version control, logging,
+    or deployment should not contain sensitive information. Sensitive values should be
+    represented as references and supplied through trusted runtime or deserialization
+    mechanisms.
 
 For this reason, Agent Spec supports referencing **components and values** that are not serialized
 in the same configuration, therefore called *disaggregated*.
@@ -2941,7 +2944,9 @@ Some of the fields in the configuration of Agent Spec components may contain sen
 such as API keys or authentication tokens. To help developers securely support these components,
 AgentSpec runtimes and SDKs must follow these three guidelines:
 
-- **When exporting configurations**: Any sensitive field must be excluded from the configurations.
+- **When exporting configurations**: Sensitive fields should be excluded by default and represented
+  as references. Any export that intentionally includes sensitive values must be treated as secret
+  material, not as an ordinary portable Agent Spec configuration.
 - **When loading configurations**: Runtime adapters and SDKs must allow passing the excluded sensitive information.
 - **When loading configurations**: If developers have already inlined the sensitive information into their
   configurations, runtimes and SDKs should allow loading these configurations too.

--- a/docs/pyagentspec/source/changelog.rst
+++ b/docs/pyagentspec/source/changelog.rst
@@ -7,6 +7,28 @@ Agent Spec |release|
 Improvements
 ^^^^^^^^^^^^
 
+* **Sensitive field export opt-in**
+
+  Serializers now support ``include_sensitive_fields`` to include sensitive field values in
+  trusted local exports instead of replacing them with ``$component_ref`` placeholders. When
+  enabled, serialization emits warnings so users know the returned data may contain sensitive
+  values and can identify which sensitive fields were exported.
+
+  We thank @spichen for the contribution!
+
+New features
+^^^^^^^^^^^^
+
+Breaking Changes
+^^^^^^^^^^^^^^^^
+
+
+Agent Spec 26.1.2
+-----------------
+
+Improvements
+^^^^^^^^^^^^
+
 * **LangGraph adapter timeout and retry improvements**
 
   The LangGraph adapter now applies ``RetryPolicy.request_timeout`` and

--- a/docs/pyagentspec/source/security.rst
+++ b/docs/pyagentspec/source/security.rst
@@ -67,7 +67,8 @@ The ``RemoteTool``, ``MCPTool`` and the ``ApiNode`` define HTTP-based interactio
 
 .. important::
 
-  Never embed API keys, passwords, or other secrets directly in Agent Spec.
+  Do not embed API keys, passwords, or other secrets directly in Agent Spec
+  configurations intended for storage, sharing, version control, logging, or deployment.
 
 Always use secure injection mechanisms and follow the principle of least privilege for credential access.
 
@@ -113,17 +114,24 @@ Considerations regarding API keys and secrets management
 
 .. important::
 
-  Never embed API keys, passwords, or other secrets directly in Agent Spec.
+  Do not embed API keys, passwords, or other secrets directly in Agent Spec
+  configurations intended for storage, sharing, version control, logging, or deployment.
 
 Agent Spec is a declarative language for agents, tools, and flows.
 It may be stored, versioned, or inspected; it is **not a secure medium for sensitive data**.
-Hardcoding secrets in the representation increases the risk of accidental exposure and must be avoided.
+Hardcoding secrets in shared or persistent representations increases the risk of accidental
+exposure and must be avoided.
 
-Instead of embedding secrets in the representation, ensure that secrets are injected securely at runtime via:
+Instead of embedding secrets in the representation, ensure that secrets are injected securely
+at runtime via:
 
 * Integration with a secrets manager (e.g., OCI Vault)
 * Use instance principal when working on OCI Computes
 * Use Kubernetes/Docker secrets if the deployments supports it
+
+If sensitive values are explicitly included in an Agent Spec configuration for a trusted
+local workflow, treat that configuration as secret material. Do not commit, log, share,
+or persist it except in systems approved for storing secrets.
 
 Furthermore, follow these general best practices around credential management
 

--- a/pyagentspec/src/pyagentspec/serialization/pydanticserializationplugin.py
+++ b/pyagentspec/src/pyagentspec/serialization/pydanticserializationplugin.py
@@ -67,7 +67,7 @@ class PydanticComponentSerializationPlugin(ComponentSerializationPlugin):
                 # If a sensitive value is left as a falsy value (e.g. None, False, {}, "") then it
                 # is not replaced by a reference, such that the empty value does not need to be
                 # explicitly specified when loading the component configuration.
-                if field_value and serialization_context.is_field_sensitive(field_info):
+                if field_value and serialization_context.should_redact_field(field_info):
                     serialized_component[field_name] = {
                         "$component_ref": f"{component.id}.{field_name}"
                     }

--- a/pyagentspec/src/pyagentspec/serialization/pydanticserializationplugin.py
+++ b/pyagentspec/src/pyagentspec/serialization/pydanticserializationplugin.py
@@ -67,7 +67,7 @@ class PydanticComponentSerializationPlugin(ComponentSerializationPlugin):
                 # If a sensitive value is left as a falsy value (e.g. None, False, {}, "") then it
                 # is not replaced by a reference, such that the empty value does not need to be
                 # explicitly specified when loading the component configuration.
-                if serialization_context.is_field_sensitive(field_info) and field_value:
+                if field_value and serialization_context.is_field_sensitive(field_info):
                     serialized_component[field_name] = {
                         "$component_ref": f"{component.id}.{field_name}"
                     }

--- a/pyagentspec/src/pyagentspec/serialization/pydanticserializationplugin.py
+++ b/pyagentspec/src/pyagentspec/serialization/pydanticserializationplugin.py
@@ -6,11 +6,13 @@
 
 """This module defines the serialization plugin for Pydantic Components."""
 
+import warnings
 from typing import Any, Dict, List, Mapping, Type
 
 from pydantic import BaseModel
 
 from pyagentspec.component import Component
+from pyagentspec.sensitive_field import is_sensitive_field
 from pyagentspec.serialization.serializationcontext import SerializationContext
 from pyagentspec.serialization.serializationplugin import ComponentSerializationPlugin
 
@@ -72,6 +74,17 @@ class PydanticComponentSerializationPlugin(ComponentSerializationPlugin):
                         "$component_ref": f"{component.id}.{field_name}"
                     }
                 else:
+                    if (
+                        field_value
+                        and serialization_context._include_sensitive_fields
+                        and is_sensitive_field(field_info)
+                    ):
+                        warnings.warn(
+                            f"'{field_name}' on '{component.id}' is a sensitive field and will be "
+                            "written to the output in plain text.",
+                            UserWarning,
+                            stacklevel=2,
+                        )
                     serialized_component[field_name] = serialization_context.dump_field(
                         value=field_value, info=field_info
                     )

--- a/pyagentspec/src/pyagentspec/serialization/pydanticserializationplugin.py
+++ b/pyagentspec/src/pyagentspec/serialization/pydanticserializationplugin.py
@@ -74,14 +74,12 @@ class PydanticComponentSerializationPlugin(ComponentSerializationPlugin):
                         "$component_ref": f"{component.id}.{field_name}"
                     }
                 else:
-                    if (
-                        field_value
-                        and serialization_context._include_sensitive_fields
-                        and is_sensitive_field(field_info)
-                    ):
+                    # A truthy sensitive field that reaches this branch is being exported.
+                    if field_value and is_sensitive_field(field_info):
                         warnings.warn(
-                            f"'{field_name}' on '{component.id}' is a sensitive field and will be "
-                            "written to the output in plain text.",
+                            "Sensitive field exported: "
+                            f"component_id={component.id!r}, field={field_name!r}. "
+                            "Review the serialized value before storing or sharing the output.",
                             UserWarning,
                             stacklevel=2,
                         )

--- a/pyagentspec/src/pyagentspec/serialization/pydanticserializationplugin.py
+++ b/pyagentspec/src/pyagentspec/serialization/pydanticserializationplugin.py
@@ -11,7 +11,6 @@ from typing import Any, Dict, List, Mapping, Type
 from pydantic import BaseModel
 
 from pyagentspec.component import Component
-from pyagentspec.sensitive_field import is_sensitive_field
 from pyagentspec.serialization.serializationcontext import SerializationContext
 from pyagentspec.serialization.serializationplugin import ComponentSerializationPlugin
 
@@ -68,7 +67,7 @@ class PydanticComponentSerializationPlugin(ComponentSerializationPlugin):
                 # If a sensitive value is left as a falsy value (e.g. None, False, {}, "") then it
                 # is not replaced by a reference, such that the empty value does not need to be
                 # explicitly specified when loading the component configuration.
-                if is_sensitive_field(field_info) and field_value:
+                if serialization_context.is_field_sensitive(field_info) and field_value:
                     serialized_component[field_name] = {
                         "$component_ref": f"{component.id}.{field_name}"
                     }

--- a/pyagentspec/src/pyagentspec/serialization/serializationcontext.py
+++ b/pyagentspec/src/pyagentspec/serialization/serializationcontext.py
@@ -33,11 +33,11 @@ class SerializationContext:
     """Interface for the serialization of Components."""
 
     agentspec_version: AgentSpecVersionEnum
-    include_sensitive_fields: bool = False
+    _include_sensitive_fields: bool = False
 
     def is_field_sensitive(self, field_info: FieldInfo) -> bool:
-        """Return True if the field should be redacted (replaced with a reference)."""
-        if self.include_sensitive_fields:
+        """Return True if the field should be redacted; False when opt-in bypass is active."""
+        if self._include_sensitive_fields:
             return False
         return is_sensitive_field(field_info)
 
@@ -93,7 +93,7 @@ class _SerializationContextImpl(SerializationContext):
     ) -> None:
 
         self._allow_partial_model_serialization = _allow_partial_model_serialization
-        self.include_sensitive_fields = include_sensitive_fields
+        self._include_sensitive_fields = include_sensitive_fields
         self.plugins = list(plugins) if plugins is not None else []
 
         from pyagentspec.serialization.builtinserializationplugin import (

--- a/pyagentspec/src/pyagentspec/serialization/serializationcontext.py
+++ b/pyagentspec/src/pyagentspec/serialization/serializationcontext.py
@@ -35,7 +35,7 @@ class SerializationContext:
     agentspec_version: AgentSpecVersionEnum
     _include_sensitive_fields: bool = False
 
-    def is_field_sensitive(self, field_info: FieldInfo) -> bool:
+    def should_redact_field(self, field_info: FieldInfo) -> bool:
         """Return True if the field should be redacted; False when opt-in bypass is active."""
         if self._include_sensitive_fields:
             return False

--- a/pyagentspec/src/pyagentspec/serialization/serializationcontext.py
+++ b/pyagentspec/src/pyagentspec/serialization/serializationcontext.py
@@ -16,6 +16,7 @@ from pydantic.fields import FieldInfo
 from typing_extensions import TypeGuard
 
 from pyagentspec.component import Component
+from pyagentspec.sensitive_field import is_sensitive_field
 from pyagentspec.versioning import AGENTSPEC_VERSION_FIELD_NAME, AgentSpecVersionEnum
 
 from .types import ComponentAsDictT, WatchingDict
@@ -32,6 +33,13 @@ class SerializationContext:
     """Interface for the serialization of Components."""
 
     agentspec_version: AgentSpecVersionEnum
+    include_sensitive_fields: bool = False
+
+    def is_field_sensitive(self, field_info: FieldInfo) -> bool:
+        """Return True if the field should be redacted (replaced with a reference)."""
+        if self.include_sensitive_fields:
+            return False
+        return is_sensitive_field(field_info)
 
     @abstractmethod
     def _dump_component_to_dict(self, component: Component) -> ComponentAsDictT:
@@ -81,9 +89,11 @@ class _SerializationContextImpl(SerializationContext):
         resolved_components: Optional[Dict[str, ComponentAsDictT]] = None,
         components_id_mapping: Optional[WatchingDict] = None,
         _allow_partial_model_serialization: bool = False,
+        include_sensitive_fields: bool = False,
     ) -> None:
 
         self._allow_partial_model_serialization = _allow_partial_model_serialization
+        self.include_sensitive_fields = include_sensitive_fields
         self.plugins = list(plugins) if plugins is not None else []
 
         from pyagentspec.serialization.builtinserializationplugin import (

--- a/pyagentspec/src/pyagentspec/serialization/serializer.py
+++ b/pyagentspec/src/pyagentspec/serialization/serializer.py
@@ -58,6 +58,8 @@ class AgentSpecSerializer:
     def to_yaml(
         self,
         component: Component,
+        *,
+        include_sensitive_fields: bool = False,
     ) -> str: ...
 
     @overload
@@ -65,6 +67,8 @@ class AgentSpecSerializer:
         self,
         component: Component,
         agentspec_version: Optional[AgentSpecVersionEnum] = None,
+        *,
+        include_sensitive_fields: bool = False,
     ) -> str: ...
 
     @overload
@@ -386,6 +390,8 @@ class AgentSpecSerializer:
     def to_dict(
         self,
         component: Component,
+        *,
+        include_sensitive_fields: bool = False,
     ) -> ComponentAsDictT: ...
 
     @overload
@@ -393,6 +399,8 @@ class AgentSpecSerializer:
         self,
         component: Component,
         agentspec_version: Optional[AgentSpecVersionEnum],
+        *,
+        include_sensitive_fields: bool = False,
     ) -> ComponentAsDictT: ...
 
     @overload

--- a/pyagentspec/src/pyagentspec/serialization/serializer.py
+++ b/pyagentspec/src/pyagentspec/serialization/serializer.py
@@ -166,13 +166,16 @@ class AgentSpecSerializer:
         export_disaggregated_components:
             Whether to export the disaggregated components or not. Defaults to ``False``.
         include_sensitive_fields:
-            If ``True``, sensitive fields like API keys and certificate paths are written to the
-            output as plain text rather than replaced with ``$component_ref`` placeholders.
-            Defaults to ``False``.
+            If ``False`` (default), non-empty sensitive fields are exported as
+            ``$component_ref`` placeholders. If ``True``, their values are included in the
+            returned serialization. Use this only for trusted local workflows; the returned
+            value may contain secrets or other sensitive data and should not be logged,
+            committed, or shared.
 
             .. warning::
 
-                The output will contain credentials in plain text. Treat it accordingly.
+                Enabling this option can expose API keys, credentials, file paths, headers, DSNs,
+                or other sensitive values in the returned data.
 
         Returns
         -------
@@ -336,13 +339,16 @@ class AgentSpecSerializer:
         indent:
             The number of spaces to use for the JSON indentation.
         include_sensitive_fields:
-            If ``True``, sensitive fields like API keys and certificate paths are written to the
-            output as plain text rather than replaced with ``$component_ref`` placeholders.
-            Defaults to ``False``.
+            If ``False`` (default), non-empty sensitive fields are exported as
+            ``$component_ref`` placeholders. If ``True``, their values are included in the
+            returned serialization. Use this only for trusted local workflows; the returned
+            value may contain secrets or other sensitive data and should not be logged,
+            committed, or shared.
 
             .. warning::
 
-                The output will contain credentials in plain text. Treat it accordingly.
+                Enabling this option can expose API keys, credentials, file paths, headers, DSNs,
+                or other sensitive values in the returned data.
 
         Returns
         -------
@@ -488,13 +494,16 @@ class AgentSpecSerializer:
         export_disaggregated_components:
             Whether to export the disaggregated components or not. Defaults to ``False``.
         include_sensitive_fields:
-            If ``True``, sensitive fields like API keys and certificate paths are written to the
-            output as plain text rather than replaced with ``$component_ref`` placeholders.
-            Defaults to ``False``.
+            If ``False`` (default), non-empty sensitive fields are exported as
+            ``$component_ref`` placeholders. If ``True``, their values are included in the
+            returned serialization. Use this only for trusted local workflows; the returned
+            value may contain secrets or other sensitive data and should not be logged,
+            committed, or shared.
 
             .. warning::
 
-                The output will contain credentials in plain text. Treat it accordingly.
+                Enabling this option can expose API keys, credentials, file paths, headers, DSNs,
+                or other sensitive values in the returned data.
 
         Returns
         -------
@@ -561,7 +570,9 @@ class AgentSpecSerializer:
         """
         if include_sensitive_fields:
             warnings.warn(
-                "include_sensitive_fields=True: credentials will appear in plain text in the output.",
+                "include_sensitive_fields=True: returned serialization may contain "
+                "unredacted sensitive values; do not log, commit, or share it unless "
+                "those values are intended to be exposed.",
                 UserWarning,
                 stacklevel=2,
             )

--- a/pyagentspec/src/pyagentspec/serialization/serializer.py
+++ b/pyagentspec/src/pyagentspec/serialization/serializer.py
@@ -165,6 +165,14 @@ class AgentSpecSerializer:
                 even if ``export_disaggregated_components`` is ``False``.
         export_disaggregated_components:
             Whether to export the disaggregated components or not. Defaults to ``False``.
+        include_sensitive_fields:
+            If ``True``, sensitive fields like API keys and certificate paths are written to the
+            output as plain text rather than replaced with ``$component_ref`` placeholders.
+            Defaults to ``False``.
+
+            .. warning::
+
+                The output will contain credentials in plain text. Treat it accordingly.
 
         Returns
         -------
@@ -327,6 +335,14 @@ class AgentSpecSerializer:
             Whether to export the disaggregated components or not. Defaults to ``False``.
         indent:
             The number of spaces to use for the JSON indentation.
+        include_sensitive_fields:
+            If ``True``, sensitive fields like API keys and certificate paths are written to the
+            output as plain text rather than replaced with ``$component_ref`` placeholders.
+            Defaults to ``False``.
+
+            .. warning::
+
+                The output will contain credentials in plain text. Treat it accordingly.
 
         Returns
         -------
@@ -471,6 +487,14 @@ class AgentSpecSerializer:
                 even if ``export_disaggregated_components`` is ``False``.
         export_disaggregated_components:
             Whether to export the disaggregated components or not. Defaults to ``False``.
+        include_sensitive_fields:
+            If ``True``, sensitive fields like API keys and certificate paths are written to the
+            output as plain text rather than replaced with ``$component_ref`` placeholders.
+            Defaults to ``False``.
+
+            .. warning::
+
+                The output will contain credentials in plain text. Treat it accordingly.
 
         Returns
         -------
@@ -535,6 +559,13 @@ class AgentSpecSerializer:
         ['custom_llm_id']
 
         """
+        if include_sensitive_fields:
+            warnings.warn(
+                "include_sensitive_fields=True: credentials will appear in plain text in the output.",
+                UserWarning,
+                stacklevel=2,
+            )
+
         # 1. we serialize the disaggregated components
         converted_config: List[Tuple[Component, str]] = []
         components_id_mapping: Dict[str, str] = {}

--- a/pyagentspec/src/pyagentspec/serialization/serializer.py
+++ b/pyagentspec/src/pyagentspec/serialization/serializer.py
@@ -73,6 +73,7 @@ class AgentSpecSerializer:
         component: Component,
         *,
         disaggregated_components: Optional[DisaggregatedComponentsConfigT],
+        include_sensitive_fields: bool = False,
     ) -> str: ...
 
     @overload
@@ -81,6 +82,7 @@ class AgentSpecSerializer:
         component: Component,
         *,
         export_disaggregated_components: Literal[False],
+        include_sensitive_fields: bool = False,
     ) -> str: ...
 
     @overload
@@ -89,6 +91,7 @@ class AgentSpecSerializer:
         component: Component,
         *,
         export_disaggregated_components: bool,
+        include_sensitive_fields: bool = False,
     ) -> Union[str, Tuple[str, str]]: ...
 
     @overload
@@ -98,6 +101,7 @@ class AgentSpecSerializer:
         *,
         disaggregated_components: Optional[DisaggregatedComponentsConfigT],
         export_disaggregated_components: Literal[False],
+        include_sensitive_fields: bool = False,
     ) -> str: ...
 
     @overload
@@ -107,6 +111,7 @@ class AgentSpecSerializer:
         *,
         disaggregated_components: DisaggregatedComponentsConfigT,
         export_disaggregated_components: Literal[True],
+        include_sensitive_fields: bool = False,
     ) -> Tuple[str, str]: ...
 
     @overload
@@ -116,6 +121,7 @@ class AgentSpecSerializer:
         *,
         disaggregated_components: Optional[DisaggregatedComponentsConfigT],
         export_disaggregated_components: bool,
+        include_sensitive_fields: bool = False,
     ) -> Union[str, Tuple[str, str]]: ...
 
     @overload
@@ -125,6 +131,7 @@ class AgentSpecSerializer:
         agentspec_version: Optional[AgentSpecVersionEnum],
         disaggregated_components: Optional[DisaggregatedComponentsConfigT],
         export_disaggregated_components: bool,
+        include_sensitive_fields: bool = False,
     ) -> Union[str, Tuple[str, str]]: ...
 
     def to_yaml(
@@ -133,6 +140,7 @@ class AgentSpecSerializer:
         agentspec_version: Optional[AgentSpecVersionEnum] = None,
         disaggregated_components: Optional[DisaggregatedComponentsConfigT] = None,
         export_disaggregated_components: bool = False,
+        include_sensitive_fields: bool = False,
     ) -> Union[str, Tuple[str, str]]:
         """
         Serialize a component and its sub-components to YAML.
@@ -183,6 +191,7 @@ class AgentSpecSerializer:
             agentspec_version=agentspec_version,
             disaggregated_components=disaggregated_components,
             export_disaggregated_components=export_disaggregated_components,
+            include_sensitive_fields=include_sensitive_fields,
         )
         return (
             tuple(yaml.safe_dump(x, sort_keys=False) for x in obj)  # type: ignore
@@ -196,6 +205,7 @@ class AgentSpecSerializer:
         component: Component,
         *,
         indent: Optional[int] = None,
+        include_sensitive_fields: bool = False,
     ) -> str: ...
 
     @overload
@@ -205,6 +215,7 @@ class AgentSpecSerializer:
         agentspec_version: Optional[AgentSpecVersionEnum],
         *,
         indent: Optional[int] = None,
+        include_sensitive_fields: bool = False,
     ) -> str: ...
 
     @overload
@@ -214,6 +225,7 @@ class AgentSpecSerializer:
         *,
         disaggregated_components: Optional[DisaggregatedComponentsConfigT],
         indent: Optional[int] = None,
+        include_sensitive_fields: bool = False,
     ) -> str: ...
 
     @overload
@@ -223,6 +235,7 @@ class AgentSpecSerializer:
         *,
         export_disaggregated_components: Literal[False],
         indent: Optional[int] = None,
+        include_sensitive_fields: bool = False,
     ) -> str: ...
 
     @overload
@@ -232,6 +245,7 @@ class AgentSpecSerializer:
         *,
         export_disaggregated_components: bool,
         indent: Optional[int] = None,
+        include_sensitive_fields: bool = False,
     ) -> Union[str, Tuple[str, str]]: ...
 
     @overload
@@ -242,6 +256,7 @@ class AgentSpecSerializer:
         disaggregated_components: Optional[DisaggregatedComponentsConfigT],
         export_disaggregated_components: Literal[False],
         indent: Optional[int] = None,
+        include_sensitive_fields: bool = False,
     ) -> str: ...
 
     @overload
@@ -252,6 +267,7 @@ class AgentSpecSerializer:
         disaggregated_components: Optional[DisaggregatedComponentsConfigT],
         export_disaggregated_components: Literal[True],
         indent: Optional[int] = None,
+        include_sensitive_fields: bool = False,
     ) -> Tuple[str, str]: ...
 
     @overload
@@ -262,6 +278,7 @@ class AgentSpecSerializer:
         disaggregated_components: Optional[DisaggregatedComponentsConfigT],
         export_disaggregated_components: bool,
         indent: Optional[int] = None,
+        include_sensitive_fields: bool = False,
     ) -> Union[str, Tuple[str, str]]: ...
 
     @overload
@@ -273,6 +290,7 @@ class AgentSpecSerializer:
         export_disaggregated_components: bool,
         *,
         indent: Optional[int] = None,
+        include_sensitive_fields: bool = False,
     ) -> Union[str, Tuple[str, str]]: ...
 
     def to_json(
@@ -282,6 +300,7 @@ class AgentSpecSerializer:
         disaggregated_components: Optional[DisaggregatedComponentsConfigT] = None,
         export_disaggregated_components: bool = False,
         indent: Optional[int] = None,
+        include_sensitive_fields: bool = False,
     ) -> Union[str, Tuple[str, str]]:
         """
         Serialize a component and its sub-components to JSON.
@@ -333,6 +352,7 @@ class AgentSpecSerializer:
             agentspec_version=agentspec_version,
             disaggregated_components=disaggregated_components,
             export_disaggregated_components=export_disaggregated_components,
+            include_sensitive_fields=include_sensitive_fields,
         )
         return (
             tuple(json.dumps(x, indent=indent, sort_keys=False) for x in obj)  # type: ignore
@@ -359,6 +379,7 @@ class AgentSpecSerializer:
         component: Component,
         *,
         disaggregated_components: Optional[DisaggregatedComponentsConfigT],
+        include_sensitive_fields: bool = False,
     ) -> ComponentAsDictT: ...
 
     @overload
@@ -367,6 +388,7 @@ class AgentSpecSerializer:
         component: Component,
         *,
         export_disaggregated_components: Literal[False],
+        include_sensitive_fields: bool = False,
     ) -> ComponentAsDictT: ...
 
     @overload
@@ -375,6 +397,7 @@ class AgentSpecSerializer:
         component: Component,
         *,
         export_disaggregated_components: bool,
+        include_sensitive_fields: bool = False,
     ) -> Union[ComponentAsDictT, Tuple[ComponentAsDictT, DisaggregatedComponentsAsDictT]]: ...
 
     @overload
@@ -384,6 +407,7 @@ class AgentSpecSerializer:
         *,
         disaggregated_components: Optional[DisaggregatedComponentsConfigT],
         export_disaggregated_components: Literal[False],
+        include_sensitive_fields: bool = False,
     ) -> ComponentAsDictT: ...
 
     @overload
@@ -393,6 +417,7 @@ class AgentSpecSerializer:
         *,
         disaggregated_components: DisaggregatedComponentsConfigT,
         export_disaggregated_components: Literal[True],
+        include_sensitive_fields: bool = False,
     ) -> Tuple[ComponentAsDictT, DisaggregatedComponentsAsDictT]: ...
 
     @overload
@@ -402,6 +427,7 @@ class AgentSpecSerializer:
         *,
         disaggregated_components: Optional[DisaggregatedComponentsConfigT],
         export_disaggregated_components: bool,
+        include_sensitive_fields: bool = False,
     ) -> Union[ComponentAsDictT, Tuple[ComponentAsDictT, DisaggregatedComponentsAsDictT]]: ...
 
     @overload
@@ -411,6 +437,7 @@ class AgentSpecSerializer:
         agentspec_version: Optional[AgentSpecVersionEnum],
         disaggregated_components: Optional[DisaggregatedComponentsConfigT],
         export_disaggregated_components: bool,
+        include_sensitive_fields: bool = False,
     ) -> Union[ComponentAsDictT, Tuple[ComponentAsDictT, DisaggregatedComponentsAsDictT]]: ...
 
     def to_dict(
@@ -419,6 +446,7 @@ class AgentSpecSerializer:
         agentspec_version: Optional[AgentSpecVersionEnum] = None,
         disaggregated_components: Optional[DisaggregatedComponentsConfigT] = None,
         export_disaggregated_components: bool = False,
+        include_sensitive_fields: bool = False,
     ) -> Union[ComponentAsDictT, Tuple[ComponentAsDictT, DisaggregatedComponentsAsDictT]]:
         """
         Serialize a component and its sub-components to a dictionary.
@@ -531,6 +559,7 @@ class AgentSpecSerializer:
             disag_serialization_context = _SerializationContextImpl(
                 plugins=self.plugins,
                 _allow_partial_model_serialization=self._allow_partial_model_serialization,
+                include_sensitive_fields=include_sensitive_fields,
             )
             model_dump = disag_serialization_context._save_to_dict(
                 disag_component, agentspec_version=agentspec_version
@@ -548,6 +577,7 @@ class AgentSpecSerializer:
             resolved_components=copy(disaggregated_components_as_dict),
             components_id_mapping=watched_components_id_mapping,
             _allow_partial_model_serialization=self._allow_partial_model_serialization,
+            include_sensitive_fields=include_sensitive_fields,
         )
 
         main_model_dump = main_serialization_context._save_to_dict(

--- a/pyagentspec/tests/serialization/test_sensitive_fields.py
+++ b/pyagentspec/tests/serialization/test_sensitive_fields.py
@@ -397,7 +397,8 @@ def test_include_sensitive_fields_opt_in() -> None:
         api_key="THIS_IS_SECRET",
         key_file="/etc/certs/client.key",
     )
-    serialized = AgentSpecSerializer().to_json(llm_config, include_sensitive_fields=True)
+    with pytest.warns(UserWarning):
+        serialized = AgentSpecSerializer().to_json(llm_config, include_sensitive_fields=True)
     assert "THIS_IS_SECRET" in serialized
     assert "/etc/certs/client.key" in serialized
     assert "$component_ref" not in serialized
@@ -406,6 +407,47 @@ def test_include_sensitive_fields_opt_in() -> None:
     assert isinstance(deserialized, OpenAiCompatibleConfig)
     assert deserialized.api_key == "THIS_IS_SECRET"
     assert deserialized.key_file == "/etc/certs/client.key"
+
+
+def test_include_sensitive_fields_warns_opt_in() -> None:
+    llm_config = OpenAiCompatibleConfig(
+        name="openai-compatible-config",
+        id="openai-compatible-config-id",
+        url="https://api.closedai.com/v2",
+        model_id="gpt-7",
+        api_key="THIS_IS_SECRET",
+    )
+    with pytest.warns(UserWarning, match="include_sensitive_fields=True"):
+        AgentSpecSerializer().to_json(llm_config, include_sensitive_fields=True)
+
+
+def test_include_sensitive_fields_warns_per_serialized_field() -> None:
+    llm_config = OpenAiCompatibleConfig(
+        name="openai-compatible-config",
+        id="openai-compatible-config-id",
+        url="https://api.closedai.com/v2",
+        model_id="gpt-7",
+        api_key="THIS_IS_SECRET",
+        key_file="/etc/certs/client.key",
+    )
+    with pytest.warns(UserWarning) as warning_list:
+        AgentSpecSerializer().to_json(llm_config, include_sensitive_fields=True)
+    messages = [str(w.message) for w in warning_list]
+    assert any("include_sensitive_fields=True" in m for m in messages)
+    assert any("'api_key'" in m and "openai-compatible-config-id" in m for m in messages)
+    assert any("'key_file'" in m and "openai-compatible-config-id" in m for m in messages)
+
+
+def test_no_warning_when_sensitive_fields_are_empty() -> None:
+    llm_config = OpenAiCompatibleConfig(
+        name="openai-compatible-config",
+        url="https://api.closedai.com/v2",
+        model_id="gpt-7",
+    )
+    # No sensitive field values set — no per-field warnings should be emitted.
+    # The opt-in warning is still expected.
+    with pytest.warns(UserWarning, match="include_sensitive_fields=True"):
+        AgentSpecSerializer().to_json(llm_config, include_sensitive_fields=True)
 
 
 def test_partial_configurations_exclude_secrets():

--- a/pyagentspec/tests/serialization/test_sensitive_fields.py
+++ b/pyagentspec/tests/serialization/test_sensitive_fields.py
@@ -417,8 +417,12 @@ def test_include_sensitive_fields_warns_opt_in() -> None:
         model_id="gpt-7",
         api_key="THIS_IS_SECRET",
     )
-    with pytest.warns(UserWarning, match="include_sensitive_fields=True"):
+    with pytest.warns(UserWarning) as warning_list:
         AgentSpecSerializer().to_json(llm_config, include_sensitive_fields=True)
+    messages = [str(w.message) for w in warning_list]
+    assert any(
+        "returned serialization may contain unredacted sensitive values" in m for m in messages
+    )
 
 
 def test_include_sensitive_fields_warns_per_serialized_field() -> None:
@@ -433,9 +437,21 @@ def test_include_sensitive_fields_warns_per_serialized_field() -> None:
     with pytest.warns(UserWarning) as warning_list:
         AgentSpecSerializer().to_json(llm_config, include_sensitive_fields=True)
     messages = [str(w.message) for w in warning_list]
-    assert any("include_sensitive_fields=True" in m for m in messages)
-    assert any("'api_key'" in m and "openai-compatible-config-id" in m for m in messages)
-    assert any("'key_file'" in m and "openai-compatible-config-id" in m for m in messages)
+    assert any("include_sensitive_fields=True: returned serialization" in m for m in messages)
+    assert any(
+        "Sensitive field exported" in m
+        and "field='api_key'" in m
+        and "component_id='openai-compatible-config-id'" in m
+        for m in messages
+    )
+    assert any(
+        "Sensitive field exported" in m
+        and "field='key_file'" in m
+        and "component_id='openai-compatible-config-id'" in m
+        for m in messages
+    )
+    assert all("THIS_IS_SECRET" not in m for m in messages)
+    assert all("/etc/certs/client.key" not in m for m in messages)
 
 
 def test_no_warning_when_sensitive_fields_are_empty() -> None:
@@ -446,7 +462,9 @@ def test_no_warning_when_sensitive_fields_are_empty() -> None:
     )
     # No sensitive field values set — no per-field warnings should be emitted.
     # The opt-in warning is still expected.
-    with pytest.warns(UserWarning, match="include_sensitive_fields=True"):
+    with pytest.warns(
+        UserWarning, match="returned serialization may contain unredacted sensitive values"
+    ):
         AgentSpecSerializer().to_json(llm_config, include_sensitive_fields=True)
 
 

--- a/pyagentspec/tests/serialization/test_sensitive_fields.py
+++ b/pyagentspec/tests/serialization/test_sensitive_fields.py
@@ -388,6 +388,26 @@ def test_disaggregated_configuration_with_sensitive_fields_can_be_loaded_back(
     }
 
 
+def test_include_sensitive_fields_opt_in() -> None:
+    llm_config = OpenAiCompatibleConfig(
+        name="openai-compatible-config",
+        id="openai-compatible-config-id",
+        url="https://api.closedai.com/v2",
+        model_id="gpt-7",
+        api_key="THIS_IS_SECRET",
+        key_file="/etc/certs/client.key",
+    )
+    serialized = AgentSpecSerializer().to_json(llm_config, include_sensitive_fields=True)
+    assert "THIS_IS_SECRET" in serialized
+    assert "/etc/certs/client.key" in serialized
+    assert "$component_ref" not in serialized
+
+    deserialized = AgentSpecDeserializer().from_json(serialized)
+    assert isinstance(deserialized, OpenAiCompatibleConfig)
+    assert deserialized.api_key == "THIS_IS_SECRET"
+    assert deserialized.key_file == "/etc/certs/client.key"
+
+
 def test_partial_configurations_exclude_secrets():
     partial_llm_config = {
         "name": "openai-compatible-config",

--- a/tsagentspec/src/serialization/builtin-serialization-plugin.ts
+++ b/tsagentspec/src/serialization/builtin-serialization-plugin.ts
@@ -43,7 +43,7 @@ export class BuiltinsComponentSerializationPlugin
       if (EXCLUDED_FIELDS.has(fieldName)) continue;
 
       // Skip sensitive fields
-      if (context.isFieldSensitive(componentType, fieldName)) continue;
+      if (context.shouldRedactField(componentType, fieldName)) continue;
 
       // Skip version-gated fields
       if (context.isFieldVersionGated(componentType, fieldName)) continue;

--- a/tsagentspec/src/serialization/builtin-serialization-plugin.ts
+++ b/tsagentspec/src/serialization/builtin-serialization-plugin.ts
@@ -6,6 +6,7 @@
  */
 import { BUILTIN_SCHEMA_MAP } from "../component-registry.js";
 import type { ComponentBase } from "../component.js";
+import { isSensitiveField } from "../sensitive-field.js";
 import type { ComponentSerializationPlugin } from "./serialization-plugin.js";
 import type { SerializationContext } from "./serialization-context.js";
 import { OPAQUE_FIELDS, sanitizeOpaqueField, type SerializedFields } from "./types.js";
@@ -20,6 +21,19 @@ const EXCLUDED_FIELDS = new Set(["componentType"]);
 const MODEL_OBJECT_FIELDS: Record<string, boolean> = {
   defaultGenerationParameters: true, // LlmGenerationConfig - exclude nulls
 };
+
+function hasSerializedSensitiveValue(value: unknown): boolean {
+  if (value === null || value === undefined || value === false || value === "") {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  if (typeof value === "object") {
+    return Object.keys(value as Record<string, unknown>).length > 0;
+  }
+  return true;
+}
 
 export class BuiltinsComponentSerializationPlugin
   implements ComponentSerializationPlugin
@@ -42,6 +56,8 @@ export class BuiltinsComponentSerializationPlugin
       // Skip internal fields
       if (EXCLUDED_FIELDS.has(fieldName)) continue;
 
+      const sensitiveField = isSensitiveField(componentType, fieldName);
+
       // Skip sensitive fields
       if (context.shouldRedactField(componentType, fieldName)) continue;
 
@@ -49,6 +65,18 @@ export class BuiltinsComponentSerializationPlugin
       if (context.isFieldVersionGated(componentType, fieldName)) continue;
 
       const snakeName = context.toSerializedFieldName(fieldName);
+
+      if (
+        context.includeSensitiveFields &&
+        sensitiveField &&
+        hasSerializedSensitiveValue(fieldValue)
+      ) {
+        console.warn(
+          `Sensitive field exported: component_id=${JSON.stringify(component.id)}, ` +
+            `field=${JSON.stringify(snakeName)}. Review the serialized value before ` +
+            "storing or sharing the output.",
+        );
+      }
 
       // Handle model object fields specially (convert keys, optionally exclude nulls)
       if (

--- a/tsagentspec/src/serialization/serialization-context.ts
+++ b/tsagentspec/src/serialization/serialization-context.ts
@@ -62,6 +62,7 @@ function isProperty(value: unknown): value is Property {
 export class SerializationContext {
   agentspecVersion: AgentSpecVersion;
   camelCase: boolean;
+  includeSensitiveFields: boolean;
   private componentTypesToPlugins: Map<string, ComponentSerializationPlugin>;
   private resolvedComponents: Map<string, SerializedDict> = new Map();
   private referencingStructure: Record<string, string> = {};
@@ -69,16 +70,21 @@ export class SerializationContext {
 
   constructor(
     plugins: ComponentSerializationPlugin[],
-    targetVersion?: AgentSpecVersion,
-    resolvedComponents?: Map<string, SerializedDict>,
-    componentsIdMapping?: Map<string, string>,
-    camelCase?: boolean,
+    options?: {
+      targetVersion?: AgentSpecVersion;
+      resolvedComponents?: Map<string, SerializedDict>;
+      componentsIdMapping?: Map<string, string>;
+      camelCase?: boolean;
+      includeSensitiveFields?: boolean;
+    },
   ) {
-    this.agentspecVersion = targetVersion ?? CURRENT_VERSION;
-    this.camelCase = camelCase ?? false;
+    const opts = options ?? {};
+    this.agentspecVersion = opts.targetVersion ?? CURRENT_VERSION;
+    this.camelCase = opts.camelCase ?? false;
+    this.includeSensitiveFields = opts.includeSensitiveFields ?? false;
     this.componentTypesToPlugins = this.buildComponentTypesToPlugins(plugins);
-    this.resolvedComponents = resolvedComponents ?? new Map();
-    this.componentsIdMapping = componentsIdMapping ?? new Map();
+    this.resolvedComponents = opts.resolvedComponents ?? new Map();
+    this.componentsIdMapping = opts.componentsIdMapping ?? new Map();
   }
 
   private buildComponentTypesToPlugins(
@@ -317,6 +323,7 @@ export class SerializationContext {
 
   /** Check if a field is sensitive and should be excluded */
   isFieldSensitive(componentType: string, fieldName: string): boolean {
+    if (this.includeSensitiveFields) return false;
     return isSensitiveField(componentType, fieldName);
   }
 

--- a/tsagentspec/src/serialization/serialization-context.ts
+++ b/tsagentspec/src/serialization/serialization-context.ts
@@ -322,7 +322,7 @@ export class SerializationContext {
   }
 
   /** Check if a field is sensitive and should be excluded */
-  isFieldSensitive(componentType: string, fieldName: string): boolean {
+  shouldRedactField(componentType: string, fieldName: string): boolean {
     if (this.includeSensitiveFields) return false;
     return isSensitiveField(componentType, fieldName);
   }

--- a/tsagentspec/src/serialization/serializer.ts
+++ b/tsagentspec/src/serialization/serializer.ts
@@ -42,6 +42,14 @@ export class AgentSpecSerializer {
     const useCamelCase = opts.camelCase ?? false;
     const includeSensitive = opts.includeSensitiveFields ?? false;
 
+    if (includeSensitive) {
+      console.warn(
+        "includeSensitiveFields=true was set. Serialized output may contain " +
+          "unredacted sensitive values; do not log, commit, or share it unless " +
+          "those values are intended to be exposed.",
+      );
+    }
+
     // Build ID mapping for disaggregated components
     const componentsIdMapping = new Map<string, string>();
     for (const disag of disaggregated) {

--- a/tsagentspec/src/serialization/serializer.ts
+++ b/tsagentspec/src/serialization/serializer.ts
@@ -33,12 +33,14 @@ export class AgentSpecSerializer {
       disaggregatedComponents?: ComponentBase[];
       exportDisaggregatedComponents?: boolean;
       camelCase?: boolean;
+      includeSensitiveFields?: boolean;
     },
   ): SerializedDict | [SerializedDict, DisaggregatedComponentsDict] {
     const opts = options ?? {};
     const disaggregated = opts.disaggregatedComponents ?? [];
     const exportDisag = opts.exportDisaggregatedComponents ?? false;
     const useCamelCase = opts.camelCase ?? false;
+    const includeSensitive = opts.includeSensitiveFields ?? false;
 
     // Build ID mapping for disaggregated components
     const componentsIdMapping = new Map<string, string>();
@@ -52,13 +54,11 @@ export class AgentSpecSerializer {
       if (disag === component) {
         throw new Error("Cannot disaggregate the root component");
       }
-      const disagCtx = new SerializationContext(
-        this.plugins,
-        opts.agentspecVersion,
-        undefined,
-        undefined,
-        useCamelCase,
-      );
+      const disagCtx = new SerializationContext(this.plugins, {
+        targetVersion: opts.agentspecVersion,
+        camelCase: useCamelCase,
+        includeSensitiveFields: includeSensitive,
+      });
       const dump = disagCtx.saveToDict(disag, opts.agentspecVersion);
       disaggregatedDict[disag.id] = dump;
     }
@@ -68,13 +68,13 @@ export class AgentSpecSerializer {
     for (const [id, dump] of Object.entries(disaggregatedDict)) {
       resolvedComponents.set(id, dump);
     }
-    const mainCtx = new SerializationContext(
-      this.plugins,
-      opts.agentspecVersion,
+    const mainCtx = new SerializationContext(this.plugins, {
+      targetVersion: opts.agentspecVersion,
       resolvedComponents,
       componentsIdMapping,
-      useCamelCase,
-    );
+      camelCase: useCamelCase,
+      includeSensitiveFields: includeSensitive,
+    });
     const mainDump = mainCtx.saveToDict(component, opts.agentspecVersion);
 
     if (!exportDisag) {
@@ -96,6 +96,7 @@ export class AgentSpecSerializer {
       exportDisaggregatedComponents?: boolean;
       indent?: number;
       camelCase?: boolean;
+      includeSensitiveFields?: boolean;
     },
   ): string | [string, string] {
     const indent = options?.indent ?? 2;
@@ -118,6 +119,7 @@ export class AgentSpecSerializer {
       disaggregatedComponents?: ComponentBase[];
       exportDisaggregatedComponents?: boolean;
       camelCase?: boolean;
+      includeSensitiveFields?: boolean;
     },
   ): string | [string, string] {
     const result = this._toDict(component, options);

--- a/tsagentspec/tests/serialization/sensitive-fields.test.ts
+++ b/tsagentspec/tests/serialization/sensitive-fields.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   AgentSpecSerializer,
   createAgent,
@@ -19,6 +19,10 @@ function makeLlmConfig() {
 }
 
 describe("sensitive field exclusion", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("should exclude apiKey from OpenAiCompatibleConfig", () => {
     const serializer = new AgentSpecSerializer();
     const llm = createOpenAiCompatibleConfig({
@@ -134,5 +138,55 @@ describe("sensitive field exclusion", () => {
     expect(llmDict["url"]).toBe("http://localhost");
     expect(llmDict["model_id"]).toBe("gpt-4");
     expect(llmDict["name"]).toBe("llm");
+  });
+
+  it("should include sensitive fields and warn when opt-in is set", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const serializer = new AgentSpecSerializer();
+    const llm = createOpenAiCompatibleConfig({
+      id: "llm-id",
+      name: "llm",
+      url: "http://localhost",
+      modelId: "gpt-4",
+      apiKey: "sk-secret",
+    });
+    const agent = createAgent({
+      name: "agent",
+      llmConfig: llm,
+      systemPrompt: "Hello",
+    });
+
+    const json = serializer.toJson(agent, { includeSensitiveFields: true }) as string;
+    const dict = JSON.parse(json);
+    const llmDict = dict["llm_config"] as Record<string, unknown>;
+    const messages = warnSpy.mock.calls.map(([message]) => String(message));
+
+    expect(llmDict["api_key"]).toBe("sk-secret");
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("includeSensitiveFields=true was set"),
+        expect.stringContaining(
+          'Sensitive field exported: component_id="llm-id", field="api_key"',
+        ),
+      ]),
+    );
+    expect(messages.every((message) => !message.includes("sk-secret"))).toBe(true);
+  });
+
+  it("should only warn about opt-in when no sensitive values are serialized", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const serializer = new AgentSpecSerializer();
+    const llm = createOpenAiCompatibleConfig({
+      id: "llm-id",
+      name: "llm",
+      url: "http://localhost",
+      modelId: "gpt-4",
+    });
+
+    serializer.toJson(llm, { includeSensitiveFields: true });
+
+    const messages = warnSpy.mock.calls.map(([message]) => String(message));
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain("Serialized output may contain unredacted sensitive values");
   });
 });

--- a/tsagentspec/tests/serialization/serialization-context.test.ts
+++ b/tsagentspec/tests/serialization/serialization-context.test.ts
@@ -33,10 +33,7 @@ describe("SerializationContext", () => {
     });
 
     it("should accept a custom target version", () => {
-      const ctx = new SerializationContext(
-        makeBuiltinPlugins(),
-        "0.4.0",
-      );
+      const ctx = new SerializationContext(makeBuiltinPlugins(), { targetVersion: "0.4.0" });
       expect(ctx.agentspecVersion).toBe("0.4.0");
     });
 
@@ -46,13 +43,7 @@ describe("SerializationContext", () => {
     });
 
     it("should accept camelCase option", () => {
-      const ctx = new SerializationContext(
-        makeBuiltinPlugins(),
-        undefined,
-        undefined,
-        undefined,
-        true,
-      );
+      const ctx = new SerializationContext(makeBuiltinPlugins(), { camelCase: true });
       expect(ctx.camelCase).toBe(true);
     });
 
@@ -130,13 +121,7 @@ describe("SerializationContext", () => {
     });
 
     it("should keep camelCase keys when camelCase mode is enabled", () => {
-      const ctx = new SerializationContext(
-        makeBuiltinPlugins(),
-        undefined,
-        undefined,
-        undefined,
-        true,
-      );
+      const ctx = new SerializationContext(makeBuiltinPlugins(), { camelCase: true });
       const result = ctx.dumpModelObject(
         { maxTokens: 1024, temperature: 0.7 },
         false,
@@ -182,13 +167,7 @@ describe("SerializationContext", () => {
     });
 
     it("should keep camelCase when camelCase mode is enabled", () => {
-      const ctx = new SerializationContext(
-        makeBuiltinPlugins(),
-        undefined,
-        undefined,
-        undefined,
-        true,
-      );
+      const ctx = new SerializationContext(makeBuiltinPlugins(), { camelCase: true });
       expect(ctx.toSerializedFieldName("systemPrompt")).toBe("systemPrompt");
     });
 
@@ -219,10 +198,7 @@ describe("SerializationContext", () => {
 
     it("should return true for _self version gate at old version", () => {
       // BuiltinTool has _self: V25_4_2, so at an earlier version all fields are gated
-      const ctx = new SerializationContext(
-        makeBuiltinPlugins(),
-        AgentSpecVersion.V25_4_1,
-      );
+      const ctx = new SerializationContext(makeBuiltinPlugins(), { targetVersion: AgentSpecVersion.V25_4_1 });
       expect(ctx.isFieldVersionGated("BuiltinTool", "toolType")).toBe(true);
     });
 
@@ -232,10 +208,7 @@ describe("SerializationContext", () => {
     });
 
     it("should return true for field-level version gate at old version", () => {
-      const ctx = new SerializationContext(
-        makeBuiltinPlugins(),
-        AgentSpecVersion.V25_4_1,
-      );
+      const ctx = new SerializationContext(makeBuiltinPlugins(), { targetVersion: AgentSpecVersion.V25_4_1 });
       expect(ctx.isFieldVersionGated("Agent", "toolboxes")).toBe(true);
     });
   });

--- a/tsagentspec/tests/serialization/serialization-context.test.ts
+++ b/tsagentspec/tests/serialization/serialization-context.test.ts
@@ -213,17 +213,17 @@ describe("SerializationContext", () => {
     });
   });
 
-  describe("isFieldSensitive", () => {
+  describe("shouldRedactField", () => {
     it("should return true for sensitive fields", () => {
       const ctx = new SerializationContext(makeBuiltinPlugins());
-      expect(ctx.isFieldSensitive("OpenAiCompatibleConfig", "apiKey")).toBe(
+      expect(ctx.shouldRedactField("OpenAiCompatibleConfig", "apiKey")).toBe(
         true,
       );
     });
 
     it("should return false for non-sensitive fields", () => {
       const ctx = new SerializationContext(makeBuiltinPlugins());
-      expect(ctx.isFieldSensitive("OpenAiCompatibleConfig", "modelId")).toBe(
+      expect(ctx.shouldRedactField("OpenAiCompatibleConfig", "modelId")).toBe(
         false,
       );
     });


### PR DESCRIPTION
## Summary

- Adds `includeSensitiveFields` option to `AgentSpecSerializer.toJson()`, `toYaml()` (TS) and `to_json()`, `to_yaml()`, `to_dict()` (Python)
- When set to `true`/`True`, sensitive fields (API keys, TLS certs, headers) are serialized inline instead of being redacted
- Default behaviour is unchanged — sensitive fields are still stripped/referenced unless the consumer explicitly opts in

## Changes

**TypeScript**
- `SerializationContext` constructor refactored from 6 positional args to an options object (eliminates `undefined, undefined` placeholders at call sites)
- `isFieldSensitive()` short-circuits when `includeSensitiveFields` is set
- `toJson` / `toYaml` option types updated

**Python**
- `SerializationContext` base class gains `is_field_sensitive(field_info)` method that encapsulates the flag — plugins call this instead of reading the raw flag and inverting it
- `include_sensitive_fields: bool = False` default added to the abstract base (prevents silent `AttributeError` for custom subclasses)
- `to_dict` / `to_json` / `to_yaml` overloads and implementations updated

