### PR TITLE
Add TypeScript Mastra adapter

### DIFF
--- a/examples/adapters/mastra/README.md
+++ b/examples/adapters/mastra/README.md
@@ -1,0 +1,19 @@
+# Mastra Adapter Examples
+
+These examples show two conversion directions supported by the TypeScript
+Mastra adapter:
+
+- `agentspec2mastra_tools.ts`: create an Agent Spec agent and load it into a
+  Mastra-shaped runtime with `AgentSpecLoader`
+- `mastra2agentspec_agent_with_tool.ts`: export a Mastra-style agent config to
+  Agent Spec YAML with `AgentSpecExporter`
+
+Run from the repository root after installing the TypeScript SDK dependencies:
+
+```bash
+npm --prefix tsagentspec install
+npm --prefix tsagentspec run build
+tsagentspec/node_modules/.bin/tsx examples/adapters/mastra/agentspec2mastra_tools.ts
+tsagentspec/node_modules/.bin/tsx examples/adapters/mastra/mastra2agentspec_agent_with_tool.ts
+```
+

--- a/examples/adapters/mastra/agentspec2mastra_tools.ts
+++ b/examples/adapters/mastra/agentspec2mastra_tools.ts
@@ -1,0 +1,118 @@
+/**
+ * Agent Spec -> Mastra example.
+ *
+ * Creates an Agent Spec agent, serializes it to YAML, and loads that YAML into
+ * a Mastra-shaped runtime using the TypeScript Mastra adapter.
+ */
+import {
+  AgentSpecSerializer,
+  createAgent,
+  createOpenAiCompatibleConfig,
+  createServerTool,
+  numberProperty,
+} from "../../../tsagentspec/src/index.js";
+import {
+  AgentSpecLoader,
+  type MastraAgentRuntimeConfig,
+  type MastraRuntimeAdapter,
+  type MastraToolRuntimeConfig,
+} from "../../../tsagentspec/src/adapters/mastra/index.js";
+
+type ExampleMastraTool = {
+  id: string;
+  description: string;
+  inputSchema?: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
+  execute: (input: unknown) => unknown | Promise<unknown>;
+};
+
+type ExampleMastraAgent = {
+  id: string;
+  name: string;
+  instructions: string;
+  model: unknown;
+  tools: Record<string, ExampleMastraTool>;
+};
+
+const subtractionTool = createServerTool({
+  name: "subtraction-tool",
+  description: "Subtract two numbers.",
+  inputs: [numberProperty({ title: "a" }), numberProperty({ title: "b" })],
+  outputs: [numberProperty({ title: "difference" })],
+});
+
+const llmConfig = createOpenAiCompatibleConfig({
+  name: "example-model",
+  modelId: "oci/openai.gpt-5.4-mini",
+  url: "https://example-llm-endpoint.invalid/v1",
+});
+
+const agent = createAgent({
+  name: "agentspec_mastra_subtraction_agent",
+  description: "Agent Spec agent loaded into a Mastra-shaped runtime.",
+  llmConfig,
+  systemPrompt: "Use the subtraction tool when the user asks for subtraction.",
+  tools: [subtractionTool],
+});
+
+const yaml = new AgentSpecSerializer().toYaml(agent) as string;
+
+const exampleRuntime: MastraRuntimeAdapter<
+  ExampleMastraAgent,
+  ExampleMastraTool
+> = {
+  createAgent(config: MastraAgentRuntimeConfig<ExampleMastraTool>) {
+    return {
+      id: config.id,
+      name: config.name,
+      instructions: config.instructions,
+      model: config.model,
+      tools: config.tools,
+    };
+  },
+
+  createTool(config: MastraToolRuntimeConfig) {
+    const execute = config.execute;
+    if (execute === undefined) {
+      throw new Error(`Missing executor for tool '${config.id}'.`);
+    }
+
+    return {
+      id: config.id,
+      description: config.description,
+      inputSchema: config.inputSchema,
+      outputSchema: config.outputSchema,
+      execute,
+    };
+  },
+};
+
+const loader = new AgentSpecLoader({
+  runtime: exampleRuntime,
+  toolRegistry: {
+    "subtraction-tool": (input) => {
+      const args = input as { a: number; b: number };
+      return { difference: args.a - args.b };
+    },
+  },
+});
+
+const main = async (): Promise<void> => {
+  const mastraAgent = loader.loadYaml(yaml);
+  const subtraction = mastraAgent.tools["subtraction-tool"];
+  if (subtraction === undefined) {
+    throw new Error("Expected subtraction tool to be loaded.");
+  }
+
+  const result = await subtraction.execute({ a: 987654321, b: 123456789 });
+
+  console.log("Agent Spec YAML:");
+  console.log(yaml);
+  console.log("Loaded Mastra-shaped agent:", mastraAgent.name);
+  console.log("Tool result:", result);
+};
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/examples/adapters/mastra/mastra2agentspec_agent_with_tool.ts
+++ b/examples/adapters/mastra/mastra2agentspec_agent_with_tool.ts
@@ -1,0 +1,62 @@
+/**
+ * Mastra -> Agent Spec example.
+ *
+ * Exports a serializable Mastra-style agent config into Agent Spec YAML using
+ * the TypeScript Mastra adapter.
+ */
+import {
+  AgentSpecExporter,
+} from "../../../tsagentspec/src/adapters/mastra/index.js";
+
+const mastraWeatherAgent = {
+  id: "mastra-weather-agent",
+  name: "mastra_weather_agent",
+  description: "Mastra-style weather agent exported to Agent Spec.",
+  instructions: "Use the weather tool when the user asks for current weather.",
+  metadata: {
+    framework: "mastra",
+    example: "mastra-to-agentspec",
+  },
+  model: {
+    provider: "openai-compatible",
+    modelId: "oci/openai.gpt-5.4-mini",
+    url: "https://example-llm-endpoint.invalid/v1",
+  },
+  tools: {
+    get_current_weather: {
+      id: "get_current_weather",
+      description: "Get current weather for a city.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          city: {
+            type: "string",
+            description: "City or place name.",
+          },
+        },
+        required: ["city"],
+        additionalProperties: false,
+      },
+      outputSchema: {
+        type: "object",
+        properties: {
+          weather_report: {
+            type: "string",
+            description: "Weather report for the requested city.",
+          },
+        },
+        required: ["weather_report"],
+        additionalProperties: false,
+      },
+    },
+  },
+};
+
+const exporter = new AgentSpecExporter();
+const agent = exporter.toAgent(mastraWeatherAgent);
+const yaml = exporter.toYaml(mastraWeatherAgent);
+
+console.log("Exported Agent Spec agent:", agent.name);
+console.log("Exported tools:", agent.tools.map((tool) => tool.name).join(", "));
+console.log("Agent Spec YAML:");
+console.log(yaml);

--- a/tsagentspec/README.md
+++ b/tsagentspec/README.md
@@ -41,6 +41,10 @@ To consume it from another local project, add it as a local path dependency in t
 
 See the [examples](./examples/README.md) directory.
 
+## Adapters
+
+- [Mastra adapter](./docs/mastra/README.md)
+
 ## License
 
 UPL-1.0 or Apache-2.0 — see [LICENSE-UPL.txt](../LICENSE-UPL.txt) and [LICENSE-APACHE.txt](../LICENSE-APACHE.txt).

--- a/tsagentspec/docs/mastra/README.md
+++ b/tsagentspec/docs/mastra/README.md
@@ -1,0 +1,314 @@
+# Mastra Adapter
+
+The Mastra adapter connects Agent Spec's portable agent definitions with Mastra
+agent, tool, storage, and workflow runtime objects. It supports both directions:
+
+- load Agent Spec components into a Mastra runtime
+- export serializable Mastra-style agent configs back into Agent Spec YAML or JSON
+
+The adapter keeps Mastra optional at package install time. `agentspec` does not
+make `@mastra/core`, `@mastra/pg`, or other Mastra packages hard dependencies.
+When the adapter is used, the default runtime binder resolves Mastra packages
+from the consuming application.
+
+## Design
+
+Agent Spec is the portable contract. Mastra is the runtime that executes it.
+The adapter keeps those responsibilities separate:
+
+- Agent Spec defines the agent, model config, prompt, tools, schemas, flows, and
+  datastore configuration.
+- The adapter supplies default Mastra `Agent`, `createTool`, `createWorkflow`,
+  and `createStep` bindings for normal loading.
+- The application supplies executable behavior such as tool functions, workflow
+  node executors, storage provider packages, or custom runtime overrides.
+- Resolver hooks translate framework-specific model and tool details without
+  forcing those choices into the Agent Spec core model.
+
+This follows the same adapter shape as the Python integrations: a loader
+converts Agent Spec into a framework runtime, while an exporter converts
+framework-side configuration back into Agent Spec when the data is serializable.
+
+## Agent Spec To Mastra
+
+Use `AgentSpecLoader` when the source of truth is Agent Spec YAML, JSON, a plain
+serialized dictionary, or an already-created Agent Spec component.
+
+```ts
+import { AgentSpecLoader } from "agentspec/adapters/mastra";
+
+const mastraAgent = new AgentSpecLoader({
+  toolRegistry,
+}).loadYaml(agentSpecYaml);
+```
+
+The loader supports Agent Spec `Agent` components with:
+
+- `id`, `name`, `description`, and `metadata`
+- `systemPrompt` as Mastra instructions
+- `OpenAiConfig`, `OpenAiCompatibleConfig`, `OllamaConfig`, and `VllmConfig`
+- `ServerTool` through a user-supplied `toolRegistry`
+- tool input and output schemas as JSON Schema object descriptors
+
+For disaggregated Agent Spec configs, load referenced components first and pass
+the returned registry into the main load:
+
+```ts
+const registry = loader.loadYaml(referencedYaml, {
+  importOnlyReferencedComponents: true,
+});
+
+const mastraAgent = loader.loadYaml(mainYaml, {
+  componentsRegistry: registry,
+});
+```
+
+The loader rejects unsupported Agent features explicitly instead of silently
+dropping them.
+
+## Runtime Binding
+
+For normal use, the loader creates real Mastra agent and tool objects through
+`@mastra/core/agent` and `@mastra/core/tools`. The consuming application must
+have `@mastra/core` installed, but it does not need to pass `Agent` or
+`createTool` manually.
+
+```ts
+const loader = new AgentSpecLoader({
+  toolRegistry: {
+    lookup_account: async (input) => lookupAccount(input.accountId),
+  },
+});
+
+const mastraAgent = loader.loadYaml(agentSpecYaml);
+```
+
+Agent Spec stores the tool contract: name, description, input schema, and output
+schema. The runtime registry supplies the actual JavaScript function.
+
+Applications with custom Mastra setup can override runtime construction:
+
+```ts
+const loader = new AgentSpecLoader({
+  runtime: {
+    createAgent: (config) => new Agent({ ...config, memory }),
+    createTool: (config) => createTool(config),
+  },
+  toolRegistry,
+});
+```
+
+## Model Resolution
+
+The default model resolver maps common Agent Spec LLM configs into Mastra-style
+model targets:
+
+- `OpenAiConfig` -> `openai/<model>`
+- `OpenAiCompatibleConfig` -> `{ id, url, apiKey? }`
+- `OllamaConfig` -> `{ id: "ollama/<model>", url, apiKey? }`
+- `VllmConfig` -> `{ id: "vllm/<model>", url, apiKey? }`
+
+Applications can provide `modelResolver` when they need a different Mastra model
+binding, provider-specific object, headers, custom endpoint handling, fallback
+models, or organization-specific model naming.
+
+## Tools
+
+The default tool resolver supports Agent Spec `ServerTool`.
+
+```ts
+const loader = new AgentSpecLoader({
+  toolRegistry: {
+    get_current_weather: async ({ city }) => getWeather(city),
+  },
+});
+```
+
+The resolver looks up tools by name first, because that is the identifier the
+LLM sees. It also accepts the Agent Spec tool id as a fallback for applications
+that use stable internal identifiers.
+
+Runtime-specific retrieval, vector stores, and embedding pipelines are not
+modeled as first-class Mastra adapter concepts. They can still be exposed
+portably as ordinary tools, with the actual retrieval implementation provided by
+the target runtime.
+
+## Mastra To Agent Spec
+
+Use `AgentSpecExporter` when the source is a Mastra-style config or an object
+previously created by the adapter.
+
+```ts
+import { AgentSpecExporter } from "agentspec/adapters/mastra";
+
+const yaml = new AgentSpecExporter(exportOptions).toYaml(weatherAgent);
+```
+
+The exporter has five entry points:
+
+- `toAgent`
+- `toFlow`
+- `toComponent`
+- `toJson`
+- `toYaml`
+
+The lossless path is provenance-based: objects created by the adapter keep the
+original Agent Spec component under `sourceAgentSpecAgent`,
+`sourceAgentSpecFlow`, or `sourceAgentSpecTool`.
+
+For native Mastra-like objects, export is intentionally conservative. The object
+must expose serializable fields such as:
+
+- `name`
+- `description`
+- `metadata`
+- string `instructions` or `systemPrompt`
+- a simple model id or model config object
+- plain tool maps with JSON Schema input and output descriptors
+
+Dynamic runtime functions, Zod-only schemas, model fallback arrays, and opaque
+native workflow objects are rejected unless the caller provides an explicit
+export hook.
+
+## Export Hooks
+
+Use hooks for framework-specific values that cannot be inferred safely:
+
+```ts
+const exporter = new AgentSpecExporter({
+  nativeModelExporter(model) {
+    return createOpenAiCompatibleConfig({
+      name: "runtime-model",
+      modelId: model.modelId,
+      url: "runtime://langgraph/default-llm",
+    });
+  },
+
+  nativeToolExporter(tool, context) {
+    if (tool.kind !== "mcp") {
+      return undefined;
+    }
+
+    return createMCPTool({
+      name: tool.name ?? context.toolName,
+      clientTransport: createStdioTransport({
+        command: "python",
+        args: ["weather_mcp_server.py"],
+      }),
+    });
+  },
+});
+```
+
+## Datastores And Storage
+
+The adapter maps Agent Spec datastores into Mastra storage targets. Store
+construction loads the resolved Mastra package/export by default:
+
+- `InMemoryCollectionDatastore` -> `@mastra/core/storage` `InMemoryStore`
+- `PostgresDatabaseDatastore` -> `@mastra/pg` `PostgresStore`
+
+```ts
+import { createMastraStorageBundle } from "agentspec/adapters/mastra";
+
+const storageBundle = createMastraStorageBundle(datastore, {
+  schemaName: "AGENTSPEC",
+});
+```
+
+The bundle includes:
+
+- `target`: the resolved datastore target
+- `storage`: the constructed storage instance
+- `mastraConfig`: `{ storage }` for a Mastra app
+- `memoryConfig`: `{ storage }` for Mastra memory
+
+`OracleDatabaseDatastore` remains an Agent Spec core datastore type, but this
+adapter does not map it to a Mastra storage package until Mastra publishes an
+official OracleDB storage provider.
+
+## Flow Conversion
+
+`convertAgentSpecFlowToMastraWorkflow` converts simple linear Agent Spec flows
+into Mastra workflow runtime configs.
+
+Supported linear shape:
+
+```text
+StartNode -> LlmNode/ToolNode/AgentNode... -> EndNode
+```
+
+The converter rejects branching, cycles, disconnected nodes, unsupported node
+types, and ambiguous execution paths. This keeps workflow conversion exact
+rather than turning a complex Agent Spec graph into an approximate Mastra
+workflow.
+
+LLM and Agent nodes require caller-supplied executor registries because prompt
+execution and agent handoff are runtime behavior:
+
+```ts
+const workflow = convertAgentSpecFlowToMastraWorkflow(flow, {
+  llmNodeRegistry,
+  agentNodeRegistry,
+  toolRegistry,
+});
+```
+
+Applications with custom workflow construction can provide `runtime`.
+
+## Unsupported Cases
+
+The adapter intentionally fails fast for unsupported cases instead of silently
+dropping fields or producing partial runtime behavior.
+
+Current limitations include:
+
+- non-server local tool execution modes that do not map cleanly to Mastra tools
+- MCP toolbox runtime loading into Mastra MCP clients
+- Agent Spec swarm, manager-worker, specialized-agent, remote-agent, and A2A
+  roots
+- advanced non-linear flow graphs
+- framework-specific vector and semantic-memory semantics
+
+## Examples
+
+Small examples are available under:
+
+```text
+examples/adapters/mastra
+```
+
+They cover:
+
+- Agent Spec agent -> Mastra-shaped runtime
+- Mastra-style agent config -> Agent Spec YAML
+
+## Test Coverage
+
+The adapter tests cover:
+
+- Agent Spec agent loading into Mastra
+- default Mastra runtime binding
+- tool registry binding
+- tool schema conversion
+- unsupported tool and agent feature failures
+- model resolution
+- Mastra-style config export
+- provenance-based round trips
+- datastore target resolution
+- in-memory and Postgres storage bundle construction
+- explicit unsupported handling for Oracle datastores
+- linear flow planning
+- Agent Spec flow to Mastra workflow conversion
+
+## Next Steps
+
+- Add Agent Spec-level vector and semantic-memory configuration.
+- Map Agent Spec vector and memory concepts into Mastra vector stores and memory providers.
+- Add MCP toolbox loading into Mastra MCP client/runtime setup.
+- Add richer local, remote, and MCP tool support.
+- Add multi-agent mapping for swarms, manager-worker patterns, specialized agents, remote agents, and A2A agents.
+- Expand workflow conversion beyond linear flows.
+- Support branching, conditional routing, parallel execution, map nodes, nested flows, and error handling nodes.
+- Add validation helpers for the Mastra-supported Agent Spec subset.
+- Add clearer diagnostics and conversion reports for unsupported fields.

