### PR TITLE
fix(adapters): map bare object schemas to passthrough dicts

### DIFF
--- a/pyagentspec/src/pyagentspec/adapters/_utils.py
+++ b/pyagentspec/src/pyagentspec/adapters/_utils.py
@@ -137,6 +137,14 @@ def _build_type_from_schema(
         return List[item_type]  # type: ignore
     # objects
     if t == "object" or ("properties" in schema or "required" in schema):
+        props = schema.get("properties", {}) or {}
+        # An object schema with no declared properties accepts any object
+        # (JSON Schema semantics). Building an empty create_model() here would
+        # silently strip every key on validation (pydantic defaults to
+        # extra="ignore"), so the tool receives {} instead of the LLM's
+        # arguments. Map it to a passthrough dict instead.
+        if not props and schema.get("additionalProperties") is not False:
+            return Dict[str, Any]
         # Create or reuse a Pydantic model for this object schema
         model_name = schema.get("title") or name
         unique_name = model_name
@@ -145,7 +153,6 @@ def _build_type_from_schema(
             suffix += 1
             unique_name = f"{model_name}_{suffix}"
 
-        props = schema.get("properties", {}) or {}
         required = set(schema.get("required", []))
 
         fields: Dict[str, Tuple[Any, Any]] = {}

--- a/pyagentspec/tests/test_bare_object_schema.py
+++ b/pyagentspec/tests/test_bare_object_schema.py
@@ -1,0 +1,47 @@
+"""A bare ``{"type": "object"}`` schema (no declared properties) must map to a
+passthrough dict, not an empty pydantic model that silently strips every key
+the LLM supplies (pydantic defaults to ``extra="ignore"``)."""
+
+from typing import Any, Dict
+
+from pyagentspec.adapters._utils import create_pydantic_model_from_properties
+from pyagentspec.property import Property
+
+
+def _model_for(json_schema: Dict[str, Any]) -> Any:
+    prop = Property(title="components", json_schema=json_schema)
+    return create_pydantic_model_from_properties("ToolArgs", [prop])
+
+
+def test_array_of_bare_objects_keeps_item_keys() -> None:
+    model = _model_for({"type": "array", "items": {"type": "object"}})
+
+    parsed = model(
+        components=[{"id": "root", "component": "Card", "child": "title"}]
+    )
+
+    assert parsed.components == [
+        {"id": "root", "component": "Card", "child": "title"}
+    ]
+
+
+def test_bare_object_keeps_keys() -> None:
+    model = _model_for({"type": "object"})
+
+    parsed = model(components={"id": "root", "nested": {"a": 1}})
+
+    assert parsed.components == {"id": "root", "nested": {"a": 1}}
+
+
+def test_object_with_declared_properties_still_builds_a_model() -> None:
+    model = _model_for(
+        {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+        }
+    )
+
+    parsed = model(components={"name": "Alice"})
+
+    assert parsed.components.name == "Alice"


### PR DESCRIPTION
## Problem

Fixes #220.

`_build_type_from_schema` (`pyagentspec/adapters/_utils.py`) converts an object schema with no declared properties — a bare `{"type": "object"}`, e.g. as the `items` schema of an array parameter — into a pydantic model built by `create_model()` with zero fields. Pydantic v2 defaults to `extra="ignore"`, so validating the LLM's arguments against that model silently strips **every key**: the tool receives `{}` (or `[{}, ...]` for arrays of objects) regardless of what the model sent, with no error surfaced anywhere.

## Fix

A bare object schema (no `properties`, and `additionalProperties` is not `false`) now maps to `Dict[str, Any]` — a passthrough, matching JSON Schema semantics: an object with no property constraints accepts any object. Schemas that declare `properties`/`required`, or set `additionalProperties: false`, still build typed models exactly as before.

## Testing

`pyagentspec/tests/test_bare_object_schema.py`:
- an array of bare objects keeps the item keys the LLM supplied
- a bare object keeps its keys (including nested values)
- an object with declared properties still builds a typed model

Commit is signed off per the contribution guide.