### PR TITLE
fix(agent-framework): pin supported beta install

### DIFF
--- a/pyagentspec/setup.py
+++ b/pyagentspec/setup.py
@@ -156,7 +156,11 @@ setup(
         ],
         "agent-framework": [
             # 3rd party dependencies (imported in code)
-            "agent-framework>=1.0.0b260130; python_version < '3.14'",
+            # The adapter targets this beta API. Newer agent-framework beta
+            # releases have introduced breaking changes, so keep the extra on
+            # the known-compatible package pair until the adapter is updated.
+            "agent-framework==1.0.0b260130; python_version < '3.14'",
+            "agent-framework-core==1.0.0b260130; python_version < '3.14'",
             "httpx>0.28.0; python_version < '3.14'",
             # 4rth party dependencies
             "certifi>=2025.1.31; python_version < '3.14'",  # needed to avoid CVE present in earlier versions

--- a/pyagentspec/setup.py
+++ b/pyagentspec/setup.py
@@ -160,7 +160,6 @@ setup(
             # releases have introduced breaking changes, so keep the extra on
             # the known-compatible package pair until the adapter is updated.
             "agent-framework==1.0.0b260130; python_version < '3.14'",
-            "agent-framework-core==1.0.0b260130; python_version < '3.14'",
             "httpx>0.28.0; python_version < '3.14'",
             # 4rth party dependencies
             "certifi>=2025.1.31; python_version < '3.14'",  # needed to avoid CVE present in earlier versions

--- a/pyagentspec/tests/adapters/openaiagents/conftest.py
+++ b/pyagentspec/tests/adapters/openaiagents/conftest.py
@@ -14,16 +14,11 @@ like `pyagentspec.adapters.openaiagents` and `agents` resolve during tests.
 import os
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 import pytest
 
 from ..conftest import skip_tests_if_dependency_not_installed
-
-# OpenAI Agents exports traces to api.openai.com when tracing is enabled and an
-# OPENAI_API_KEY is present. Adapter tests use a fake key, so disable SDK trace
-# export before test modules import `agents`.
-os.environ["OPENAI_AGENTS_DISABLE_TRACING"] = "1"
 
 
 def _add_path(p: Path) -> None:
@@ -51,13 +46,36 @@ if DEV_FALLBACK:
 
 
 @pytest.fixture(scope="package", autouse=True)
-def _disable_openai_agents_trace_export() -> None:
+def _disable_openai_agents_trace_export() -> Iterator[None]:
+    """
+    Disable OpenAI Agents SDK trace export while adapter tests run.
+
+    The SDK exports traces to api.openai.com when tracing is enabled and an
+    OPENAI_API_KEY is present. Adapter tests use a fake key, so keep SDK trace
+    export disabled without leaving the environment changed for later tests.
+    """
+    env_name = "OPENAI_AGENTS_DISABLE_TRACING"
+    old_value = os.environ.get(env_name)
+    os.environ[env_name] = "1"
+
     try:
         from agents import set_tracing_disabled
     except ImportError:
-        return
+        set_tracing_disabled = None
+    else:
+        set_tracing_disabled(True)
 
-    set_tracing_disabled(True)
+    try:
+        yield
+    finally:
+        if old_value is not None:
+            os.environ[env_name] = old_value
+        else:
+            os.environ.pop(env_name, None)
+
+        if set_tracing_disabled is not None:
+            tracing_disabled = os.environ.get(env_name, "false").lower() in ("1", "true")
+            set_tracing_disabled(tracing_disabled)
 
 
 def pytest_collection_modifyitems(config: Any, items: Any):

--- a/pyagentspec/tests/adapters/openaiagents/conftest.py
+++ b/pyagentspec/tests/adapters/openaiagents/conftest.py
@@ -11,11 +11,19 @@ Adds local src paths for the adapter and vendored Agents SDK so imports
 like `pyagentspec.adapters.openaiagents` and `agents` resolve during tests.
 """
 
+import os
 import sys
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from ..conftest import skip_tests_if_dependency_not_installed
+
+# OpenAI Agents exports traces to api.openai.com when tracing is enabled and an
+# OPENAI_API_KEY is present. Adapter tests use a fake key, so disable SDK trace
+# export before test modules import `agents`.
+os.environ["OPENAI_AGENTS_DISABLE_TRACING"] = "1"
 
 
 def _add_path(p: Path) -> None:
@@ -40,6 +48,16 @@ DEV_FALLBACK = (Path.cwd() / ".dev_fallback").exists()
 if DEV_FALLBACK:
     _add_path(ADAPTER_DIR / "src")
     _add_path(PYAGENTSPEC_DIR / "openai-agents-python" / "src")
+
+
+@pytest.fixture(scope="package", autouse=True)
+def _disable_openai_agents_trace_export() -> None:
+    try:
+        from agents import set_tracing_disabled
+    except ImportError:
+        return
+
+    set_tracing_disabled(True)
 
 
 def pytest_collection_modifyitems(config: Any, items: Any):


### PR DESCRIPTION
## Summary
- Pin the agent-framework extra to the known-compatible beta package
- Rely on that pinned agent-framework package to resolve the matching agent-framework-core dependency
- Leave constraints files unchanged
- Disable OpenAI Agents SDK trace export in adapter tests so the fake test API key does not trigger background posts to api.openai.com during CI

## Validation
- Fresh temp install of pyagentspec[agent-framework] without an explicit agent-framework-core requirement resolved agent-framework==1.0.0b260130 and agent-framework-core==1.0.0b260130
- pip check passed in that temp install
- Pre-commit hooks passed via shared agent-spec venv
- Targeted OpenAI Agents live/simple-flow plus security/datastore regression passed locally with the shared venv and LLM env