--- a/tsagentspec/package-lock.json
+++ b/tsagentspec/package-lock.json
@@ -25,6 +25,18 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@mastra/core": "^1.45.0",
+        "@mastra/pg": "^1.14.0"
+      },
+      "peerDependenciesMeta": {
+        "@mastra/core": {
+          "optional": true
+        },
+        "@mastra/pg": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/tsagentspec/package.json
+++ b/tsagentspec/package.json
@@ -28,6 +28,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./adapters/mastra": {
+      "types": "./dist/adapters/mastra/index.d.ts",
+      "import": "./dist/adapters/mastra/index.js",
+      "require": "./dist/adapters/mastra/index.cjs"
     }
   },
   "files": [
@@ -44,6 +49,18 @@
   "dependencies": {
     "yaml": "^2.8.3",
     "zod": "^3.23.0"
+  },
+  "peerDependencies": {
+    "@mastra/core": "^1.45.0",
+    "@mastra/pg": "^1.14.0"
+  },
+  "peerDependenciesMeta": {
+    "@mastra/core": {
+      "optional": true
+    },
+    "@mastra/pg": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",

--- a/tsagentspec/src/adapters/mastra/agentspec-converter.ts
+++ b/tsagentspec/src/adapters/mastra/agentspec-converter.ts
@@ -1,0 +1,620 @@
+import { AgentSchema, createAgent, type Agent } from "../../agents/index.js";
+import { FlowSchema, type Flow } from "../../flows/index.js";
+import {
+  createOllamaConfig,
+  createOpenAiCompatibleConfig,
+  createOpenAiConfig,
+  createVllmConfig,
+  LlmConfigUnion,
+  type LlmConfig,
+} from "../../llms/index.js";
+import {
+  propertyFromJsonSchema,
+  type JsonSchemaValue,
+  type Property,
+} from "../../property.js";
+import {
+  createBuiltinTool,
+  createServerTool,
+  ToolUnion,
+  type Tool,
+} from "../../tools/index.js";
+import { UnsupportedMastraExportError } from "./errors.js";
+
+export type AgentSpecExportedComponent = Agent | Flow;
+
+export type MastraModelExportContext = {
+  agentName?: string;
+};
+
+export type MastraToolExportContext = {
+  toolName: string;
+  tool: unknown;
+};
+
+export type MastraToAgentSpecConversionOptions = {
+  nativeModelExporter?: (
+    model: unknown,
+    context: MastraModelExportContext,
+  ) => LlmConfig;
+  nativeToolExporter?: (
+    tool: unknown,
+    context: MastraToolExportContext,
+  ) => Tool | undefined;
+  defaultModelName?: string;
+  nativeModelBaseUrls?: Record<string, string | undefined>;
+  includeModelApiKey?: boolean;
+};
+
+export class MastraToAgentSpecConverter {
+  private readonly options: MastraToAgentSpecConversionOptions;
+
+  constructor(options: MastraToAgentSpecConversionOptions = {}) {
+    this.options = options;
+  }
+
+  convert(input: unknown): AgentSpecExportedComponent {
+    const agent = this.tryExportAgent(input);
+    if (agent) {
+      return agent;
+    }
+
+    const flow = this.tryExportFlow(input);
+    if (flow) {
+      return flow;
+    }
+
+    throw new UnsupportedMastraExportError(
+      "Cannot export Mastra object to Agent Spec. Provide an adapter-created object with Agent Spec provenance, or a simple serializable native agent config.",
+    );
+  }
+
+  toAgent(input: unknown): Agent {
+    const agent = this.tryExportAgent(input);
+    if (!agent) {
+      throw new UnsupportedMastraExportError(
+        "Cannot export Mastra agent to Agent Spec. Runtime-only agents without Agent Spec provenance or serializable native config are unsupported.",
+      );
+    }
+    return agent;
+  }
+
+  toFlow(input: unknown): Flow {
+    const flow = this.tryExportFlow(input);
+    if (!flow) {
+      throw new UnsupportedMastraExportError(
+        "Cannot export Mastra workflow to Agent Spec. Workflow export currently requires adapter-created Agent Spec flow provenance.",
+      );
+    }
+    return flow;
+  }
+
+  private tryExportAgent(input: unknown): Agent | undefined {
+    // Provenance is the lossless path: objects produced by this adapter keep the
+    // original Agent Spec component attached to their runtime config.
+    const sourceAgent = findAgentSpecAgent(input);
+    if (sourceAgent) {
+      return sourceAgent;
+    }
+
+    // Native Mastra export is intentionally narrower. We only accept plain,
+    // serializable config objects that can be represented in Agent Spec.
+    const nativeConfig = resolveNativeAgentConfig(input);
+    if (!nativeConfig) {
+      return undefined;
+    }
+
+    return this.exportNativeAgent(nativeConfig);
+  }
+
+  private tryExportFlow(input: unknown): Flow | undefined {
+    return findAgentSpecFlow(input);
+  }
+
+  private exportNativeAgent(config: Record<string, unknown>): Agent {
+    const name = requiredString(config["name"], "native Mastra agent name");
+    const instructions = requiredString(
+      config["instructions"] ?? config["systemPrompt"],
+      `native Mastra agent '${name}' instructions`,
+    );
+    const metadata = optionalRecord(
+      config["metadata"],
+      `native Mastra agent '${name}' metadata`,
+    );
+    const model = this.exportNativeModel(config["model"] ?? config["llmConfig"], {
+      agentName: name,
+    });
+    const tools = this.exportNativeTools(config["tools"]);
+
+    return createAgent({
+      name,
+      id: optionalString(config["id"]),
+      description: optionalString(config["description"]),
+      metadata,
+      llmConfig: model,
+      systemPrompt: instructions,
+      tools,
+    });
+  }
+
+  private exportNativeModel(
+    model: unknown,
+    context: MastraModelExportContext,
+  ): LlmConfig {
+    if (this.options.nativeModelExporter) {
+      return this.options.nativeModelExporter(model, context);
+    }
+
+    // If the caller already gave us an Agent Spec LLM config, keep it as-is.
+    const parsed = LlmConfigUnion.safeParse(model);
+    if (parsed.success) {
+      return parsed.data;
+    }
+
+    if (typeof model === "function") {
+      throw new UnsupportedMastraExportError(
+        "Cannot export dynamic Mastra model resolver functions to Agent Spec.",
+      );
+    }
+
+    if (Array.isArray(model)) {
+      throw new UnsupportedMastraExportError(
+        "Cannot export Mastra model fallback arrays to a single Agent Spec LLM config.",
+      );
+    }
+
+    if (typeof model === "string") {
+      return this.exportModelId(model, {});
+    }
+
+    if (isRecord(model)) {
+      const provider = optionalString(model["provider"]);
+      const modelId =
+        optionalString(model["id"]) ??
+        optionalString(model["modelId"]) ??
+        optionalString(model["model"]) ??
+        optionalString(model["name"]);
+      const url =
+        optionalString(model["url"]) ??
+        optionalString(model["baseUrl"]) ??
+        optionalString(model["baseURL"]);
+      const apiKey = this.options.includeModelApiKey
+        ? optionalString(model["apiKey"])
+        : undefined;
+
+      if (!modelId) {
+        throw new UnsupportedMastraExportError(
+          "Cannot export native Mastra model object without a string id/model/name.",
+        );
+      }
+
+      return this.exportModelId(modelId, { provider, url, apiKey });
+    }
+
+    throw new UnsupportedMastraExportError(
+      "Cannot export native Mastra model. Use Agent Spec provenance or provide nativeModelExporter.",
+    );
+  }
+
+  private exportModelId(
+    modelId: string,
+    options: {
+      provider?: string;
+      url?: string;
+      apiKey?: string;
+    },
+  ): LlmConfig {
+    const parsed = parseProviderModelId(modelId, options.provider);
+    const provider = parsed.provider;
+    const id = parsed.modelId;
+    const name = this.options.defaultModelName ?? "mastra-native-model";
+    const url =
+      options.url ??
+      this.options.nativeModelBaseUrls?.[provider] ??
+      this.options.nativeModelBaseUrls?.["openai-compatible"];
+
+    if (provider === "openai") {
+      return createOpenAiConfig({
+        name,
+        modelId: id,
+        apiKey: options.apiKey,
+      });
+    }
+
+    if (provider === "ollama" && url) {
+      return createOllamaConfig({
+        name,
+        modelId: id,
+        url,
+        apiKey: options.apiKey,
+      });
+    }
+
+    if (provider === "vllm" && url) {
+      return createVllmConfig({
+        name,
+        modelId: id,
+        url,
+        apiKey: options.apiKey,
+      });
+    }
+
+    if (url) {
+      return createOpenAiCompatibleConfig({
+        name,
+        modelId: id,
+        url,
+        apiKey: options.apiKey,
+      });
+    }
+
+    throw new UnsupportedMastraExportError(
+      `Cannot export native Mastra model '${modelId}'. Only OpenAI model ids are portable without a base URL.`,
+    );
+  }
+
+  private exportNativeTools(toolsInput: unknown): Tool[] {
+    if (toolsInput === undefined || toolsInput === null) {
+      return [];
+    }
+
+    if (Array.isArray(toolsInput)) {
+      return toolsInput.map((tool, index) =>
+        this.exportNativeTool(tool, `tool_${index + 1}`),
+      );
+    }
+
+    if (!isRecord(toolsInput)) {
+      throw new UnsupportedMastraExportError(
+        "Cannot export native Mastra tools unless tools are provided as an array or object map.",
+      );
+    }
+
+    return Object.entries(toolsInput).map(([toolName, tool]) =>
+      this.exportNativeTool(tool, toolName),
+    );
+  }
+
+  private exportNativeTool(tool: unknown, fallbackName: string): Tool {
+    // Runtime-created tools from the loader carry their source Agent Spec tool,
+    // which is safer than reconstructing the contract from runtime fields.
+    const sourceTool = findAgentSpecTool(tool);
+    if (sourceTool) {
+      return sourceTool;
+    }
+
+    const custom = this.options.nativeToolExporter?.(tool, {
+      toolName: fallbackName,
+      tool,
+    });
+    if (custom) {
+      return custom;
+    }
+
+    const parsed = ToolUnion.safeParse(tool);
+    if (parsed.success) {
+      return parsed.data;
+    }
+
+    if (!isRecord(tool)) {
+      throw new UnsupportedMastraExportError(
+        `Cannot export native Mastra tool '${fallbackName}' without a serializable tool descriptor.`,
+      );
+    }
+
+    const toolConfig = isRecord(tool["config"])
+      ? (tool["config"] as Record<string, unknown>)
+      : tool;
+    const name =
+      optionalString(toolConfig["name"]) ??
+      optionalString(toolConfig["id"]) ??
+      fallbackName;
+    const description = optionalString(toolConfig["description"]);
+    const metadata = optionalRecord(
+      toolConfig["metadata"],
+      `native Mastra tool '${name}' metadata`,
+    );
+    const requiresConfirmation = optionalBoolean(
+      toolConfig["requiresConfirmation"] ?? toolConfig["requireApproval"],
+      `native Mastra tool '${name}' requireApproval`,
+    );
+    const inputs = jsonSchemaToProperties(toolConfig["inputSchema"], name);
+    const outputs = jsonSchemaToProperties(toolConfig["outputSchema"], name);
+    const toolType = optionalString(toolConfig["toolType"]);
+
+    // A plain `toolType` describes a runtime-provided tool. Without it, the
+    // portable representation is a ServerTool backed by a runtime registry.
+    if (toolType) {
+      return createBuiltinTool({
+        name,
+        id: optionalString(toolConfig["id"]),
+        description,
+        metadata,
+        toolType,
+        configuration: optionalRecord(
+          toolConfig["configuration"],
+          `native Mastra tool '${name}' configuration`,
+        ),
+        executorName: optionalExecutorName(toolConfig["executorName"]),
+        toolVersion: optionalString(toolConfig["toolVersion"]),
+        inputs,
+        outputs,
+        requiresConfirmation,
+      });
+    }
+
+    return createServerTool({
+      name,
+      id: optionalString(toolConfig["id"]),
+      description,
+      metadata,
+      inputs,
+      outputs,
+      requiresConfirmation,
+    });
+  }
+}
+
+const findAgentSpecAgent = (input: unknown): Agent | undefined => {
+  const direct = parseAgent(input);
+  if (direct) {
+    return direct;
+  }
+
+  return findByComponentType(input, "Agent", parseAgent);
+};
+
+const findAgentSpecFlow = (input: unknown): Flow | undefined => {
+  const direct = parseFlow(input);
+  if (direct) {
+    return direct;
+  }
+
+  return findByComponentType(input, "Flow", parseFlow);
+};
+
+const findAgentSpecTool = (input: unknown): Tool | undefined => {
+  const parsed = ToolUnion.safeParse(input);
+  if (parsed.success) {
+    return parsed.data;
+  }
+
+  return findByComponentType(input, undefined, (value) => {
+    const result = ToolUnion.safeParse(value);
+    return result.success ? result.data : undefined;
+  });
+};
+
+const parseAgent = (input: unknown): Agent | undefined => {
+  const parsed = AgentSchema.safeParse(input);
+  return parsed.success ? parsed.data : undefined;
+};
+
+const parseFlow = (input: unknown): Flow | undefined => {
+  const parsed = FlowSchema.safeParse(input);
+  return parsed.success ? parsed.data : undefined;
+};
+
+const findByComponentType = <T>(
+  input: unknown,
+  componentType: string | undefined,
+  parse: (value: unknown) => T | undefined,
+): T | undefined => {
+  // Adapter-created objects usually tuck provenance under config/source fields.
+  // Keep the search shallow so arbitrary runtime objects are not walked forever.
+  const visited = new Set<unknown>();
+  const queue: Array<{ value: unknown; depth: number }> = [
+    { value: input, depth: 0 },
+  ];
+
+  while (queue.length > 0) {
+    const { value, depth } = queue.shift()!;
+    if (!isRecord(value) || visited.has(value)) {
+      continue;
+    }
+    visited.add(value);
+
+    if (
+      (componentType === undefined || value["componentType"] === componentType) &&
+      depth > 0
+    ) {
+      const parsed = parse(value);
+      if (parsed) {
+        return parsed;
+      }
+    }
+
+    if (depth >= 3) {
+      continue;
+    }
+
+    for (const key of [
+      "sourceAgentSpecAgent",
+      "sourceAgentSpecFlow",
+      "sourceAgentSpecTool",
+      "config",
+      "source",
+      "rawConfig",
+    ]) {
+      const next = value[key];
+      if (next !== undefined) {
+        queue.push({ value: next, depth: depth + 1 });
+      }
+    }
+  }
+
+  return undefined;
+};
+
+const resolveNativeAgentConfig = (
+  input: unknown,
+): Record<string, unknown> | undefined => {
+  if (!isRecord(input)) {
+    return undefined;
+  }
+
+  if (isNativeAgentConfig(input)) {
+    return input;
+  }
+
+  const config = input["config"];
+  if (isRecord(config) && isNativeAgentConfig(config)) {
+    return config;
+  }
+
+  return undefined;
+};
+
+const isNativeAgentConfig = (value: Record<string, unknown>): boolean =>
+  typeof value["name"] === "string" &&
+  (value["instructions"] !== undefined || value["systemPrompt"] !== undefined) &&
+  (value["model"] !== undefined || value["llmConfig"] !== undefined);
+
+const parseProviderModelId = (
+  modelId: string,
+  explicitProvider?: string,
+): { provider: string; modelId: string } => {
+  if (explicitProvider) {
+    return { provider: explicitProvider.toLowerCase(), modelId };
+  }
+
+  const separator = modelId.indexOf("/");
+  if (separator <= 0 || separator === modelId.length - 1) {
+    return { provider: "openai", modelId };
+  }
+
+  return {
+    provider: modelId.slice(0, separator).toLowerCase(),
+    modelId: modelId.slice(separator + 1),
+  };
+};
+
+const jsonSchemaToProperties = (
+  schemaInput: unknown,
+  fallbackTitle: string,
+): Property[] | undefined => {
+  const schema = extractJsonSchema(schemaInput);
+  if (!schema) {
+    return undefined;
+  }
+
+  if (schema["type"] === "object" && isRecord(schema["properties"])) {
+    return Object.entries(schema["properties"]).map(([name, propertySchema]) => {
+      if (!isRecord(propertySchema)) {
+        throw new UnsupportedMastraExportError(
+          `Cannot export JSON schema property '${name}' because it is not an object schema.`,
+        );
+      }
+      return propertyFromJsonSchema({
+        title: name,
+        ...propertySchema,
+      });
+    });
+  }
+
+  return [
+    propertyFromJsonSchema({
+      title: fallbackTitle,
+      ...schema,
+    }),
+  ];
+};
+
+const extractJsonSchema = (schemaInput: unknown): JsonSchemaValue | undefined => {
+  if (schemaInput === undefined || schemaInput === null) {
+    return undefined;
+  }
+
+  if (isRecord(schemaInput) && isRecord(schemaInput["jsonSchema"])) {
+    return schemaInput["jsonSchema"] as JsonSchemaValue;
+  }
+
+  if (isRecord(schemaInput) && isRecord(schemaInput["_def"])) {
+    throw new UnsupportedMastraExportError(
+      "Cannot export Zod runtime schemas from native Mastra tools. Provide JSON Schema or nativeToolExporter.",
+    );
+  }
+
+  if (isRecord(schemaInput)) {
+    return schemaInput as JsonSchemaValue;
+  }
+
+  throw new UnsupportedMastraExportError(
+    "Cannot export native Mastra tool schema unless it is JSON Schema.",
+  );
+};
+
+const requiredString = (value: unknown, label: string): string => {
+  if (typeof value === "function") {
+    throw new UnsupportedMastraExportError(
+      `Cannot export ${label} because it is a runtime function.`,
+    );
+  }
+  if (typeof value !== "string" || value.length === 0) {
+    throw new UnsupportedMastraExportError(
+      `Cannot export ${label}; expected a non-empty string.`,
+    );
+  }
+  return value;
+};
+
+const optionalString = (value: unknown): string | undefined =>
+  typeof value === "string" && value.length > 0 ? value : undefined;
+
+const optionalBoolean = (
+  value: unknown,
+  label: string,
+): boolean | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value === "function") {
+    throw new UnsupportedMastraExportError(
+      `Cannot export ${label} because it is a runtime function.`,
+    );
+  }
+  if (typeof value !== "boolean") {
+    throw new UnsupportedMastraExportError(
+      `Cannot export ${label}; expected a boolean.`,
+    );
+  }
+  return value;
+};
+
+const optionalRecord = (
+  value: unknown,
+  label: string,
+): Record<string, unknown> | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value === "function") {
+    throw new UnsupportedMastraExportError(
+      `Cannot export ${label} because it is a runtime function.`,
+    );
+  }
+  if (!isRecord(value)) {
+    throw new UnsupportedMastraExportError(
+      `Cannot export ${label}; expected an object.`,
+    );
+  }
+  return value;
+};
+
+const optionalExecutorName = (value: unknown): string | string[] | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Array.isArray(value) && value.every((item) => typeof item === "string")) {
+    return value;
+  }
+  throw new UnsupportedMastraExportError(
+    "Cannot export native Mastra built-in tool executorName; expected string or string array.",
+  );
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);

