### PR TITLE
Bump wayflowcore dependency

### DIFF
--- a/pyagentspec/constraints/constraints.txt
+++ b/pyagentspec/constraints/constraints.txt
@@ -23,7 +23,7 @@ langchain-mcp-adapters==0.2.2
 langgraph-swarm==0.1.0
 
 # WayFlow adapter
-wayflowcore==26.2.0.dev3
+wayflowcore==26.1.2
 
 # AgentFramework adapter
 agent-framework==1.0.0b260130

--- a/pyagentspec/constraints/constraints_dev.txt
+++ b/pyagentspec/constraints/constraints_dev.txt
@@ -23,7 +23,7 @@ langchain-mcp-adapters==0.2.2
 langgraph-swarm==0.1.0
 
 # WayFlow adapter
-wayflowcore==26.2.0.dev3
+wayflowcore==26.1.2
 
 # AgentFramework adapter
 agent-framework==1.0.0b260130

--- a/pyagentspec/setup.py
+++ b/pyagentspec/setup.py
@@ -124,18 +124,16 @@ setup(
         ],
         "langgraph": LANGGRAPH_DEPS,
         "langgraph-full": LANGGRAPH_FULL_DEPS,
-        # wayflowcore 26.1.x caps starlette<0.48.0, so use the fixed
-        # WayFlow dev release until a compatible stable release is published.
         "wayflow": [
             # 3rd party dependencies (imported in code)
-            "wayflowcore>=26.2.0.dev3",
+            "wayflowcore>=26.1.2",
             # 4rth party dependencies
             "certifi>=2025.1.31; python_version < '3.14'",  # needed to avoid CVE present in earlier versions
             "cryptography>=46.0.7; python_version < '3.14'",  # needed to avoid CVE present in earlier versions
         ],
         "wayflow_oci": [
             # 3rd party dependencies (imported in code)
-            "wayflowcore[oci]>=26.2.0.dev3",
+            "wayflowcore[oci]>=26.1.2",
             # 4rth party dependencies
             "certifi>=2025.1.31; python_version < '3.14'",  # needed to avoid CVE present in earlier versions
             "cryptography>=46.0.7; python_version < '3.14'",  # needed to avoid CVE present in earlier versions
@@ -144,14 +142,14 @@ setup(
         ],
         "wayflow_a2a": [
             # 3rd party dependencies (imported in code)
-            "wayflowcore[a2a]>=26.2.0.dev3",
+            "wayflowcore[a2a]>=26.1.2",
             # 4rth party dependencies
             "certifi>=2025.1.31; python_version < '3.14'",  # needed to avoid CVE present in earlier versions
             "cryptography>=46.0.7; python_version < '3.14'",  # needed to avoid CVE present in earlier versions
         ],
         "wayflow_datastore": [
             # 3rd party dependencies (imported in code)
-            "wayflowcore[datastore]>=26.2.0.dev3",
+            "wayflowcore[datastore]>=26.1.2",
             # 4rth party dependencies
             "certifi>=2025.1.31; python_version < '3.14'",  # needed to avoid CVE present in earlier versions
             "cryptography>=46.0.7; python_version < '3.14'",  # needed to avoid CVE present in earlier versions


### PR DESCRIPTION
## Changes

  - Require `wayflowcore>=26.1.2` for the WayFlow adapter extras.
  - Pin `wayflowcore==26.1.2` in Agent Spec constraints.
  - Set the Python Agent Spec language version to `26.1.2`.
  - Move currently supported Python feature gates from `26.2.0` to `26.1.2`.
  - Add the generated `agentspec_json_spec_26_1_2.json`.
  - Add the `language_spec_26_1_2.rst` release spec page.
  - Update docs navigation so `26.1.2` is the latest release spec.
  - Leave the TypeScript SDK unchanged.