--- a/tsagentspec/src/adapters/mastra/agentspec-exporter.ts
+++ b/tsagentspec/src/adapters/mastra/agentspec-exporter.ts
@@ -1,0 +1,50 @@
+import type { Agent } from "../../agents/index.js";
+import type { Flow } from "../../flows/index.js";
+import { AgentSpecSerializer } from "../../serialization/index.js";
+import {
+  MastraToAgentSpecConverter,
+  type AgentSpecExportedComponent,
+  type MastraToAgentSpecConversionOptions,
+} from "./agentspec-converter.js";
+
+export type AgentSpecExporterOptions = MastraToAgentSpecConversionOptions;
+
+export class AgentSpecExporter {
+  private readonly serializer: AgentSpecSerializer;
+  private readonly converter: MastraToAgentSpecConverter;
+
+  constructor(options: AgentSpecExporterOptions = {}) {
+    this.serializer = new AgentSpecSerializer();
+    this.converter = new MastraToAgentSpecConverter(options);
+  }
+
+  get runtimeToAgentSpecConverter(): MastraToAgentSpecConverter {
+    return this.converter;
+  }
+
+  toComponent(input: unknown): AgentSpecExportedComponent {
+    return this.converter.convert(input);
+  }
+
+  toAgent(input: unknown): Agent {
+    return this.converter.toAgent(input);
+  }
+
+  toFlow(input: unknown): Flow {
+    return this.converter.toFlow(input);
+  }
+
+  toJson(
+    input: unknown,
+    options?: Parameters<AgentSpecSerializer["toJson"]>[1],
+  ): ReturnType<AgentSpecSerializer["toJson"]> {
+    return this.serializer.toJson(this.toComponent(input), options);
+  }
+
+  toYaml(
+    input: unknown,
+    options?: Parameters<AgentSpecSerializer["toYaml"]>[1],
+  ): ReturnType<AgentSpecSerializer["toYaml"]> {
+    return this.serializer.toYaml(this.toComponent(input), options);
+  }
+}

--- a/tsagentspec/src/adapters/mastra/agentspec-loader.ts
+++ b/tsagentspec/src/adapters/mastra/agentspec-loader.ts
@@ -1,0 +1,162 @@
+import { AgentSchema, type Agent } from "../../agents/index.js";
+import type { ComponentBase } from "../../component.js";
+import {
+  AgentSpecDeserializer,
+  type ComponentsRegistry,
+  type DisaggregatedComponentsDict,
+  type SerializedDict,
+} from "../../serialization/index.js";
+import { AgentSpecToMastraConverter } from "./mastra-converter.js";
+import { InvalidMastraAgentSpecError } from "./errors.js";
+import type { AgentSpecToMastraConversionOptions } from "./types.js";
+
+export type AgentSpecDeserializeOptions = {
+  componentsRegistry?: ComponentsRegistry;
+  importOnlyReferencedComponents?: boolean;
+  camelCase?: boolean;
+};
+
+export type AgentSpecReferencedComponentsOptions =
+  AgentSpecDeserializeOptions & {
+    importOnlyReferencedComponents: true;
+  };
+
+export type AgentSpecMainComponentOptions =
+  AgentSpecDeserializeOptions & {
+    importOnlyReferencedComponents?: false;
+  };
+
+export type AgentSpecLoaderOptions<
+  TAgent = unknown,
+  TTool = unknown,
+> = AgentSpecToMastraConversionOptions<TAgent, TTool> & {
+  deserializer?: AgentSpecDeserializer;
+};
+
+export class AgentSpecLoader<TAgent = unknown, TTool = unknown> {
+  private readonly deserializer: AgentSpecDeserializer;
+  private readonly converter: AgentSpecToMastraConverter<TAgent, TTool>;
+
+  constructor(options: AgentSpecLoaderOptions<TAgent, TTool> = {}) {
+    const { deserializer, ...conversionOptions } = options;
+    this.deserializer = deserializer ?? new AgentSpecDeserializer();
+    this.converter = new AgentSpecToMastraConverter(conversionOptions);
+  }
+
+  loadJson(
+    json: string,
+    options: AgentSpecReferencedComponentsOptions,
+  ): ComponentsRegistry;
+
+  loadJson(
+    json: string,
+    options?: AgentSpecMainComponentOptions,
+  ): TAgent;
+
+  loadJson(
+    json: string,
+    options?: AgentSpecDeserializeOptions,
+  ): TAgent | ComponentsRegistry {
+    return this.loadDeserialized(this.deserializer.fromJson(json, options), options);
+  }
+
+  loadYaml(
+    yaml: string,
+    options: AgentSpecReferencedComponentsOptions,
+  ): ComponentsRegistry;
+
+  loadYaml(
+    yaml: string,
+    options?: AgentSpecMainComponentOptions,
+  ): TAgent;
+
+  loadYaml(
+    yaml: string,
+    options?: AgentSpecDeserializeOptions,
+  ): TAgent | ComponentsRegistry {
+    return this.loadDeserialized(this.deserializer.fromYaml(yaml, options), options);
+  }
+
+  loadDict(
+    dict: SerializedDict | DisaggregatedComponentsDict,
+    options: AgentSpecReferencedComponentsOptions,
+  ): ComponentsRegistry;
+
+  loadDict(
+    dict: SerializedDict | DisaggregatedComponentsDict,
+    options?: AgentSpecMainComponentOptions,
+  ): TAgent;
+
+  loadDict(
+    dict: SerializedDict | DisaggregatedComponentsDict,
+    options?: AgentSpecDeserializeOptions,
+  ): TAgent | ComponentsRegistry {
+    return this.loadDeserialized(
+      this.deserializer.fromJson(JSON.stringify(dict), options),
+      options,
+    );
+  }
+
+  loadComponent(component: ComponentBase): TAgent;
+
+  loadComponent(component: Record<string, ComponentBase>): ComponentsRegistry;
+
+  loadComponent(
+    component: ComponentBase | Record<string, ComponentBase>,
+  ): TAgent | ComponentsRegistry {
+    if (!isComponentBase(component)) {
+      return toComponentsRegistry(component);
+    }
+
+    return this.converter.convert(assertAgent(component));
+  }
+
+  private loadDeserialized(
+    component: ComponentBase | Record<string, ComponentBase>,
+    options?: AgentSpecDeserializeOptions,
+  ): TAgent | ComponentsRegistry {
+    if (options?.importOnlyReferencedComponents) {
+      if (isComponentBase(component)) {
+        throw new InvalidMastraAgentSpecError(
+          "Expected referenced Agent Spec components, but received a root component.",
+        );
+      }
+      return toComponentsRegistry(component);
+    }
+
+    if (!isComponentBase(component)) {
+      throw new InvalidMastraAgentSpecError(
+        "Expected a root Agent component, but received a component registry.",
+      );
+    }
+
+    return this.loadComponent(component);
+  }
+}
+
+const assertAgent = (
+  component: ComponentBase,
+): Agent => {
+  if (component.componentType !== "Agent") {
+    throw new InvalidMastraAgentSpecError(
+      `Expected a root Agent component, but received ${component.componentType}.`,
+    );
+  }
+
+  return AgentSchema.parse(component);
+};
+
+const toComponentsRegistry = (
+  components: Record<string, ComponentBase>,
+): ComponentsRegistry => new Map(Object.entries(components));
+
+const isComponentBase = (
+  value: ComponentBase | Record<string, ComponentBase>,
+): value is ComponentBase => {
+  const candidate = value as Partial<ComponentBase>;
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.name === "string" &&
+    typeof candidate.componentType === "string"
+  );
+};

--- a/tsagentspec/src/adapters/mastra/datastores.ts
+++ b/tsagentspec/src/adapters/mastra/datastores.ts
@@ -1,0 +1,103 @@
+import type {
+  InMemoryCollectionDatastore,
+  OracleDatabaseDatastore,
+  PostgresDatabaseDatastore,
+  TlsPostgresDatabaseConnectionConfig,
+} from "../../datastores/index.js";
+import { UnsupportedMastraDatastoreError } from "./errors.js";
+import type {
+  AgentSpecMastraDatastore,
+  MastraDatastoreTarget,
+  MastraDatastoreTargetOptions,
+  MastraInMemoryDatastoreTarget,
+  MastraPostgresDatastoreTarget,
+  MastraPostgresSslTarget,
+  MastraPostgresStoreConfig,
+} from "./types.js";
+
+type MastraDatastoreCandidate =
+  | AgentSpecMastraDatastore
+  | OracleDatabaseDatastore;
+
+export const resolveMastraDatastore = (
+  datastore: MastraDatastoreCandidate,
+  options: MastraDatastoreTargetOptions = {},
+): MastraDatastoreTarget => {
+  if (datastore.componentType === "InMemoryCollectionDatastore") {
+    return resolveInMemoryDatastore(datastore, options);
+  }
+
+  if (datastore.componentType === "PostgresDatabaseDatastore") {
+    return resolvePostgresDatastore(datastore, options);
+  }
+
+  throw new UnsupportedMastraDatastoreError(datastore.componentType);
+};
+
+export const resolveInMemoryDatastore = (
+  datastore: InMemoryCollectionDatastore,
+  options: MastraDatastoreTargetOptions = {},
+): MastraInMemoryDatastoreTarget => {
+  const id = options.id ?? datastore.id;
+
+  return {
+    provider: "in-memory",
+    packageName: "@mastra/core/storage",
+    exportName: "InMemoryStore",
+    id,
+    datastoreSchema: datastore.datastoreSchema,
+    config: { id },
+  };
+};
+
+export const resolvePostgresDatastore = (
+  datastore: PostgresDatabaseDatastore,
+  options: MastraDatastoreTargetOptions = {},
+): MastraPostgresDatastoreTarget => {
+  const id = options.id ?? datastore.id;
+  const connection = datastore.connectionConfig;
+  // Datastore resolvers only build an import/config target. They should never
+  // open sockets, run migrations, or require the Mastra provider package.
+  const config: MastraPostgresStoreConfig = {
+    id,
+    connectionString: connection.url,
+    user: connection.user,
+    password: connection.password,
+    ssl: resolvePostgresSslTarget(connection),
+    ...storageRuntimeOptions(options),
+  };
+
+  return {
+    provider: "postgres",
+    packageName: "@mastra/pg",
+    exportName: "PostgresStore",
+    id,
+    datastoreSchema: datastore.datastoreSchema,
+    config,
+  };
+};
+
+const resolvePostgresSslTarget = (
+  connection: TlsPostgresDatabaseConnectionConfig,
+): MastraPostgresSslTarget => {
+  if (connection.sslmode === "disable") {
+    return false;
+  }
+
+  return {
+    mode: connection.sslmode,
+    ...(connection.sslcert ? { certPath: connection.sslcert } : {}),
+    ...(connection.sslkey ? { keyPath: connection.sslkey } : {}),
+    ...(connection.sslrootcert ? { rootCertPath: connection.sslrootcert } : {}),
+    ...(connection.sslcrl ? { crlPath: connection.sslcrl } : {}),
+  };
+};
+
+const storageRuntimeOptions = (
+  options: MastraDatastoreTargetOptions,
+): Pick<MastraPostgresStoreConfig, "schemaName" | "disableInit"> => ({
+  ...(options.schemaName ? { schemaName: options.schemaName } : {}),
+  ...(options.disableInit === undefined
+    ? {}
+    : { disableInit: options.disableInit }),
+});

--- a/tsagentspec/src/adapters/mastra/errors.ts
+++ b/tsagentspec/src/adapters/mastra/errors.ts
@@ -1,0 +1,94 @@
+export class MastraAdapterError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MastraAdapterError";
+  }
+}
+
+export class UnsupportedMastraDatastoreError extends MastraAdapterError {
+  constructor(componentType: string) {
+    super(`Unsupported Agent Spec datastore for Mastra adapter: ${componentType}`);
+    this.name = "UnsupportedMastraDatastoreError";
+  }
+}
+
+export class MissingMastraRuntimeDependencyError extends MastraAdapterError {
+  constructor(packageName: string, exportName: string) {
+    super(
+      `Mastra runtime dependency is required: install '${packageName}' with export '${exportName}', or pass a custom runtime to the Mastra adapter.`,
+    );
+    this.name = "MissingMastraRuntimeDependencyError";
+  }
+}
+
+export class UnsupportedMastraModelError extends MastraAdapterError {
+  constructor(componentType: string) {
+    super(`Unsupported Agent Spec LLM config for Mastra adapter: ${componentType}`);
+    this.name = "UnsupportedMastraModelError";
+  }
+}
+
+export class UnsupportedMastraToolError extends MastraAdapterError {
+  constructor(componentType: string) {
+    super(`Unsupported Agent Spec tool for Mastra adapter: ${componentType}`);
+    this.name = "UnsupportedMastraToolError";
+  }
+}
+
+export class MissingMastraToolExecutorError extends MastraAdapterError {
+  constructor(toolName: string) {
+    super(
+      `ServerTool '${toolName}' requires an executor in the Mastra toolRegistry.`,
+    );
+    this.name = "MissingMastraToolExecutorError";
+  }
+}
+
+export class DuplicateMastraToolNameError extends MastraAdapterError {
+  constructor(toolName: string) {
+    super(`Duplicate Agent Spec tool name cannot be mapped to Mastra: ${toolName}`);
+    this.name = "DuplicateMastraToolNameError";
+  }
+}
+
+export class UnsupportedMastraAgentFeatureError extends MastraAdapterError {
+  constructor(feature: string) {
+    super(`Unsupported Agent Spec agent feature for Mastra adapter: ${feature}`);
+    this.name = "UnsupportedMastraAgentFeatureError";
+  }
+}
+
+export class InvalidMastraAgentSpecError extends MastraAdapterError {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidMastraAgentSpecError";
+  }
+}
+
+export class UnsupportedMastraFlowNodeError extends MastraAdapterError {
+  constructor(componentType: string) {
+    super(`Unsupported Agent Spec flow node for Mastra adapter: ${componentType}`);
+    this.name = "UnsupportedMastraFlowNodeError";
+  }
+}
+
+export class UnsupportedMastraFlowShapeError extends MastraAdapterError {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnsupportedMastraFlowShapeError";
+  }
+}
+
+export class MissingMastraFlowNodeExecutorError extends MastraAdapterError {
+  constructor(nodeName: string) {
+    super(`Flow node '${nodeName}' requires an executor for Mastra conversion.`);
+    this.name = "MissingMastraFlowNodeExecutorError";
+  }
+}
+
+export class UnsupportedMastraExportError extends MastraAdapterError {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnsupportedMastraExportError";
+  }
+}

--- a/tsagentspec/src/adapters/mastra/flow-converter.ts
+++ b/tsagentspec/src/adapters/mastra/flow-converter.ts
@@ -1,0 +1,161 @@
+import type { Flow, Node } from "../../flows/index.js";
+import {
+  MissingMastraFlowNodeExecutorError,
+  UnsupportedMastraFlowNodeError,
+} from "./errors.js";
+import { createDefaultMastraWorkflowRuntime } from "./runtime.js";
+import { defaultMastraModelResolver } from "./model.js";
+import type {
+  AgentSpecFlowToMastraWorkflowConversionOptions,
+  MastraFlowNodeExecutor,
+  MastraFlowNodeExecutorRegistry,
+  MastraModelResolver,
+  MastraToolResolver,
+  MastraWorkflowRuntimeAdapter,
+  MastraWorkflowStepRuntimeConfig,
+} from "./types.js";
+import { defaultMastraToolResolver } from "./tool.js";
+import { propertiesToMastraJsonSchema } from "./tool.js";
+import { planLinearMastraFlow } from "./flow-planner.js";
+
+export class AgentSpecFlowToMastraWorkflowConverter<
+  TWorkflow = unknown,
+  TStep = unknown,
+> {
+  private readonly runtime: MastraWorkflowRuntimeAdapter<TWorkflow, TStep>;
+  private readonly modelResolver: MastraModelResolver;
+  private readonly toolResolver: MastraToolResolver;
+  private readonly options: AgentSpecFlowToMastraWorkflowConversionOptions<
+    TWorkflow,
+    TStep
+  >;
+
+  constructor(
+    options: AgentSpecFlowToMastraWorkflowConversionOptions<TWorkflow, TStep>,
+  ) {
+    this.runtime =
+      options.runtime ??
+      createDefaultMastraWorkflowRuntime<TWorkflow, TStep>(
+        options.defaultRuntime,
+      );
+    this.modelResolver = options.modelResolver ?? defaultMastraModelResolver;
+    this.toolResolver = options.toolResolver ?? defaultMastraToolResolver;
+    this.options = options;
+  }
+
+  convert(flow: Flow): TWorkflow {
+    const plan = planLinearMastraFlow(flow);
+    let workflow = this.runtime.createWorkflow({
+      id: flow.id,
+      name: flow.name,
+      ...(flow.description ? { description: flow.description } : {}),
+      metadata: flow.metadata,
+      inputSchema: propertiesToMastraJsonSchema(flow.inputs),
+      outputSchema: propertiesToMastraJsonSchema(flow.outputs),
+      steps: [],
+      sourceAgentSpecFlow: flow,
+      plan,
+    });
+
+    for (const node of plan.executableNodes) {
+      const step = this.runtime.createStep(this.resolveStep(flow, node));
+      workflow = this.runtime.addStep(workflow, step);
+    }
+
+    return this.runtime.commitWorkflow(workflow);
+  }
+
+  private resolveStep(
+    flow: Flow,
+    node: (ReturnType<typeof planLinearMastraFlow>)["executableNodes"][number],
+  ): MastraWorkflowStepRuntimeConfig {
+    if (node.componentType === "LlmNode") {
+      // Prompt execution is runtime behavior, not static Agent Spec data. The
+      // registry lets callers bind their own Mastra step implementation.
+      const executor = resolveNodeExecutor(this.options.llmNodeRegistry, node);
+      const model = this.modelResolver(node.llmConfig, {});
+      return {
+        id: node.name,
+        name: node.name,
+        kind: "llm",
+        ...(node.description ? { description: node.description } : {}),
+        inputSchema: propertiesToMastraJsonSchema(node.inputs),
+        outputSchema: propertiesToMastraJsonSchema(node.outputs),
+        execute: wrapNodeExecutor(flow, node, executor),
+        sourceAgentSpecNode: node,
+        model,
+        promptTemplate: node.promptTemplate,
+        metadata: node.metadata,
+      };
+    }
+
+    if (node.componentType === "ToolNode") {
+      // ToolNode reuses the same tool resolver as agents so server-tool behavior
+      // stays consistent across agent and workflow conversion.
+      const tool = this.toolResolver(node.tool, {
+        toolRegistry: this.options.toolRegistry,
+      });
+      return {
+        id: node.name,
+        name: node.name,
+        kind: "tool",
+        ...(node.description ? { description: node.description } : {}),
+        inputSchema: propertiesToMastraJsonSchema(node.inputs),
+        outputSchema: propertiesToMastraJsonSchema(node.outputs),
+        execute: (input, mastraContext) => tool.execute?.(input, mastraContext),
+        sourceAgentSpecNode: node,
+        metadata: node.metadata,
+      };
+    }
+
+    if (node.componentType === "AgentNode") {
+      // Agent handoff can mean different things in different Mastra apps, so the
+      // caller supplies the executable behavior explicitly.
+      const executor = resolveNodeExecutor(this.options.agentNodeRegistry, node);
+      return {
+        id: node.name,
+        name: node.name,
+        kind: "agent",
+        ...(node.description ? { description: node.description } : {}),
+        inputSchema: propertiesToMastraJsonSchema(node.inputs),
+        outputSchema: propertiesToMastraJsonSchema(node.outputs),
+        execute: wrapNodeExecutor(flow, node, executor),
+        sourceAgentSpecNode: node,
+        metadata: node.metadata,
+      };
+    }
+
+    throw new UnsupportedMastraFlowNodeError("unknown");
+  }
+}
+
+export const convertAgentSpecFlowToMastraWorkflow = <
+  TWorkflow = unknown,
+  TStep = unknown,
+>(
+  flow: Flow,
+  options: AgentSpecFlowToMastraWorkflowConversionOptions<TWorkflow, TStep>,
+): TWorkflow => new AgentSpecFlowToMastraWorkflowConverter(options).convert(flow);
+
+const resolveNodeExecutor = (
+  registry: MastraFlowNodeExecutorRegistry | undefined,
+  node: Node,
+): MastraFlowNodeExecutor => {
+  const executor = registry?.[node.name] ?? registry?.[node.id];
+  if (!executor) {
+    throw new MissingMastraFlowNodeExecutorError(node.name);
+  }
+  return executor;
+};
+
+const wrapNodeExecutor = (
+  flow: Flow,
+  node: Node,
+  executor: MastraFlowNodeExecutor,
+): MastraWorkflowStepRuntimeConfig["execute"] =>
+  (input, mastraContext) =>
+    executor(input, {
+      flow,
+      node,
+      mastraContext,
+    });

--- a/tsagentspec/src/adapters/mastra/flow-planner.ts
+++ b/tsagentspec/src/adapters/mastra/flow-planner.ts
@@ -1,0 +1,128 @@
+import type { Flow, Node } from "../../flows/index.js";
+import {
+  UnsupportedMastraFlowNodeError,
+  UnsupportedMastraFlowShapeError,
+} from "./errors.js";
+
+export type MastraLinearFlowPlan = {
+  flowId: string;
+  nodeOrder: Node[];
+  executableNodes: Array<Extract<Node, { componentType: "LlmNode" | "ToolNode" | "AgentNode" }>>;
+  startNode: Extract<Node, { componentType: "StartNode" }>;
+  endNode: Extract<Node, { componentType: "EndNode" }>;
+};
+
+const SUPPORTED_NODE_TYPES = new Set<string>([
+  "StartNode",
+  "LlmNode",
+  "ToolNode",
+  "AgentNode",
+  "EndNode",
+]);
+
+export const planLinearMastraFlow = (flow: Flow): MastraLinearFlowPlan => {
+  const nodes = flow.nodes as Node[];
+  const startNodeRef = flow.startNode as Node;
+
+  for (const node of nodes) {
+    if (!SUPPORTED_NODE_TYPES.has(node.componentType)) {
+      throw new UnsupportedMastraFlowNodeError(node.componentType);
+    }
+  }
+
+  const nodesById = new Map(nodes.map((node) => [node.id, node]));
+  const startNode = nodesById.get(startNodeRef.id);
+  if (!startNode || startNode.componentType !== "StartNode") {
+    throw new UnsupportedMastraFlowShapeError(
+      "Linear Mastra flow requires a StartNode as the flow start node.",
+    );
+  }
+
+  const outgoingByNodeId = new Map<string, typeof flow.controlFlowConnections>();
+  for (const edge of flow.controlFlowConnections) {
+    const fromNode = edge.fromNode as Node;
+    const edges = outgoingByNodeId.get(fromNode.id) ?? [];
+    edges.push(edge);
+    outgoingByNodeId.set(fromNode.id, edges);
+  }
+
+  const nodeOrder: Node[] = [];
+  const executableNodes: MastraLinearFlowPlan["executableNodes"] = [];
+  const visited = new Set<string>();
+  let current: Node = startNode;
+
+  // Walk one `next` edge at a time. Anything branched, cyclic, or disconnected
+  // is rejected so the converted workflow has the same shape as the source flow.
+  while (true) {
+    if (visited.has(current.id)) {
+      throw new UnsupportedMastraFlowShapeError(
+        `Linear Mastra flow cannot contain cycles. Revisited node '${current.name}'.`,
+      );
+    }
+    visited.add(current.id);
+    nodeOrder.push(current);
+
+    if (isExecutableNode(current)) {
+      executableNodes.push(current);
+    }
+
+    if (current.componentType === "EndNode") {
+      break;
+    }
+
+    const outgoing = outgoingByNodeId.get(current.id) ?? [];
+    if (outgoing.length !== 1) {
+      throw new UnsupportedMastraFlowShapeError(
+        `Linear Mastra flow requires exactly one outgoing edge from '${current.name}', found ${outgoing.length}.`,
+      );
+    }
+
+    const [edge] = outgoing;
+    if (edge!.fromBranch && edge!.fromBranch !== "next") {
+      throw new UnsupportedMastraFlowShapeError(
+        `Linear Mastra flow does not support branch '${edge!.fromBranch}' from '${current.name}'.`,
+      );
+    }
+
+    const toNode = edge!.toNode as Node;
+    const next = nodesById.get(toNode.id);
+    if (!next) {
+      throw new UnsupportedMastraFlowShapeError(
+        `Flow edge '${edge!.name}' points to a node outside the flow.`,
+      );
+    }
+    current = next;
+  }
+
+  if (visited.size !== nodes.length) {
+    const unreachable = nodes
+      .filter((node) => !visited.has(node.id))
+      .map((node) => node.name)
+      .sort();
+    throw new UnsupportedMastraFlowShapeError(
+      `Linear Mastra flow cannot contain disconnected or branched nodes: ${unreachable.join(", ")}.`,
+    );
+  }
+
+  const endNode = current;
+  if (endNode.componentType !== "EndNode") {
+    throw new UnsupportedMastraFlowShapeError(
+      "Linear Mastra flow must terminate at an EndNode.",
+    );
+  }
+
+  return {
+    flowId: flow.id,
+    nodeOrder,
+    executableNodes,
+    startNode,
+    endNode,
+  };
+};
+
+const isExecutableNode = (
+  node: Node,
+): node is MastraLinearFlowPlan["executableNodes"][number] =>
+  node.componentType === "LlmNode" ||
+  node.componentType === "ToolNode" ||
+  node.componentType === "AgentNode";

--- a/tsagentspec/src/adapters/mastra/index.ts
+++ b/tsagentspec/src/adapters/mastra/index.ts
@@ -1,0 +1,130 @@
+export {
+  resolveMastraDatastore,
+  resolveInMemoryDatastore,
+  resolvePostgresDatastore,
+} from "./datastores.js";
+
+export {
+  constructMastraDatastore,
+  createMastraAppStorageConfig,
+  createMastraMemoryStorageConfig,
+  createMastraStorageBundle,
+} from "./storage.js";
+
+export {
+  createDefaultMastraRuntime,
+  createDefaultMastraWorkflowRuntime,
+} from "./runtime.js";
+
+export {
+  AgentSpecToMastraConverter,
+  convertAgentSpecToMastraAgent,
+} from "./mastra-converter.js";
+
+export {
+  AgentSpecFlowToMastraWorkflowConverter,
+  convertAgentSpecFlowToMastraWorkflow,
+} from "./flow-converter.js";
+
+export {
+  MastraToAgentSpecConverter,
+} from "./agentspec-converter.js";
+
+export { AgentSpecExporter } from "./agentspec-exporter.js";
+
+export { planLinearMastraFlow } from "./flow-planner.js";
+
+export { AgentSpecLoader } from "./agentspec-loader.js";
+
+export { defaultMastraModelResolver } from "./model.js";
+
+export {
+  defaultMastraToolResolver,
+  propertiesToMastraJsonSchema,
+} from "./tool.js";
+
+export {
+  MastraAdapterError,
+  DuplicateMastraToolNameError,
+  InvalidMastraAgentSpecError,
+  MissingMastraFlowNodeExecutorError,
+  MissingMastraRuntimeDependencyError,
+  MissingMastraToolExecutorError,
+  UnsupportedMastraAgentFeatureError,
+  UnsupportedMastraDatastoreError,
+  UnsupportedMastraFlowNodeError,
+  UnsupportedMastraFlowShapeError,
+  UnsupportedMastraModelError,
+  UnsupportedMastraExportError,
+  UnsupportedMastraToolError,
+} from "./errors.js";
+
+export type {
+  AgentSpecMastraDatastore,
+  DatastoreSchema,
+  MastraDatastoreProvider,
+  MastraDatastoreTargetOptions,
+  MastraInMemoryStoreConfig,
+  MastraPostgresSslTarget,
+  MastraPostgresStoreConfig,
+  MastraInMemoryDatastoreTarget,
+  MastraPostgresDatastoreTarget,
+  MastraDatastoreTarget,
+} from "./types.js";
+
+export type {
+  MastraAgentRuntimeConfig,
+  AgentSpecFlowToMastraWorkflowConversionOptions,
+  AgentSpecToMastraConversionOptions,
+  MastraFlowNodeExecutor,
+  MastraFlowNodeExecutorContext,
+  MastraFlowNodeExecutorRegistry,
+  MastraModelResolver,
+  MastraModelResolverContext,
+  MastraModelTarget,
+  MastraModelTargetConfig,
+  MastraRuntimeAdapter,
+  MastraServerToolExecutor,
+  MastraToolExecutorContext,
+  MastraToolRegistry,
+  MastraToolResolver,
+  MastraToolResolverContext,
+  MastraToolRuntimeConfig,
+  MastraWorkflowRuntimeAdapter,
+  MastraWorkflowRuntimeConfig,
+  MastraWorkflowStepKind,
+  MastraWorkflowStepRuntimeConfig,
+} from "./types.js";
+
+export type {
+  AgentSpecDeserializeOptions,
+  AgentSpecMainComponentOptions,
+  AgentSpecLoaderOptions,
+  AgentSpecReferencedComponentsOptions,
+} from "./agentspec-loader.js";
+
+export type {
+  AgentSpecExportedComponent,
+  MastraModelExportContext,
+  MastraToolExportContext,
+  MastraToAgentSpecConversionOptions,
+} from "./agentspec-converter.js";
+
+export type { AgentSpecExporterOptions } from "./agentspec-exporter.js";
+
+export type {
+  MastraAppStorageConfig,
+  MastraMemoryStorageConfig,
+  MastraStorageBundle,
+  MastraStoreConstructor,
+  MastraStoreRuntime,
+} from "./storage.js";
+
+export type {
+  MastraDefaultWorkflowRuntimeOptions,
+  MastraDefaultRuntimeOptions,
+  MastraRuntimeModule,
+  MastraRuntimeModuleLoader,
+} from "./types.js";
+
+export type { MastraLinearFlowPlan } from "./flow-planner.js";

--- a/tsagentspec/src/adapters/mastra/mastra-converter.ts
+++ b/tsagentspec/src/adapters/mastra/mastra-converter.ts
@@ -1,0 +1,80 @@
+import type { Agent } from "../../agents/index.js";
+import {
+  DuplicateMastraToolNameError,
+  UnsupportedMastraAgentFeatureError,
+} from "./errors.js";
+import { createDefaultMastraRuntime } from "./runtime.js";
+import { defaultMastraModelResolver } from "./model.js";
+import type {
+  AgentSpecToMastraConversionOptions,
+  MastraModelResolver,
+  MastraRuntimeAdapter,
+  MastraToolRegistry,
+  MastraToolResolver,
+} from "./types.js";
+import { defaultMastraToolResolver } from "./tool.js";
+
+export class AgentSpecToMastraConverter<TAgent = unknown, TTool = unknown> {
+  private readonly runtime: MastraRuntimeAdapter<TAgent, TTool>;
+  private readonly modelResolver: MastraModelResolver;
+  private readonly toolResolver: MastraToolResolver;
+  private readonly toolRegistry?: MastraToolRegistry;
+
+  constructor(options: AgentSpecToMastraConversionOptions<TAgent, TTool> = {}) {
+    this.runtime =
+      options.runtime ??
+      createDefaultMastraRuntime<TAgent, TTool>(options.defaultRuntime);
+    this.modelResolver = options.modelResolver ?? defaultMastraModelResolver;
+    this.toolResolver = options.toolResolver ?? defaultMastraToolResolver;
+    this.toolRegistry = options.toolRegistry;
+  }
+
+  convert(agent: Agent): TAgent {
+    assertSupportedAgent(agent);
+
+    const model = this.modelResolver(agent.llmConfig, { agent });
+    const tools: Record<string, TTool> = {};
+
+    // Mastra tools are keyed by name at runtime, so duplicate Agent Spec tool
+    // names would silently overwrite each other if we did not stop here.
+    for (const tool of agent.tools) {
+      if (Object.prototype.hasOwnProperty.call(tools, tool.name)) {
+        throw new DuplicateMastraToolNameError(tool.name);
+      }
+
+      const toolConfig = this.toolResolver(tool, {
+        agent,
+        toolRegistry: this.toolRegistry,
+      });
+      tools[tool.name] = this.runtime.createTool(toolConfig);
+    }
+
+    return this.runtime.createAgent({
+      id: agent.id,
+      name: agent.name,
+      ...(agent.description ? { description: agent.description } : {}),
+      metadata: agent.metadata,
+      instructions: agent.systemPrompt,
+      model,
+      tools,
+      sourceAgentSpecAgent: agent,
+    });
+  }
+}
+
+export const convertAgentSpecToMastraAgent = <TAgent = unknown, TTool = unknown>(
+  agent: Agent,
+  options: AgentSpecToMastraConversionOptions<TAgent, TTool> = {},
+): TAgent => new AgentSpecToMastraConverter(options).convert(agent);
+
+const assertSupportedAgent = (agent: Agent): void => {
+  // These features need explicit Mastra mappings rather than being dropped
+  // during conversion.
+  if (agent.toolboxes.length > 0) {
+    throw new UnsupportedMastraAgentFeatureError("Agent.toolboxes");
+  }
+
+  if (agent.transforms.length > 0) {
+    throw new UnsupportedMastraAgentFeatureError("Agent.transforms");
+  }
+};

--- a/tsagentspec/src/adapters/mastra/model.ts
+++ b/tsagentspec/src/adapters/mastra/model.ts
@@ -1,0 +1,68 @@
+import type { LlmConfig } from "../../llms/index.js";
+import { UnsupportedMastraModelError } from "./errors.js";
+import type { MastraModelResolver, MastraModelTarget } from "./types.js";
+
+export const defaultMastraModelResolver: MastraModelResolver = (
+  llmConfig: LlmConfig,
+  _context,
+): MastraModelTarget => {
+  switch (llmConfig.componentType) {
+    case "OpenAiConfig":
+      return llmConfig.apiKey
+        ? { id: withProviderPrefix("openai", llmConfig.modelId), apiKey: llmConfig.apiKey }
+        : withProviderPrefix("openai", llmConfig.modelId);
+
+    case "OpenAiCompatibleConfig":
+      return modelConfig(
+        withOpenAiCompatiblePrefix(llmConfig.modelId),
+        llmConfig.url,
+        llmConfig.apiKey,
+      );
+
+    case "OllamaConfig":
+      return modelConfig(
+        withProviderPrefix("ollama", llmConfig.modelId),
+        llmConfig.url,
+        llmConfig.apiKey,
+      );
+
+    case "VllmConfig":
+      return modelConfig(
+        withProviderPrefix("vllm", llmConfig.modelId),
+        llmConfig.url,
+        llmConfig.apiKey,
+      );
+
+    case "OciGenAiConfig":
+      throw new UnsupportedMastraModelError(llmConfig.componentType);
+  }
+};
+
+const modelConfig = (
+  id: string,
+  url: string,
+  apiKey?: string,
+): MastraModelTarget => ({
+  id,
+  url,
+  ...(apiKey ? { apiKey } : {}),
+});
+
+const withProviderPrefix = (provider: string, modelId: string): string => {
+  if (modelId.includes("/")) {
+    return modelId;
+  }
+  // Mastra commonly accepts provider-qualified model ids such as
+  // `openai/gpt-4o-mini`; preserve ids that are already qualified.
+  return `${provider}/${modelId}`;
+};
+
+const withOpenAiCompatiblePrefix = (modelId: string): string => {
+  if (modelId.startsWith("openai-compatible/")) {
+    return modelId;
+  }
+
+  // Mastra parses URL-backed model targets as provider/model. Prefixing with a
+  // neutral provider keeps endpoint-specific ids like `oci/openai...` intact.
+  return `openai-compatible/${modelId}`;
+};

--- a/tsagentspec/src/adapters/mastra/runtime.ts
+++ b/tsagentspec/src/adapters/mastra/runtime.ts
@@ -1,0 +1,271 @@
+import { createRequire } from "node:module";
+
+import { MissingMastraRuntimeDependencyError } from "./errors.js";
+import type {
+  MastraAgentRuntimeConfig,
+  MastraDefaultRuntimeOptions,
+  MastraDefaultWorkflowRuntimeOptions,
+  MastraRuntimeAdapter,
+  MastraRuntimeModule,
+  MastraRuntimeModuleLoader,
+  MastraToolRuntimeConfig,
+  MastraWorkflowRuntimeAdapter,
+  MastraWorkflowRuntimeConfig,
+  MastraWorkflowStepRuntimeConfig,
+} from "./types.js";
+
+type MastraAgentConstructor = new (config: Record<string, unknown>) => unknown;
+
+type MastraCreateTool = (config: Record<string, unknown>) => unknown;
+
+type MastraCreateWorkflow = (config: Record<string, unknown>) => unknown;
+
+type MastraCreateStep = (config: Record<string, unknown>) => unknown;
+
+const DEFAULT_AGENT_PACKAGE = "@mastra/core/agent";
+const DEFAULT_AGENT_EXPORT = "Agent";
+const DEFAULT_TOOLS_PACKAGE = "@mastra/core/tools";
+const DEFAULT_CREATE_TOOL_EXPORT = "createTool";
+const DEFAULT_WORKFLOWS_PACKAGE = "@mastra/core/workflows";
+const DEFAULT_CREATE_WORKFLOW_EXPORT = "createWorkflow";
+const DEFAULT_CREATE_STEP_EXPORT = "createStep";
+
+export const createDefaultMastraRuntime = <
+  TAgent = unknown,
+  TTool = unknown,
+>(
+  options: MastraDefaultRuntimeOptions = {},
+): MastraRuntimeAdapter<TAgent, TTool> => {
+  const agentPackageName = options.agentPackageName ?? DEFAULT_AGENT_PACKAGE;
+  const agentExportName = options.agentExportName ?? DEFAULT_AGENT_EXPORT;
+  const toolsPackageName = options.toolsPackageName ?? DEFAULT_TOOLS_PACKAGE;
+  const createToolExportName =
+    options.createToolExportName ?? DEFAULT_CREATE_TOOL_EXPORT;
+  const moduleLoader = options.moduleLoader ?? loadMastraRuntimeModule;
+
+  const Agent = loadMastraRuntimeExport<MastraAgentConstructor>(
+    moduleLoader,
+    agentPackageName,
+    agentExportName,
+  );
+  const createTool = loadMastraRuntimeExport<MastraCreateTool>(
+    moduleLoader,
+    toolsPackageName,
+    createToolExportName,
+  );
+
+  return {
+    createAgent: (config) =>
+      attachProvenance(
+        new Agent(toMastraAgentConfig(config, options.agentOptions)),
+        "sourceAgentSpecAgent",
+        config.sourceAgentSpecAgent,
+      ) as TAgent,
+    createTool: (config) =>
+      attachProvenance(
+        createTool(toMastraToolConfig(config, options.toolOptions)),
+        "sourceAgentSpecTool",
+        config.sourceAgentSpecTool,
+      ) as TTool,
+  };
+};
+
+export const createDefaultMastraWorkflowRuntime = <
+  TWorkflow = unknown,
+  TStep = unknown,
+>(
+  options: MastraDefaultWorkflowRuntimeOptions = {},
+): MastraWorkflowRuntimeAdapter<TWorkflow, TStep> => {
+  const workflowsPackageName =
+    options.workflowsPackageName ?? DEFAULT_WORKFLOWS_PACKAGE;
+  const createWorkflowExportName =
+    options.createWorkflowExportName ?? DEFAULT_CREATE_WORKFLOW_EXPORT;
+  const createStepExportName =
+    options.createStepExportName ?? DEFAULT_CREATE_STEP_EXPORT;
+  const moduleLoader = options.moduleLoader ?? loadMastraRuntimeModule;
+
+  const createWorkflow = loadMastraRuntimeExport<MastraCreateWorkflow>(
+    moduleLoader,
+    workflowsPackageName,
+    createWorkflowExportName,
+  );
+  const createStep = loadMastraRuntimeExport<MastraCreateStep>(
+    moduleLoader,
+    workflowsPackageName,
+    createStepExportName,
+  );
+
+  return {
+    createWorkflow: (config) =>
+      attachProvenance(
+        createWorkflow(toMastraWorkflowConfig(config, options.workflowOptions)),
+        "sourceAgentSpecFlow",
+        config.sourceAgentSpecFlow,
+      ) as TWorkflow,
+    createStep: (config) =>
+      attachProvenance(
+        createStep(toMastraWorkflowStepConfig(config, options.stepOptions)),
+        "sourceAgentSpecNode",
+        config.sourceAgentSpecNode,
+      ) as TStep,
+    addStep: (workflow, step) =>
+      callRuntimeMethod<TWorkflow>(workflow, "then", step),
+    commitWorkflow: (workflow) =>
+      callOptionalRuntimeMethod<TWorkflow>(workflow, "commit") ?? workflow,
+  };
+};
+
+export const loadMastraRuntimeModule: MastraRuntimeModuleLoader = (packageName) => {
+  const require = createRequire(import.meta.url);
+  return require(packageName) as MastraRuntimeModule;
+};
+
+export const loadMastraRuntimeExport = <T>(
+  moduleLoader: MastraRuntimeModuleLoader,
+  packageName: string,
+  exportName: string,
+): T => {
+  let runtimeModule: MastraRuntimeModule;
+  try {
+    runtimeModule = moduleLoader(packageName);
+  } catch {
+    throw new MissingMastraRuntimeDependencyError(packageName, exportName);
+  }
+
+  const exported =
+    runtimeModule[exportName] ??
+    (isRecord(runtimeModule["default"])
+      ? runtimeModule["default"][exportName]
+      : undefined);
+
+  if (typeof exported !== "function") {
+    throw new MissingMastraRuntimeDependencyError(packageName, exportName);
+  }
+
+  return exported as T;
+};
+
+const toMastraAgentConfig = <TTool>(
+  config: MastraAgentRuntimeConfig<TTool>,
+  agentOptions: Record<string, unknown> | undefined,
+): Record<string, unknown> => ({
+  ...agentOptions,
+  id: config.id,
+  name: config.name,
+  description: config.description,
+  metadata: config.metadata,
+  instructions: config.instructions,
+  model: config.model,
+  tools: config.tools,
+});
+
+const toMastraToolConfig = (
+  config: MastraToolRuntimeConfig,
+  toolOptions: Record<string, unknown> | undefined,
+): Record<string, unknown> => ({
+  ...toolOptions,
+  id: config.id,
+  description: config.description,
+  inputSchema: config.inputSchema,
+  outputSchema: config.outputSchema,
+  requireApproval: config.requireApproval,
+  execute: config.execute,
+});
+
+const toMastraWorkflowConfig = <TStep>(
+  config: MastraWorkflowRuntimeConfig<TStep>,
+  workflowOptions: Record<string, unknown> | undefined,
+): Record<string, unknown> => ({
+  ...workflowOptions,
+  id: config.id,
+  name: config.name,
+  description: config.description,
+  metadata: config.metadata,
+  inputSchema: config.inputSchema,
+  outputSchema: config.outputSchema,
+});
+
+const toMastraWorkflowStepConfig = (
+  config: MastraWorkflowStepRuntimeConfig,
+  stepOptions: Record<string, unknown> | undefined,
+): Record<string, unknown> => ({
+  ...stepOptions,
+  id: config.id,
+  name: config.name,
+  description: config.description,
+  inputSchema: config.inputSchema,
+  outputSchema: config.outputSchema,
+  execute: async (params: unknown) =>
+    config.execute(resolveStepInput(params), params),
+  metadata: {
+    ...config.metadata,
+    kind: config.kind,
+    ...(config.model ? { model: config.model } : {}),
+    ...(config.promptTemplate
+      ? { promptTemplate: config.promptTemplate }
+      : {}),
+  },
+});
+
+const resolveStepInput = (params: unknown): unknown =>
+  isRecord(params) && "inputData" in params ? params["inputData"] : params;
+
+const callRuntimeMethod = <T>(
+  target: T,
+  methodName: string,
+  ...args: unknown[]
+): T => {
+  if (!isRecord(target) && typeof target !== "function") {
+    throw new MissingMastraRuntimeDependencyError("runtime object", methodName);
+  }
+
+  const method = (target as Record<string, unknown>)[methodName];
+  if (typeof method !== "function") {
+    throw new MissingMastraRuntimeDependencyError("runtime object", methodName);
+  }
+
+  return method.apply(target, args) as T;
+};
+
+const callOptionalRuntimeMethod = <T>(
+  target: T,
+  methodName: string,
+): T | undefined => {
+  if (!isRecord(target) && typeof target !== "function") {
+    return undefined;
+  }
+
+  const method = (target as Record<string, unknown>)[methodName];
+  if (typeof method !== "function") {
+    return undefined;
+  }
+
+  return method.call(target) as T;
+};
+
+const attachProvenance = (
+  target: unknown,
+  key: string,
+  value: unknown,
+): unknown => {
+  if (!isObjectLike(target)) {
+    return target;
+  }
+
+  try {
+    Object.defineProperty(target, key, {
+      value,
+      configurable: true,
+    });
+  } catch {
+    return target;
+  }
+
+  return target;
+};
+
+const isObjectLike = (value: unknown): value is object =>
+  (typeof value === "object" && value !== null) || typeof value === "function";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);

--- a/tsagentspec/src/adapters/mastra/storage.ts
+++ b/tsagentspec/src/adapters/mastra/storage.ts
@@ -1,0 +1,122 @@
+import { resolveMastraDatastore } from "./datastores.js";
+import {
+  loadMastraRuntimeExport,
+  loadMastraRuntimeModule,
+} from "./runtime.js";
+import type {
+  AgentSpecMastraDatastore,
+  MastraDatastoreTarget,
+  MastraDatastoreTargetOptions,
+  MastraRuntimeModuleLoader,
+} from "./types.js";
+
+export type MastraStoreConstructor<
+  TStore = unknown,
+  TConfig = Record<string, unknown>,
+> = new (config: TConfig) => TStore;
+
+export type MastraStoreRuntime<TStore = unknown> = {
+  Store?: MastraStoreConstructor<TStore>;
+  moduleLoader?: MastraRuntimeModuleLoader;
+};
+
+export type MastraAppStorageConfig<TStore> = {
+  storage: TStore;
+};
+
+export type MastraMemoryStorageConfig<TStore> = {
+  storage: TStore;
+};
+
+export type MastraStorageBundle<TStore = unknown> = {
+  target: MastraDatastoreTarget;
+  storage: TStore;
+  mastraConfig: MastraAppStorageConfig<TStore>;
+  memoryConfig: MastraMemoryStorageConfig<TStore>;
+};
+
+export const constructMastraDatastore = <TStore = unknown>(
+  target: MastraDatastoreTarget,
+  runtime: MastraStoreRuntime<TStore> = {},
+): TStore => {
+  const Store =
+    runtime.Store ??
+    loadMastraRuntimeExport<MastraStoreConstructor<TStore>>(
+      runtime.moduleLoader ?? loadMastraRuntimeModule,
+      target.packageName,
+      target.exportName,
+    );
+
+  return new Store(target.config);
+};
+
+export const createMastraAppStorageConfig = <TStore>(
+  storage: TStore,
+): MastraAppStorageConfig<TStore> => ({ storage });
+
+export const createMastraMemoryStorageConfig = <TStore>(
+  storage: TStore,
+): MastraMemoryStorageConfig<TStore> => ({ storage });
+
+export function createMastraStorageBundle<TStore = unknown>(
+  datastore: AgentSpecMastraDatastore,
+  runtime: MastraStoreRuntime<TStore>,
+  options?: MastraDatastoreTargetOptions,
+): MastraStorageBundle<TStore>;
+
+export function createMastraStorageBundle<TStore = unknown>(
+  datastore: AgentSpecMastraDatastore,
+  options?: MastraDatastoreTargetOptions,
+): MastraStorageBundle<TStore>;
+
+export function createMastraStorageBundle<TStore = unknown>(
+  datastore: AgentSpecMastraDatastore,
+  runtimeOrOptions: MastraStoreRuntime<TStore> | MastraDatastoreTargetOptions = {},
+  maybeOptions?: MastraDatastoreTargetOptions,
+): MastraStorageBundle<TStore> {
+  const { runtime, options } = parseStorageBundleArgs(
+    runtimeOrOptions,
+    maybeOptions,
+  );
+  const target = resolveMastraDatastore(datastore, options);
+  const storage = constructMastraDatastore(target, runtime);
+
+  return {
+    target,
+    storage,
+    mastraConfig: createMastraAppStorageConfig(storage),
+    memoryConfig: createMastraMemoryStorageConfig(storage),
+  };
+}
+
+const parseStorageBundleArgs = <TStore>(
+  runtimeOrOptions: MastraStoreRuntime<TStore> | MastraDatastoreTargetOptions,
+  maybeOptions: MastraDatastoreTargetOptions | undefined,
+): {
+  runtime: MastraStoreRuntime<TStore>;
+  options: MastraDatastoreTargetOptions;
+} => {
+  if (maybeOptions !== undefined) {
+    return {
+      runtime: runtimeOrOptions as MastraStoreRuntime<TStore>,
+      options: maybeOptions,
+    };
+  }
+
+  if (isMastraStoreRuntime(runtimeOrOptions)) {
+    return {
+      runtime: runtimeOrOptions,
+      options: {},
+    };
+  }
+
+  return {
+    runtime: {},
+    options: runtimeOrOptions,
+  };
+};
+
+const isMastraStoreRuntime = <TStore>(
+  value: MastraStoreRuntime<TStore> | MastraDatastoreTargetOptions,
+): value is MastraStoreRuntime<TStore> =>
+  "Store" in value || "moduleLoader" in value;

--- a/tsagentspec/src/adapters/mastra/tool.ts
+++ b/tsagentspec/src/adapters/mastra/tool.ts
@@ -1,0 +1,71 @@
+import type { JsonSchemaValue, Property } from "../../property.js";
+import type { Tool } from "../../tools/index.js";
+import {
+  MissingMastraToolExecutorError,
+  UnsupportedMastraToolError,
+} from "./errors.js";
+import type {
+  MastraToolResolver,
+  MastraToolResolverContext,
+  MastraToolRuntimeConfig,
+} from "./types.js";
+
+export const defaultMastraToolResolver: MastraToolResolver = (
+  tool: Tool,
+  context: MastraToolResolverContext,
+): MastraToolRuntimeConfig => {
+  if (tool.componentType !== "ServerTool") {
+    throw new UnsupportedMastraToolError(tool.componentType);
+  }
+
+  // Match by name first because that is what the LLM sees; id is kept as a
+  // useful escape hatch for configs that use stable internal identifiers.
+  const executor =
+    context.toolRegistry?.[tool.name] ?? context.toolRegistry?.[tool.id];
+
+  if (!executor) {
+    throw new MissingMastraToolExecutorError(tool.name);
+  }
+
+  return {
+    id: tool.name,
+    description: tool.description ?? `Agent Spec server tool: ${tool.name}`,
+    inputSchema: propertiesToMastraJsonSchema(tool.inputs),
+    outputSchema: propertiesToMastraJsonSchema(tool.outputs),
+    execute: (input, mastraContext) =>
+      executor(input, {
+        agentSpecTool: tool,
+        agentSpecAgent: context.agent,
+        mastraContext,
+      }),
+    requireApproval: tool.requiresConfirmation,
+    sourceAgentSpecTool: tool,
+  };
+};
+
+export const propertiesToMastraJsonSchema = (
+  properties: Property[] | undefined,
+): JsonSchemaValue | undefined => {
+  if (properties === undefined) {
+    return undefined;
+  }
+
+  const schemaProperties: Record<string, JsonSchemaValue> = {};
+  const required: string[] = [];
+
+  // Agent Spec properties are already JSON Schema fragments. Mastra tools expect
+  // one object schema, so we wrap the properties without changing their shape.
+  for (const property of properties) {
+    schemaProperties[property.title] = property.jsonSchema;
+    if (!Object.prototype.hasOwnProperty.call(property.jsonSchema, "default")) {
+      required.push(property.title);
+    }
+  }
+
+  return {
+    type: "object",
+    properties: schemaProperties,
+    required,
+    additionalProperties: false,
+  };
+};

--- a/tsagentspec/src/adapters/mastra/types.ts
+++ b/tsagentspec/src/adapters/mastra/types.ts
@@ -1,0 +1,255 @@
+import type { Agent } from "../../agents/index.js";
+import type { Flow, Node } from "../../flows/index.js";
+import type { LlmConfig } from "../../llms/index.js";
+import type { JsonSchemaValue } from "../../property.js";
+import type { ServerTool, Tool } from "../../tools/index.js";
+import type {
+  InMemoryCollectionDatastore,
+  PostgresDatabaseDatastore,
+} from "../../datastores/index.js";
+
+export type AgentSpecMastraDatastore =
+  | InMemoryCollectionDatastore
+  | PostgresDatabaseDatastore;
+
+export type DatastoreSchema = Record<string, Record<string, unknown>>;
+
+export type MastraDatastoreProvider = "in-memory" | "postgres";
+
+export type MastraDatastoreTargetOptions = {
+  id?: string;
+  schemaName?: string;
+  disableInit?: boolean;
+};
+
+export type MastraInMemoryStoreConfig = {
+  id: string;
+};
+
+export type MastraPostgresSslTarget =
+  | false
+  | {
+      mode: "allow" | "prefer" | "require" | "verify-ca" | "verify-full";
+      certPath?: string;
+      keyPath?: string;
+      rootCertPath?: string;
+      crlPath?: string;
+    };
+
+export type MastraPostgresStoreConfig = {
+  id: string;
+  connectionString: string;
+  user: string;
+  password: string;
+  ssl: MastraPostgresSslTarget;
+  schemaName?: string;
+  disableInit?: boolean;
+};
+
+type MastraDatastoreTargetBase<
+  TProvider extends MastraDatastoreProvider,
+  TPackageName extends string,
+  TExportName extends string,
+  TConfig,
+> = {
+  provider: TProvider;
+  packageName: TPackageName;
+  exportName: TExportName;
+  id: string;
+  datastoreSchema: DatastoreSchema;
+  config: TConfig;
+};
+
+export type MastraInMemoryDatastoreTarget = MastraDatastoreTargetBase<
+  "in-memory",
+  "@mastra/core/storage",
+  "InMemoryStore",
+  MastraInMemoryStoreConfig
+>;
+
+export type MastraPostgresDatastoreTarget = MastraDatastoreTargetBase<
+  "postgres",
+  "@mastra/pg",
+  "PostgresStore",
+  MastraPostgresStoreConfig
+>;
+
+export type MastraDatastoreTarget =
+  | MastraInMemoryDatastoreTarget
+  | MastraPostgresDatastoreTarget;
+
+export type MastraRuntimeModule = Record<string, unknown>;
+
+export type MastraRuntimeModuleLoader = (
+  packageName: string,
+) => MastraRuntimeModule;
+
+export type MastraDefaultRuntimeOptions = {
+  agentPackageName?: string;
+  agentExportName?: string;
+  toolsPackageName?: string;
+  createToolExportName?: string;
+  moduleLoader?: MastraRuntimeModuleLoader;
+  agentOptions?: Record<string, unknown>;
+  toolOptions?: Record<string, unknown>;
+};
+
+export type MastraDefaultWorkflowRuntimeOptions = {
+  workflowsPackageName?: string;
+  createWorkflowExportName?: string;
+  createStepExportName?: string;
+  moduleLoader?: MastraRuntimeModuleLoader;
+  workflowOptions?: Record<string, unknown>;
+  stepOptions?: Record<string, unknown>;
+};
+
+export type MastraModelTargetConfig = {
+  id: string;
+  url?: string;
+  apiKey?: string;
+  headers?: Record<string, string>;
+};
+
+export type MastraModelTarget = string | MastraModelTargetConfig;
+
+export type MastraToolExecutorContext = {
+  agentSpecTool: ServerTool;
+  agentSpecAgent?: Agent;
+  mastraContext?: unknown;
+};
+
+export type MastraServerToolExecutor = (
+  input: unknown,
+  context: MastraToolExecutorContext,
+) => unknown | Promise<unknown>;
+
+// Agent Spec carries the tool contract; the Mastra runtime still needs the
+// actual executable function. The registry is that handoff point.
+export type MastraToolRegistry = Record<string, MastraServerToolExecutor>;
+
+export type MastraToolRuntimeConfig = {
+  id: string;
+  description: string;
+  inputSchema?: JsonSchemaValue;
+  outputSchema?: JsonSchemaValue;
+  execute?: (input: unknown, mastraContext?: unknown) => unknown | Promise<unknown>;
+  requireApproval?: boolean;
+  sourceAgentSpecTool: Tool;
+};
+
+export type MastraAgentRuntimeConfig<TTool = unknown> = {
+  id: string;
+  name: string;
+  description?: string;
+  metadata?: Record<string, unknown>;
+  instructions: string;
+  model: MastraModelTarget;
+  tools: Record<string, TTool>;
+  sourceAgentSpecAgent: Agent;
+};
+
+// Keep Mastra as an optional runtime dependency. The default binder loads
+// Mastra only when Agent Spec is converted through the Mastra adapter.
+export type MastraRuntimeAdapter<TAgent = unknown, TTool = unknown> = {
+  createAgent: (config: MastraAgentRuntimeConfig<TTool>) => TAgent;
+  createTool: (config: MastraToolRuntimeConfig) => TTool;
+};
+
+export type MastraModelResolverContext = {
+  agent?: Agent;
+};
+
+export type MastraModelResolver = (
+  llmConfig: LlmConfig,
+  context: MastraModelResolverContext,
+) => MastraModelTarget;
+
+export type MastraToolResolverContext = {
+  agent?: Agent;
+  toolRegistry?: MastraToolRegistry;
+};
+
+export type MastraToolResolver = (
+  tool: Tool,
+  context: MastraToolResolverContext,
+) => MastraToolRuntimeConfig;
+
+export type AgentSpecToMastraConversionOptions<
+  TAgent = unknown,
+  TTool = unknown,
+> = {
+  runtime?: MastraRuntimeAdapter<TAgent, TTool>;
+  defaultRuntime?: MastraDefaultRuntimeOptions;
+  modelResolver?: MastraModelResolver;
+  toolResolver?: MastraToolResolver;
+  toolRegistry?: MastraToolRegistry;
+};
+
+export type MastraWorkflowStepKind = "llm" | "tool" | "agent";
+
+export type MastraFlowNodeExecutorContext = {
+  flow: Flow;
+  node: Node;
+  mastraContext?: unknown;
+};
+
+export type MastraFlowNodeExecutor = (
+  input: unknown,
+  context: MastraFlowNodeExecutorContext,
+) => unknown | Promise<unknown>;
+
+export type MastraFlowNodeExecutorRegistry = Record<
+  string,
+  MastraFlowNodeExecutor
+>;
+
+export type MastraWorkflowStepRuntimeConfig = {
+  id: string;
+  name: string;
+  kind: MastraWorkflowStepKind;
+  description?: string;
+  inputSchema?: JsonSchemaValue;
+  outputSchema?: JsonSchemaValue;
+  execute: (input: unknown, mastraContext?: unknown) => unknown | Promise<unknown>;
+  sourceAgentSpecNode: Node;
+  model?: MastraModelTarget;
+  promptTemplate?: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type MastraWorkflowRuntimeConfig<TStep = unknown> = {
+  id: string;
+  name: string;
+  description?: string;
+  metadata?: Record<string, unknown>;
+  inputSchema?: JsonSchemaValue;
+  outputSchema?: JsonSchemaValue;
+  steps: TStep[];
+  sourceAgentSpecFlow: Flow;
+  plan: unknown;
+};
+
+// Workflow APIs are still runtime-specific in Mastra, so the converter exposes
+// a small port instead of importing workflow classes directly.
+export type MastraWorkflowRuntimeAdapter<
+  TWorkflow = unknown,
+  TStep = unknown,
+> = {
+  createWorkflow: (config: MastraWorkflowRuntimeConfig<TStep>) => TWorkflow;
+  createStep: (config: MastraWorkflowStepRuntimeConfig) => TStep;
+  addStep: (workflow: TWorkflow, step: TStep) => TWorkflow;
+  commitWorkflow: (workflow: TWorkflow) => TWorkflow;
+};
+
+export type AgentSpecFlowToMastraWorkflowConversionOptions<
+  TWorkflow = unknown,
+  TStep = unknown,
+> = {
+  runtime?: MastraWorkflowRuntimeAdapter<TWorkflow, TStep>;
+  defaultRuntime?: MastraDefaultWorkflowRuntimeOptions;
+  modelResolver?: MastraModelResolver;
+  toolResolver?: MastraToolResolver;
+  toolRegistry?: MastraToolRegistry;
+  llmNodeRegistry?: MastraFlowNodeExecutorRegistry;
+  agentNodeRegistry?: MastraFlowNodeExecutorRegistry;
+};

--- a/tsagentspec/tests/adapters/mastra/agentspec-exporter.test.ts
+++ b/tsagentspec/tests/adapters/mastra/agentspec-exporter.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, it } from "vitest";
+import {
+  AgentSpecDeserializer,
+  AgentSpecSerializer,
+  createAgent,
+  createAgentNode,
+  createBuiltinTool,
+  createControlFlowEdge,
+  createEndNode,
+  createFlow,
+  createLlmNode,
+  createOpenAiConfig,
+  createOpenAiCompatibleConfig,
+  createServerTool,
+  createStartNode,
+  createToolNode,
+  stringProperty,
+  type Agent,
+} from "../../../src/index.js";
+import {
+  AgentSpecExporter,
+  convertAgentSpecFlowToMastraWorkflow,
+  convertAgentSpecToMastraAgent,
+  UnsupportedMastraExportError,
+  type MastraAgentRuntimeConfig,
+  type MastraRuntimeAdapter,
+  type MastraToolRuntimeConfig,
+  type MastraWorkflowRuntimeAdapter,
+  type MastraWorkflowRuntimeConfig,
+  type MastraWorkflowStepRuntimeConfig,
+} from "../../../src/adapters/mastra/index.js";
+
+type FakeTool = {
+  config: MastraToolRuntimeConfig;
+};
+
+type FakeAgent = {
+  config: MastraAgentRuntimeConfig<FakeTool>;
+};
+
+type FakeStep = {
+  config: MastraWorkflowStepRuntimeConfig;
+};
+
+type FakeWorkflow = {
+  config: MastraWorkflowRuntimeConfig<FakeStep>;
+  steps: FakeStep[];
+};
+
+const fakeAgentRuntime: MastraRuntimeAdapter<FakeAgent, FakeTool> = {
+  createAgent: (config) => ({ config }),
+  createTool: (config) => ({ config }),
+};
+
+const fakeWorkflowRuntime: MastraWorkflowRuntimeAdapter<FakeWorkflow, FakeStep> = {
+  createWorkflow: (config) => ({ config, steps: [] }),
+  createStep: (config) => ({ config }),
+  addStep: (workflow, step) => {
+    workflow.steps.push(step);
+    return workflow;
+  },
+  commitWorkflow: (workflow) => workflow,
+};
+
+describe("Mastra Agent Spec exporter", () => {
+  it("round-trips adapter-created Mastra agents losslessly through Agent Spec JSON", () => {
+    const exporter = new AgentSpecExporter();
+    const agent = createAgent({
+      id: "agent-1",
+      name: "Support Agent",
+      description: "Answers support questions",
+      metadata: { team: "support" },
+      llmConfig: createOpenAiConfig({
+        name: "llm",
+        modelId: "gpt-4o-mini",
+      }),
+      systemPrompt: "You answer support questions.",
+      tools: [
+        createServerTool({
+          name: "lookup",
+          description: "Look up account data",
+          inputs: [stringProperty({ title: "accountId" })],
+        }),
+      ],
+    });
+    const mastraAgent = convertAgentSpecToMastraAgent(agent, {
+      runtime: fakeAgentRuntime,
+      toolRegistry: {
+        lookup: () => ({ ok: true }),
+      },
+    });
+
+    const exported = exporter.toAgent(mastraAgent);
+    const serializer = new AgentSpecSerializer();
+    const json = serializer.toJson(exported);
+    const reloaded = new AgentSpecDeserializer().fromJson(json) as Agent;
+
+    expect(exported).toEqual(agent);
+    expect(reloaded).toEqual(agent);
+  });
+
+  it("exports adapter-created Mastra workflows from flow provenance", () => {
+    const exporter = new AgentSpecExporter();
+    const llmConfig = createOpenAiConfig({
+      name: "llm",
+      modelId: "gpt-4o-mini",
+    });
+    const start = createStartNode({ name: "start" });
+    const draft = createLlmNode({
+      name: "draft",
+      llmConfig,
+      promptTemplate: "Draft.",
+    });
+    const tool = createServerTool({ name: "lookup" });
+    const lookup = createToolNode({ name: "lookup-step", tool });
+    const review = createAgentNode({
+      name: "review",
+      agent: createAgent({
+        name: "reviewer",
+        llmConfig,
+        systemPrompt: "Review.",
+      }),
+    });
+    const end = createEndNode({ name: "end" });
+    const flow = createFlow({
+      name: "linear-flow",
+      startNode: start,
+      nodes: [start, draft, lookup, review, end],
+      controlFlowConnections: [
+        createControlFlowEdge({ name: "start_to_draft", fromNode: start, toNode: draft }),
+        createControlFlowEdge({ name: "draft_to_lookup", fromNode: draft, toNode: lookup }),
+        createControlFlowEdge({ name: "lookup_to_review", fromNode: lookup, toNode: review }),
+        createControlFlowEdge({ name: "review_to_end", fromNode: review, toNode: end }),
+      ],
+    });
+    const workflow = convertAgentSpecFlowToMastraWorkflow(flow, {
+      runtime: fakeWorkflowRuntime,
+      llmNodeRegistry: { draft: () => ({}) },
+      toolRegistry: { lookup: () => ({}) },
+      agentNodeRegistry: { review: () => ({}) },
+    });
+
+    expect(exporter.toFlow(workflow)).toEqual(flow);
+    expect(exporter.toComponent(workflow)).toEqual(flow);
+  });
+
+  it("exports a simple native Mastra-like agent config", () => {
+    const exported = new AgentSpecExporter().toAgent({
+      id: "weather-agent",
+      name: "Weather Agent",
+      description: "Answers weather questions",
+      metadata: { domain: "weather" },
+      instructions: "Use tools for weather.",
+      model: "openai/gpt-4o-mini",
+      tools: {
+        get_weather: {
+          id: "get_weather",
+          description: "Return weather for a city",
+          inputSchema: {
+            type: "object",
+            properties: {
+              city: { type: "string", description: "City name" },
+            },
+          },
+          outputSchema: {
+            type: "object",
+            properties: {
+              condition: { type: "string" },
+            },
+          },
+          execute: () => ({ condition: "foggy" }),
+        },
+      },
+    });
+
+    expect(exported).toMatchObject({
+      id: "weather-agent",
+      name: "Weather Agent",
+      description: "Answers weather questions",
+      metadata: { domain: "weather" },
+      systemPrompt: "Use tools for weather.",
+      llmConfig: {
+        componentType: "OpenAiConfig",
+        modelId: "gpt-4o-mini",
+      },
+    });
+    expect(exported.tools).toHaveLength(1);
+    expect(exported.tools[0]).toMatchObject({
+      componentType: "ServerTool",
+      name: "get_weather",
+      description: "Return weather for a city",
+      inputs: [
+        {
+          title: "city",
+          jsonSchema: {
+            title: "city",
+            type: "string",
+            description: "City name",
+          },
+        },
+      ],
+      outputs: [
+        {
+          title: "condition",
+          jsonSchema: {
+            title: "condition",
+            type: "string",
+          },
+        },
+      ],
+    });
+  });
+
+  it("exports simple native runtime tool descriptors as BuiltinTool", () => {
+    const exported = new AgentSpecExporter().toAgent({
+      name: "Runtime Tool Agent",
+      instructions: "Use runtime tools.",
+      model: {
+        provider: "openai",
+        name: "gpt-4o-mini",
+      },
+      tools: {
+        runtime_search: {
+          id: "runtime_search",
+          description: "Search using a runtime-provided tool",
+          toolType: "runtime_search",
+          configuration: {
+            source: "framework-runtime",
+            limit: 3,
+          },
+        },
+      },
+    });
+
+    expect(exported.tools).toEqual([
+      createBuiltinTool({
+        id: "runtime_search",
+        name: "runtime_search",
+        description: "Search using a runtime-provided tool",
+        toolType: "runtime_search",
+        configuration: {
+          source: "framework-runtime",
+          limit: 3,
+        },
+      }),
+    ]);
+  });
+
+  it("uses native model exporters for non-portable model shapes", () => {
+    const exported = new AgentSpecExporter({
+      nativeModelExporter: () =>
+        createOpenAiCompatibleConfig({
+          name: "custom",
+          modelId: "custom-model",
+          url: "http://localhost:8000/v1",
+        }),
+    }).toAgent({
+      name: "Custom Agent",
+      instructions: "Use custom model.",
+      model: { runtimeOnly: true },
+    });
+
+    expect(exported.llmConfig).toMatchObject({
+      componentType: "OpenAiCompatibleConfig",
+      modelId: "custom-model",
+      url: "http://localhost:8000/v1",
+    });
+  });
+
+  it("serializes exported Mastra configs through the docs-style exporter API", () => {
+    const yaml = new AgentSpecExporter().toYaml({
+      name: "Weather Agent",
+      instructions: "Use weather tools.",
+      model: "openai/gpt-4o-mini",
+    }) as string;
+
+    expect(yaml).toContain("component_type: Agent");
+    expect(yaml).toContain("name: Weather Agent");
+  });
+
+  it("refuses to export dynamic runtime functions as agent fields", () => {
+    expect(() =>
+      new AgentSpecExporter().toAgent({
+        name: "Dynamic Agent",
+        instructions: () => "dynamic",
+        model: "openai/gpt-4o-mini",
+      }),
+    ).toThrow(UnsupportedMastraExportError);
+  });
+
+  it("refuses to export opaque workflows without Agent Spec provenance", () => {
+    expect(() =>
+      new AgentSpecExporter().toFlow({
+        id: "native-workflow",
+        steps: [],
+      }),
+    ).toThrow(UnsupportedMastraExportError);
+  });
+});

--- a/tsagentspec/tests/adapters/mastra/agentspec-loader.test.ts
+++ b/tsagentspec/tests/adapters/mastra/agentspec-loader.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from "vitest";
+import {
+  AgentSpecSerializer,
+  createAgent,
+  createOpenAiConfig,
+  createOpenAiCompatibleConfig,
+  createServerTool,
+} from "../../../src/index.js";
+import {
+  InvalidMastraAgentSpecError,
+  AgentSpecLoader,
+  MissingMastraRuntimeDependencyError,
+  type MastraAgentRuntimeConfig,
+  type MastraRuntimeAdapter,
+  type MastraToolRuntimeConfig,
+} from "../../../src/adapters/mastra/index.js";
+
+type FakeTool = {
+  kind: "tool";
+  config: MastraToolRuntimeConfig;
+};
+
+type FakeAgent = {
+  kind: "agent";
+  config: MastraAgentRuntimeConfig<FakeTool>;
+};
+
+const fakeRuntime: MastraRuntimeAdapter<FakeAgent, FakeTool> = {
+  createAgent: (config) => ({ kind: "agent", config }),
+  createTool: (config) => ({ kind: "tool", config }),
+};
+
+class DefaultRuntimeAgent {
+  readonly config: Record<string, unknown>;
+
+  constructor(config: Record<string, unknown>) {
+    this.config = config;
+  }
+}
+
+describe("AgentSpecLoader", () => {
+  it("loads with the default Mastra runtime binder when no runtime is supplied", () => {
+    const serializer = new AgentSpecSerializer();
+    const agent = createAgent({
+      name: "Default Runtime Agent",
+      llmConfig: createOpenAiCompatibleConfig({
+        name: "llm",
+        modelId: "custom-model",
+        url: "http://localhost:8000/v1",
+      }),
+      systemPrompt: "Use the lookup tool.",
+      tools: [
+        createServerTool({
+          id: "lookup-tool",
+          name: "lookup",
+          description: "Look up a value",
+        }),
+      ],
+    });
+    const yaml = serializer.toYaml(agent) as string;
+    const createdTools: Array<Record<string, unknown>> = [];
+    const loader = new AgentSpecLoader({
+      defaultRuntime: {
+        moduleLoader: (packageName) => {
+          if (packageName === "@mastra/core/agent") {
+            return { Agent: DefaultRuntimeAgent };
+          }
+          if (packageName === "@mastra/core/tools") {
+            return {
+              createTool: (config: Record<string, unknown>) => {
+                createdTools.push(config);
+                return { config };
+              },
+            };
+          }
+          return {};
+        },
+        agentOptions: {
+          memory: "memory-instance",
+        },
+      },
+      toolRegistry: {
+        lookup: () => "value",
+      },
+    });
+
+    const converted = loader.loadYaml(yaml) as DefaultRuntimeAgent & {
+      sourceAgentSpecAgent?: unknown;
+    };
+
+    expect(converted).toBeInstanceOf(DefaultRuntimeAgent);
+    expect(converted.config).toMatchObject({
+      name: "Default Runtime Agent",
+      instructions: "Use the lookup tool.",
+      memory: "memory-instance",
+      model: {
+        id: "openai-compatible/custom-model",
+        url: "http://localhost:8000/v1",
+      },
+    });
+    expect(converted.config["tools"]).toHaveProperty("lookup");
+    expect(converted.sourceAgentSpecAgent).toEqual(agent);
+    expect(createdTools[0]).toMatchObject({
+      id: "lookup",
+      description: "Look up a value",
+    });
+    expect(createdTools[0]?.["execute"]).toBeTypeOf("function");
+  });
+
+  it("fails clearly when the default Mastra runtime dependency is unavailable", () => {
+    const agent = createAgent({
+      name: "Missing Runtime Agent",
+      llmConfig: createOpenAiCompatibleConfig({
+        name: "llm",
+        modelId: "custom-model",
+        url: "http://localhost:8000/v1",
+      }),
+      systemPrompt: "You answer.",
+    });
+
+    expect(
+      () =>
+        new AgentSpecLoader({
+          defaultRuntime: {
+            moduleLoader: () => {
+              throw new Error("missing module");
+            },
+          },
+        }).loadComponent(agent),
+    ).toThrow(MissingMastraRuntimeDependencyError);
+  });
+
+  it("loads a JSON Agent Spec into a Mastra runtime agent", () => {
+    const serializer = new AgentSpecSerializer();
+    const agent = createAgent({
+      id: "agent-1",
+      name: "JSON Agent",
+      llmConfig: createOpenAiCompatibleConfig({
+        name: "llm",
+        modelId: "custom-model",
+        url: "http://localhost:8000/v1",
+      }),
+      systemPrompt: "You answer from JSON.",
+    });
+    const json = serializer.toJson(agent) as string;
+    const loader = new AgentSpecLoader({ runtime: fakeRuntime });
+
+    const converted = loader.loadJson(json);
+
+    expect(converted.config).toMatchObject({
+      id: "agent-1",
+      name: "JSON Agent",
+      instructions: "You answer from JSON.",
+      model: {
+        id: "openai-compatible/custom-model",
+        url: "http://localhost:8000/v1",
+      },
+      tools: {},
+    });
+  });
+
+  it("loads a YAML Agent Spec into a Mastra runtime agent", () => {
+    const serializer = new AgentSpecSerializer();
+    const agent = createAgent({
+      name: "YAML Agent",
+      llmConfig: createOpenAiCompatibleConfig({
+        name: "llm",
+        modelId: "custom-model",
+        url: "http://localhost:8000/v1",
+      }),
+      systemPrompt: "You answer from YAML.",
+    });
+    const yaml = serializer.toYaml(agent) as string;
+    const loader = new AgentSpecLoader({ runtime: fakeRuntime });
+
+    const converted = loader.loadYaml(yaml);
+
+    expect(converted.config.name).toBe("YAML Agent");
+    expect(converted.config.instructions).toBe("You answer from YAML.");
+  });
+
+  it("loads disaggregated referenced components for a later main load", () => {
+    const serializer = new AgentSpecSerializer();
+    const llmConfig = createOpenAiConfig({
+      id: "shared-llm",
+      name: "llm",
+      modelId: "gpt-4o-mini",
+    });
+    const agent = createAgent({
+      name: "Disaggregated Agent",
+      llmConfig,
+      systemPrompt: "Use the shared model.",
+    });
+    const [mainYaml, referencedYaml] = serializer.toYaml(agent, {
+      disaggregatedComponents: [llmConfig],
+      exportDisaggregatedComponents: true,
+    }) as [string, string];
+    const loader = new AgentSpecLoader({ runtime: fakeRuntime });
+
+    const registry = loader.loadYaml(referencedYaml, {
+      importOnlyReferencedComponents: true,
+    });
+    const converted = loader.loadYaml(mainYaml, {
+      componentsRegistry: registry,
+    });
+
+    expect(registry.get("shared-llm")).toEqual(llmConfig);
+    expect(converted.config).toMatchObject({
+      name: "Disaggregated Agent",
+      model: "openai/gpt-4o-mini",
+    });
+  });
+
+  it("loads from an already-created Agent component", () => {
+    const agent = createAgent({
+      name: "Component Agent",
+      llmConfig: createOpenAiCompatibleConfig({
+        name: "llm",
+        modelId: "custom-model",
+        url: "http://localhost:8000/v1",
+      }),
+      systemPrompt: "You answer from a component.",
+    });
+    const loader = new AgentSpecLoader({ runtime: fakeRuntime });
+
+    const converted = loader.loadComponent(agent);
+
+    expect(converted.config.sourceAgentSpecAgent).toEqual(agent);
+  });
+
+  it("fails when the loaded root component is not an Agent", () => {
+    const serializer = new AgentSpecSerializer();
+    const json = serializer.toJson(createServerTool({ name: "lookup" })) as string;
+    const loader = new AgentSpecLoader({ runtime: fakeRuntime });
+
+    expect(() => loader.loadJson(json)).toThrow(InvalidMastraAgentSpecError);
+  });
+});

--- a/tsagentspec/tests/adapters/mastra/datastores.test.ts
+++ b/tsagentspec/tests/adapters/mastra/datastores.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import {
+  createInMemoryCollectionDatastore,
+  createOracleDatabaseDatastore,
+  createPostgresDatabaseDatastore,
+  createTlsOracleDatabaseConnectionConfig,
+  createTlsPostgresDatabaseConnectionConfig,
+} from "../../../src/index.js";
+import {
+  resolveMastraDatastore,
+  UnsupportedMastraDatastoreError,
+} from "../../../src/adapters/mastra/index.js";
+
+describe("Mastra datastore resolver", () => {
+  it("maps InMemoryCollectionDatastore to Mastra InMemoryStore target", () => {
+    const datastore = createInMemoryCollectionDatastore({
+      id: "memory-ds",
+      name: "memory",
+      datastoreSchema: { cache: { value: { type: "string" } } },
+    });
+
+    const target = resolveMastraDatastore(datastore);
+
+    expect(target).toMatchObject({
+      provider: "in-memory",
+      packageName: "@mastra/core/storage",
+      exportName: "InMemoryStore",
+      id: "memory-ds",
+      config: { id: "memory-ds" },
+    });
+    expect(target.datastoreSchema).toEqual(datastore.datastoreSchema);
+  });
+
+  it("maps PostgresDatabaseDatastore url to PostgresStore connectionString", () => {
+    const datastore = createPostgresDatabaseDatastore({
+      id: "pg-ds",
+      name: "postgres",
+      datastoreSchema: { users: { id: { type: "string" } } },
+      connectionConfig: createTlsPostgresDatabaseConnectionConfig({
+        name: "pg-connection",
+        user: "postgres",
+        password: "secret",
+        url: "postgresql://localhost:5432/agentspec",
+        sslmode: "verify-full",
+        sslcert: "/certs/client.pem",
+        sslkey: "/certs/client-key.pem",
+        sslrootcert: "/certs/ca.pem",
+        sslcrl: "/certs/crl.pem",
+      }),
+    });
+
+    const target = resolveMastraDatastore(datastore, {
+      schemaName: "agentspec",
+      disableInit: true,
+    });
+
+    expect(target.provider).toBe("postgres");
+    expect(target.packageName).toBe("@mastra/pg");
+    expect(target.exportName).toBe("PostgresStore");
+    expect(target.config).toEqual({
+      id: "pg-ds",
+      connectionString: "postgresql://localhost:5432/agentspec",
+      user: "postgres",
+      password: "secret",
+      ssl: {
+        mode: "verify-full",
+        certPath: "/certs/client.pem",
+        keyPath: "/certs/client-key.pem",
+        rootCertPath: "/certs/ca.pem",
+        crlPath: "/certs/crl.pem",
+      },
+      schemaName: "agentspec",
+      disableInit: true,
+    });
+  });
+
+  it("maps disabled Postgres SSL mode to false", () => {
+    const datastore = createPostgresDatabaseDatastore({
+      id: "pg-no-ssl",
+      name: "postgres",
+      datastoreSchema: {},
+      connectionConfig: createTlsPostgresDatabaseConnectionConfig({
+        name: "pg-connection",
+        user: "postgres",
+        password: "secret",
+        url: "postgresql://localhost:5432/agentspec",
+        sslmode: "disable",
+      }),
+    });
+
+    const target = resolveMastraDatastore(datastore);
+
+    expect(target.provider).toBe("postgres");
+    expect(target.config.ssl).toBe(false);
+  });
+
+  it("does not map OracleDatabaseDatastore until Mastra publishes an official provider", () => {
+    const datastore = createOracleDatabaseDatastore({
+      id: "oracle-ds",
+      name: "oracle",
+      datastoreSchema: { threads: { id: { type: "string" } } },
+      connectionConfig: createTlsOracleDatabaseConnectionConfig({
+        name: "oracle-connection",
+        user: "admin",
+        password: "secret",
+        dsn: "localhost:1521/FREEPDB1",
+        configDir: "/opt/oracle/network/admin",
+      }),
+    });
+
+    expect(() => resolveMastraDatastore(datastore)).toThrow(
+      UnsupportedMastraDatastoreError,
+    );
+  });
+});

--- a/tsagentspec/tests/adapters/mastra/flow-converter.test.ts
+++ b/tsagentspec/tests/adapters/mastra/flow-converter.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest";
+import {
+  createAgent,
+  createAgentNode,
+  createControlFlowEdge,
+  createEndNode,
+  createFlow,
+  createLlmNode,
+  createOpenAiConfig,
+  createOpenAiCompatibleConfig,
+  createServerTool,
+  createStartNode,
+  createToolNode,
+  stringProperty,
+} from "../../../src/index.js";
+import {
+  convertAgentSpecFlowToMastraWorkflow,
+  MissingMastraFlowNodeExecutorError,
+  type MastraWorkflowRuntimeAdapter,
+  type MastraWorkflowRuntimeConfig,
+  type MastraWorkflowStepRuntimeConfig,
+} from "../../../src/adapters/mastra/index.js";
+
+type FakeStep = {
+  config: MastraWorkflowStepRuntimeConfig;
+};
+
+type FakeWorkflow = {
+  config: MastraWorkflowRuntimeConfig<FakeStep>;
+  steps: FakeStep[];
+  committed: boolean;
+};
+
+const fakeRuntime: MastraWorkflowRuntimeAdapter<FakeWorkflow, FakeStep> = {
+  createWorkflow: (config) => ({ config, steps: [], committed: false }),
+  createStep: (config) => ({ config }),
+  addStep: (workflow, step) => {
+    workflow.steps.push(step);
+    return workflow;
+  },
+  commitWorkflow: (workflow) => {
+    workflow.committed = true;
+    return workflow;
+  },
+};
+
+const llmConfig = createOpenAiConfig({
+  name: "llm",
+  modelId: "gpt-4o-mini",
+});
+
+const makeFlow = () => {
+  const start = createStartNode({
+    name: "start",
+    inputs: [stringProperty({ title: "topic" })],
+  });
+  const draft = createLlmNode({
+    name: "draft",
+    llmConfig,
+    promptTemplate: "Draft about {{topic}}.",
+  });
+  const tool = createServerTool({
+    name: "lookup",
+    inputs: [stringProperty({ title: "topic" })],
+    outputs: [stringProperty({ title: "facts" })],
+  });
+  const lookup = createToolNode({
+    name: "lookup-step",
+    tool,
+  });
+  const agent = createAgent({
+    name: "reviewer",
+    llmConfig: createOpenAiCompatibleConfig({
+      name: "review-llm",
+      url: "http://localhost:8000/v1",
+      modelId: "review-model",
+    }),
+    systemPrompt: "Review the draft.",
+  });
+  const review = createAgentNode({
+    name: "review",
+    agent,
+  });
+  const end = createEndNode({
+    name: "end",
+    outputs: [stringProperty({ title: "answer" })],
+  });
+
+  return createFlow({
+    name: "support-flow",
+    startNode: start,
+    nodes: [start, draft, lookup, review, end],
+    controlFlowConnections: [
+      createControlFlowEdge({ name: "start_to_draft", fromNode: start, toNode: draft }),
+      createControlFlowEdge({ name: "draft_to_lookup", fromNode: draft, toNode: lookup }),
+      createControlFlowEdge({ name: "lookup_to_review", fromNode: lookup, toNode: review }),
+      createControlFlowEdge({ name: "review_to_end", fromNode: review, toNode: end }),
+    ],
+  });
+};
+
+describe("Agent Spec flow to Mastra workflow converter", () => {
+  it("uses the default Mastra workflow runtime binder when no runtime is supplied", async () => {
+    const flow = makeFlow();
+    const createdSteps: Array<Record<string, unknown>> = [];
+
+    const workflow = convertAgentSpecFlowToMastraWorkflow(flow, {
+      defaultRuntime: {
+        moduleLoader: (packageName) => {
+          expect(packageName).toBe("@mastra/core/workflows");
+          return {
+            createWorkflow: (config: Record<string, unknown>) => ({
+              config,
+              steps: [] as Array<Record<string, unknown>>,
+              committed: false,
+              then(step: Record<string, unknown>) {
+                this.steps.push(step);
+                return this;
+              },
+              commit() {
+                this.committed = true;
+                return this;
+              },
+            }),
+            createStep: (config: Record<string, unknown>) => {
+              createdSteps.push(config);
+              return { config };
+            },
+          };
+        },
+      },
+      llmNodeRegistry: {
+        draft: (input) => ({ draft: input }),
+      },
+      toolRegistry: {
+        lookup: (input) => ({ facts: input }),
+      },
+      agentNodeRegistry: {
+        review: (input) => ({ answer: input }),
+      },
+    }) as FakeWorkflow;
+
+    expect(workflow.config.name).toBe("support-flow");
+    expect(workflow.committed).toBe(true);
+    expect(workflow.steps).toHaveLength(3);
+    expect(createdSteps.map((step) => step["id"])).toEqual([
+      "draft",
+      "lookup-step",
+      "review",
+    ]);
+    await expect(
+      Promise.resolve(
+        (createdSteps[0]?.["execute"] as (input: unknown) => unknown)({
+          inputData: { topic: "pricing" },
+        }),
+      ),
+    ).resolves.toEqual({ draft: { topic: "pricing" } });
+  });
+
+  it("converts a linear flow into an ordered workflow", async () => {
+    const flow = makeFlow();
+
+    const workflow = convertAgentSpecFlowToMastraWorkflow(flow, {
+      runtime: fakeRuntime,
+      llmNodeRegistry: {
+        draft: (input) => ({ draft: input }),
+      },
+      toolRegistry: {
+        lookup: (input) => ({ facts: input }),
+      },
+      agentNodeRegistry: {
+        review: (input) => ({ answer: input }),
+      },
+    });
+
+    expect(workflow.committed).toBe(true);
+    expect(workflow.config.name).toBe("support-flow");
+    expect(workflow.config.inputSchema).toMatchObject({
+      properties: { topic: { title: "topic", type: "string" } },
+    });
+    expect(workflow.steps.map((step) => step.config.id)).toEqual([
+      "draft",
+      "lookup-step",
+      "review",
+    ]);
+    expect(workflow.steps.map((step) => step.config.kind)).toEqual([
+      "llm",
+      "tool",
+      "agent",
+    ]);
+    expect(workflow.steps[0]?.config.model).toBe("openai/gpt-4o-mini");
+    expect(workflow.steps[0]?.config.promptTemplate).toBe("Draft about {{topic}}.");
+
+    await expect(
+      Promise.resolve(workflow.steps[0]?.config.execute({ topic: "pricing" })),
+    ).resolves.toEqual({ draft: { topic: "pricing" } });
+    await expect(
+      Promise.resolve(workflow.steps[1]?.config.execute({ topic: "pricing" })),
+    ).resolves.toEqual({ facts: { topic: "pricing" } });
+    await expect(
+      Promise.resolve(workflow.steps[2]?.config.execute({ facts: "ok" })),
+    ).resolves.toEqual({ answer: { facts: "ok" } });
+  });
+
+  it("requires explicit LLM node executors for deterministic conversion", () => {
+    const flow = makeFlow();
+
+    expect(() =>
+      convertAgentSpecFlowToMastraWorkflow(flow, {
+        runtime: fakeRuntime,
+        toolRegistry: { lookup: () => ({}) },
+        agentNodeRegistry: { review: () => ({}) },
+      }),
+    ).toThrow(MissingMastraFlowNodeExecutorError);
+  });
+});

--- a/tsagentspec/tests/adapters/mastra/flow-planner.test.ts
+++ b/tsagentspec/tests/adapters/mastra/flow-planner.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import {
+  createBranchingNode,
+  createControlFlowEdge,
+  createEndNode,
+  createFlow,
+  createLlmNode,
+  createOpenAiConfig,
+  createStartNode,
+} from "../../../src/index.js";
+import {
+  planLinearMastraFlow,
+  UnsupportedMastraFlowNodeError,
+  UnsupportedMastraFlowShapeError,
+} from "../../../src/adapters/mastra/index.js";
+
+const llmConfig = createOpenAiConfig({
+  name: "llm",
+  modelId: "gpt-4o-mini",
+});
+
+describe("Mastra linear flow planner", () => {
+  it("orders a simple linear flow", () => {
+    const start = createStartNode({ name: "start" });
+    const llm = createLlmNode({
+      name: "draft",
+      llmConfig,
+      promptTemplate: "Draft a reply.",
+    });
+    const end = createEndNode({ name: "end" });
+    const flow = createFlow({
+      name: "linear",
+      startNode: start,
+      nodes: [start, llm, end],
+      controlFlowConnections: [
+        createControlFlowEdge({ name: "start_to_draft", fromNode: start, toNode: llm }),
+        createControlFlowEdge({ name: "draft_to_end", fromNode: llm, toNode: end }),
+      ],
+    });
+
+    const plan = planLinearMastraFlow(flow);
+
+    expect(plan.nodeOrder.map((node) => node.name)).toEqual([
+      "start",
+      "draft",
+      "end",
+    ]);
+    expect(plan.executableNodes.map((node) => node.name)).toEqual(["draft"]);
+  });
+
+  it("rejects unsupported node types", () => {
+    const start = createStartNode({ name: "start" });
+    const branch = createBranchingNode({
+      name: "branch",
+      mapping: { yes: "yes_end" },
+    });
+    const end = createEndNode({ name: "end" });
+    const flow = createFlow({
+      name: "branching",
+      startNode: start,
+      nodes: [start, branch, end],
+      controlFlowConnections: [
+        createControlFlowEdge({ name: "start_to_branch", fromNode: start, toNode: branch }),
+        createControlFlowEdge({ name: "branch_to_end", fromNode: branch, toNode: end }),
+      ],
+    });
+
+    expect(() => planLinearMastraFlow(flow)).toThrow(
+      UnsupportedMastraFlowNodeError,
+    );
+  });
+
+  it("rejects control-flow splits in supported node types", () => {
+    const start = createStartNode({ name: "start" });
+    const llm = createLlmNode({
+      name: "router",
+      llmConfig,
+      promptTemplate: "Route.",
+    });
+    const endA = createEndNode({ name: "end_a" });
+    const endB = createEndNode({ name: "end_b" });
+    const flow = createFlow({
+      name: "split",
+      startNode: start,
+      nodes: [start, llm, endA, endB],
+      controlFlowConnections: [
+        createControlFlowEdge({ name: "start_to_router", fromNode: start, toNode: llm }),
+        createControlFlowEdge({ name: "router_to_a", fromNode: llm, toNode: endA }),
+        createControlFlowEdge({ name: "router_to_b", fromNode: llm, toNode: endB }),
+      ],
+    });
+
+    expect(() => planLinearMastraFlow(flow)).toThrow(
+      UnsupportedMastraFlowShapeError,
+    );
+  });
+});

--- a/tsagentspec/tests/adapters/mastra/mastra-converter.test.ts
+++ b/tsagentspec/tests/adapters/mastra/mastra-converter.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import {
+  createAgent,
+  createClientTool,
+  createMCPToolBox,
+  createOpenAiConfig,
+  createServerTool,
+  createStdioTransport,
+  stringProperty,
+} from "../../../src/index.js";
+import {
+  convertAgentSpecToMastraAgent,
+  DuplicateMastraToolNameError,
+  UnsupportedMastraAgentFeatureError,
+  UnsupportedMastraToolError,
+  type MastraAgentRuntimeConfig,
+  type MastraRuntimeAdapter,
+  type MastraToolRuntimeConfig,
+} from "../../../src/adapters/mastra/index.js";
+
+type FakeTool = {
+  kind: "tool";
+  config: MastraToolRuntimeConfig;
+};
+
+type FakeAgent = {
+  kind: "agent";
+  config: MastraAgentRuntimeConfig<FakeTool>;
+};
+
+const fakeRuntime: MastraRuntimeAdapter<FakeAgent, FakeTool> = {
+  createAgent: (config) => ({ kind: "agent", config }),
+  createTool: (config) => ({ kind: "tool", config }),
+};
+
+describe("Agent Spec to Mastra converter", () => {
+  it("converts a basic Agent into a Mastra runtime config", async () => {
+    const tool = createServerTool({
+      name: "lookup",
+      description: "Look up account data",
+      inputs: [stringProperty({ title: "accountId" })],
+    });
+    const agent = createAgent({
+      id: "agent-1",
+      name: "Support Agent",
+      description: "Answers support questions",
+      metadata: { team: "support" },
+      llmConfig: createOpenAiConfig({
+        name: "llm",
+        modelId: "gpt-4o-mini",
+      }),
+      systemPrompt: "You answer support questions.",
+      tools: [tool],
+    });
+
+    const converted = convertAgentSpecToMastraAgent(agent, {
+      runtime: fakeRuntime,
+      toolRegistry: {
+        lookup: (input) => ({ ok: true, input }),
+      },
+    });
+
+    expect(converted).toMatchObject({
+      kind: "agent",
+      config: {
+        id: "agent-1",
+        name: "Support Agent",
+        description: "Answers support questions",
+        metadata: { team: "support" },
+        instructions: "You answer support questions.",
+        model: "openai/gpt-4o-mini",
+      },
+    });
+    expect(Object.keys(converted.config.tools)).toEqual(["lookup"]);
+    expect(converted.config.tools.lookup?.config.id).toBe("lookup");
+    await expect(
+      Promise.resolve(
+        converted.config.tools.lookup?.config.execute?.({ accountId: "A-1" }),
+      ),
+    ).resolves.toEqual({
+      ok: true,
+      input: { accountId: "A-1" },
+    });
+  });
+
+  it("fails when two Agent Spec tools map to the same Mastra tool key", () => {
+    const agent = createAgent({
+      name: "agent",
+      llmConfig: createOpenAiConfig({
+        name: "llm",
+        modelId: "gpt-4o-mini",
+      }),
+      systemPrompt: "Hello",
+      tools: [
+        createServerTool({ id: "tool-1", name: "lookup" }),
+        createServerTool({ id: "tool-2", name: "lookup" }),
+      ],
+    });
+
+    expect(() =>
+      convertAgentSpecToMastraAgent(agent, {
+        runtime: fakeRuntime,
+        toolRegistry: {
+          lookup: () => "ok",
+        },
+      }),
+    ).toThrow(DuplicateMastraToolNameError);
+  });
+
+  it("fails explicitly for unsupported tool types", () => {
+    const agent = createAgent({
+      name: "agent",
+      llmConfig: createOpenAiConfig({
+        name: "llm",
+        modelId: "gpt-4o-mini",
+      }),
+      systemPrompt: "Hello",
+      tools: [createClientTool({ name: "client-input" })],
+    });
+
+    expect(() =>
+      convertAgentSpecToMastraAgent(agent, {
+        runtime: fakeRuntime,
+      }),
+    ).toThrow(UnsupportedMastraToolError);
+  });
+
+  it("fails explicitly when toolboxes would be dropped", () => {
+    const agent = createAgent({
+      name: "agent",
+      llmConfig: createOpenAiConfig({
+        name: "llm",
+        modelId: "gpt-4o-mini",
+      }),
+      systemPrompt: "Hello",
+      toolboxes: [
+        createMCPToolBox({
+          name: "remote-tools",
+          clientTransport: createStdioTransport({
+            name: "stdio",
+            command: "node",
+          }),
+          toolFilter: [],
+        }),
+      ],
+    });
+
+    expect(() =>
+      convertAgentSpecToMastraAgent(agent, {
+        runtime: fakeRuntime,
+      }),
+    ).toThrow(UnsupportedMastraAgentFeatureError);
+  });
+});

--- a/tsagentspec/tests/adapters/mastra/model.test.ts
+++ b/tsagentspec/tests/adapters/mastra/model.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import {
+  createOciClientConfigWithApiKey,
+  createOciGenAiConfig,
+  createOllamaConfig,
+  createOpenAiCompatibleConfig,
+  createOpenAiConfig,
+  createVllmConfig,
+} from "../../../src/index.js";
+import {
+  defaultMastraModelResolver,
+  UnsupportedMastraModelError,
+} from "../../../src/adapters/mastra/index.js";
+
+describe("Mastra model resolver", () => {
+  it("maps OpenAiConfig to a Mastra provider model id", () => {
+    const target = defaultMastraModelResolver(
+      createOpenAiConfig({
+        name: "openai",
+        modelId: "gpt-4o-mini",
+      }),
+      {},
+    );
+
+    expect(target).toBe("openai/gpt-4o-mini");
+  });
+
+  it("preserves OpenAI API keys in model config targets", () => {
+    const target = defaultMastraModelResolver(
+      createOpenAiConfig({
+        name: "openai",
+        modelId: "gpt-4o",
+        apiKey: "secret",
+      }),
+      {},
+    );
+
+    expect(target).toEqual({
+      id: "openai/gpt-4o",
+      apiKey: "secret",
+    });
+  });
+
+  it("maps OpenAiCompatibleConfig to a URL-backed model target", () => {
+    const target = defaultMastraModelResolver(
+      createOpenAiCompatibleConfig({
+        name: "compatible",
+        modelId: "custom-model",
+        url: "https://models.example.com/v1",
+        apiKey: "secret",
+      }),
+      {},
+    );
+
+    expect(target).toEqual({
+      id: "openai-compatible/custom-model",
+      url: "https://models.example.com/v1",
+      apiKey: "secret",
+    });
+  });
+
+  it("preserves slash-containing OpenAI-compatible model ids", () => {
+    const target = defaultMastraModelResolver(
+      createOpenAiCompatibleConfig({
+        name: "compatible",
+        modelId: "oci/openai.gpt-5.4-mini",
+        url: "https://models.example.com/v1",
+        apiKey: "secret",
+      }),
+      {},
+    );
+
+    expect(target).toEqual({
+      id: "openai-compatible/oci/openai.gpt-5.4-mini",
+      url: "https://models.example.com/v1",
+      apiKey: "secret",
+    });
+  });
+
+  it("maps OllamaConfig to an ollama-prefixed model target", () => {
+    const target = defaultMastraModelResolver(
+      createOllamaConfig({
+        name: "ollama",
+        modelId: "llama3.1",
+        url: "http://localhost:11434",
+      }),
+      {},
+    );
+
+    expect(target).toEqual({
+      id: "ollama/llama3.1",
+      url: "http://localhost:11434",
+    });
+  });
+
+  it("maps VllmConfig to a vllm-prefixed model target", () => {
+    const target = defaultMastraModelResolver(
+      createVllmConfig({
+        name: "vllm",
+        modelId: "qwen2.5",
+        url: "http://localhost:8000",
+      }),
+      {},
+    );
+
+    expect(target).toEqual({
+      id: "vllm/qwen2.5",
+      url: "http://localhost:8000",
+    });
+  });
+
+  it("fails explicitly for unsupported OCI GenAI configs", () => {
+    const ociConfig = createOciGenAiConfig({
+      name: "oci",
+      modelId: "cohere.command-r-plus",
+      compartmentId: "ocid1.compartment.oc1..example",
+      clientConfig: createOciClientConfigWithApiKey({
+        name: "oci-client",
+        serviceEndpoint: "https://inference.generativeai.us-ashburn-1.oci.oraclecloud.com",
+        authProfile: "DEFAULT",
+        authFileLocation: "~/.oci/config",
+      }),
+    });
+
+    expect(() => defaultMastraModelResolver(ociConfig, {})).toThrow(
+      UnsupportedMastraModelError,
+    );
+  });
+});

--- a/tsagentspec/tests/adapters/mastra/storage.test.ts
+++ b/tsagentspec/tests/adapters/mastra/storage.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  createInMemoryCollectionDatastore,
+} from "../../../src/index.js";
+import {
+  constructMastraDatastore,
+  createMastraAppStorageConfig,
+  createMastraMemoryStorageConfig,
+  createMastraStorageBundle,
+  MissingMastraRuntimeDependencyError,
+  resolveInMemoryDatastore,
+} from "../../../src/adapters/mastra/index.js";
+
+class FakeStore {
+  readonly config: Record<string, unknown>;
+
+  constructor(config: Record<string, unknown>) {
+    this.config = config;
+  }
+}
+
+describe("Mastra datastore factory", () => {
+  it("constructs a datastore with the resolved default Mastra store export", () => {
+    class FakeInMemoryStore {
+      readonly config: Record<string, unknown>;
+
+      constructor(config: Record<string, unknown>) {
+        this.config = config;
+      }
+    }
+
+    const datastore = createInMemoryCollectionDatastore({
+      id: "memory-ds",
+      name: "memory",
+      datastoreSchema: {},
+    });
+    const target = resolveInMemoryDatastore(datastore);
+
+    const store = constructMastraDatastore(target, {
+      moduleLoader: (packageName) => {
+        expect(packageName).toBe("@mastra/core/storage");
+        return { InMemoryStore: FakeInMemoryStore };
+      },
+    });
+
+    expect(store).toBeInstanceOf(FakeInMemoryStore);
+    expect(store.config).toEqual({ id: "memory-ds" });
+  });
+
+  it("fails explicitly when the resolved store package is unavailable", () => {
+    const datastore = createInMemoryCollectionDatastore({
+      id: "memory-ds",
+      name: "memory",
+      datastoreSchema: {},
+    });
+    const target = resolveInMemoryDatastore(datastore);
+
+    expect(() =>
+      constructMastraDatastore(target, {
+        moduleLoader: () => {
+          throw new Error("missing module");
+        },
+      }),
+    ).toThrow(
+      MissingMastraRuntimeDependencyError,
+    );
+  });
+
+  it("creates Mastra app and Memory storage configs from a store", () => {
+    const store = new FakeStore({ id: "memory-store" });
+
+    expect(createMastraAppStorageConfig(store)).toEqual({ storage: store });
+    expect(createMastraMemoryStorageConfig(store)).toEqual({ storage: store });
+  });
+
+  it("creates a storage bundle with implicit runtime module binding", () => {
+    const datastore = createInMemoryCollectionDatastore({
+      id: "memory-ds",
+      name: "memory",
+      datastoreSchema: {},
+    });
+
+    const bundle = createMastraStorageBundle(datastore, {
+      moduleLoader: () => ({ InMemoryStore: FakeStore }),
+    });
+
+    expect(bundle.target.provider).toBe("in-memory");
+    expect(bundle.storage).toBeInstanceOf(FakeStore);
+    expect(bundle.mastraConfig).toEqual({ storage: bundle.storage });
+    expect(bundle.memoryConfig).toEqual({ storage: bundle.storage });
+  });
+});

--- a/tsagentspec/tests/adapters/mastra/tool.test.ts
+++ b/tsagentspec/tests/adapters/mastra/tool.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import {
+  createClientTool,
+  createServerTool,
+  integerProperty,
+  stringProperty,
+} from "../../../src/index.js";
+import {
+  defaultMastraToolResolver,
+  MissingMastraToolExecutorError,
+  propertiesToMastraJsonSchema,
+  UnsupportedMastraToolError,
+} from "../../../src/adapters/mastra/index.js";
+
+describe("Mastra tool resolver", () => {
+  it("maps properties to a Mastra-compatible object JSON schema", () => {
+    expect(
+      propertiesToMastraJsonSchema([
+        stringProperty({ title: "query" }),
+        integerProperty({ title: "limit" }),
+      ]),
+    ).toEqual({
+      type: "object",
+      properties: {
+        query: { title: "query", type: "string" },
+        limit: { title: "limit", type: "integer" },
+      },
+      required: ["query", "limit"],
+      additionalProperties: false,
+    });
+  });
+
+  it("does not require properties that define Agent Spec defaults", () => {
+    expect(
+      propertiesToMastraJsonSchema([
+        stringProperty({ title: "city", default: "zurich" }),
+        integerProperty({ title: "limit" }),
+      ]),
+    ).toEqual({
+      type: "object",
+      properties: {
+        city: { title: "city", default: "zurich", type: "string" },
+        limit: { title: "limit", type: "integer" },
+      },
+      required: ["limit"],
+      additionalProperties: false,
+    });
+  });
+
+  it("wraps ServerTool registry executors with Agent Spec context", async () => {
+    const tool = createServerTool({
+      name: "lookup",
+      description: "Look up an item",
+      inputs: [stringProperty({ title: "query" })],
+      outputs: [stringProperty({ title: "answer" })],
+      requiresConfirmation: true,
+    });
+
+    const target = defaultMastraToolResolver(tool, {
+      toolRegistry: {
+        lookup: (input, context) => ({
+          input,
+          toolName: context.agentSpecTool.name,
+          mastraContext: context.mastraContext,
+        }),
+      },
+    });
+
+    expect(target).toMatchObject({
+      id: "lookup",
+      description: "Look up an item",
+      requireApproval: true,
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: { title: "query", type: "string" },
+        },
+        required: ["query"],
+        additionalProperties: false,
+      },
+      outputSchema: {
+        type: "object",
+        properties: {
+          answer: { title: "answer", type: "string" },
+        },
+        required: ["answer"],
+        additionalProperties: false,
+      },
+    });
+
+    await expect(
+      Promise.resolve(target.execute?.({ query: "x" }, { runId: "run-1" })),
+    ).resolves.toEqual({
+      input: { query: "x" },
+      toolName: "lookup",
+      mastraContext: { runId: "run-1" },
+    });
+  });
+
+  it("allows registry lookup by Agent Spec tool id", async () => {
+    const tool = createServerTool({
+      id: "tool-id",
+      name: "lookup",
+    });
+
+    const target = defaultMastraToolResolver(tool, {
+      toolRegistry: {
+        "tool-id": () => "ok",
+      },
+    });
+
+    await expect(Promise.resolve(target.execute?.({}, undefined))).resolves.toBe(
+      "ok",
+    );
+  });
+
+  it("fails when a ServerTool has no registered executor", () => {
+    const tool = createServerTool({ name: "lookup" });
+
+    expect(() => defaultMastraToolResolver(tool, {})).toThrow(
+      MissingMastraToolExecutorError,
+    );
+  });
+
+  it("fails explicitly for non-server tools", () => {
+    const tool = createClientTool({ name: "client-input" });
+
+    expect(() => defaultMastraToolResolver(tool, {})).toThrow(
+      UnsupportedMastraToolError,
+    );
+  });
+});

--- a/tsagentspec/tsup.config.ts
+++ b/tsagentspec/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/adapters/mastra/index.ts"],
   format: ["cjs", "esm"],
   dts: true,
   splitting: false,


### PR DESCRIPTION
Adds initial Mastra adapter support for the TypeScript SDK.
This includes Agent Spec -> Mastra loading, Mastra-style config -> Agent Spec export, model/tool mapping, datastore target mapping for in-memory and Postgres storage, initial linear Flow -> Mastra Workflow conversion, docs, tests, and adapter examples.  

Credit: this work was developed with **Darsh Patel** (@darshpatel1052). The branch is squashed under my OCA verified contributor account for contribution processing.