### PR TITLE
fix(langgraph): add description to OCI structured-output schema

### DIFF
--- a/pyagentspec/src/pyagentspec/adapters/langgraph/_node_execution.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/_node_execution.py
@@ -619,6 +619,10 @@ class LlmNodeExecutor(NodeExecutor):
             json_schema = {
                 # Title is required by langgraph
                 "title": "structured_output",
+                # Description is required by some providers' tool-schema validation
+                # (e.g. langchain_oci's CohereProvider.convert_to_oci_tool rejects a
+                # dict missing "description" with "Unsupported dict type").
+                "description": "Structured output for the LLM node.",
                 "type": "object",
                 "properties": {output.title: output.json_schema for output in node_outputs},
             }

--- a/pyagentspec/tests/adapters/langgraph/llms/test_ocigenai_conversion.py
+++ b/pyagentspec/tests/adapters/langgraph/llms/test_ocigenai_conversion.py
@@ -267,82 +267,51 @@ def test_reverse_convert_chatocigenai_to_agentspec_real():
     assert isinstance(client_cfg, OciClientConfigWithApiKey)
 
 
-def _write_throwaway_oci_config(directory: Path) -> str:
-    """Write a syntactically valid, locally-generated OCI API-key config/keypair.
-
-    Not a real credential and never sent anywhere: `ChatOCIGenAI` parses this file
-    to construct its client, but the LangGraph adapter code under test never issues
-    a network call, so no real OCI account is required.
-    """
-    from cryptography.hazmat.primitives import serialization
-    from cryptography.hazmat.primitives.asymmetric import rsa
-
-    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-    key_path = directory / "oci_api_key.pem"
-    key_path.write_bytes(
-        key.private_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PrivateFormat.TraditionalOpenSSL,
-            encryption_algorithm=serialization.NoEncryption(),
-        )
-    )
-    config_path = directory / "config"
-    config_path.write_text(
-        "[DEFAULT]\n"
-        "user=ocid1.user.oc1..aaaaaaaathrowaway\n"
-        "fingerprint=aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99\n"
-        "tenancy=ocid1.tenancy.oc1..aaaaaaaathrowaway\n"
-        "region=us-ashburn-1\n"
-        f"key_file={key_path}\n"
-    )
-    return str(config_path)
-
-
-@pytest.mark.parametrize(
-    "model_id",
-    [
-        "cohere.command-a-03-2025",
-        "meta.llama-3.3-70b-instruct",
-    ],
-)
-def test_llmnodeexecutor_structured_output_supported_across_providers(
-    tmp_path: Path, model_id: str
-) -> None:
-    """`LlmNodeExecutor` must build a `with_structured_output` schema every
+def test_llmnodeexecutor_structured_output_schema_has_description() -> None:
+    """`LlmNodeExecutor` must pass `with_structured_output` a schema every
     `ChatOCIGenAI` provider backend accepts, not only the ones whose tool-schema
-    validation happens to tolerate a dict with no "description" key.
+    validation happens to tolerate a dict with no "description" key
+    (`langchain_oci`'s `CohereProvider.convert_to_oci_tool` requires one).
 
-    `ChatOCIGenAI` picks its provider (Cohere vs. Meta/generic) from `model_id`
-    alone (`AgentSpecToLangGraphConverter` never forwards `OciGenAiConfig.provider`),
-    so the two ids above exercise the two `convert_to_oci_tool` implementations.
+    Monkey-patches `_node_execution.BaseChatModel` with a tiny fake that
+    captures the schema `with_structured_output` is called with, instead of
+    building a real `ChatOCIGenAI`, which needs no OCI configuration and does
+    not depend on which provider a given `model_id` would route to.
     """
-    from pyagentspec.adapters.langgraph._node_execution import LlmNodeExecutor
+    from pyagentspec.adapters.langgraph import _node_execution
     from pyagentspec.flows.nodes import LlmNode
+    from pyagentspec.llms.llmconfig import LlmConfig
     from pyagentspec.property import Property
 
-    auth_file_location = _write_throwaway_oci_config(tmp_path)
-    llm_node = LlmNode(
-        name="llm_node",
-        llm_config=OciGenAiConfig(
-            name="oci_cfg",
-            model_id=model_id,
-            compartment_id="ocid1.compartment.oc1..dummy",
-            client_config=OciClientConfigWithApiKey(
-                name="api_key_cfg",
-                service_endpoint=OCI_SERVICE_ENDPOINT,
-                auth_profile="DEFAULT",
-                auth_file_location=auth_file_location,
-            ),
-        ),
-        prompt_template="irrelevant",
-        outputs=[
-            Property(json_schema={"title": "name", "type": "string"}),
-            Property(json_schema={"title": "active", "type": "boolean"}),
-        ],
-    )
+    class _FakeChatModel:
+        def __init__(self) -> None:
+            self.captured_schema: dict | None = None
 
-    llm = AgentSpecToLangGraphConverter().convert(llm_node.llm_config, {})
-    executor = LlmNodeExecutor(llm_node, llm)
+        def with_structured_output(self, schema: dict) -> object:
+            self.captured_schema = schema
+            return object()
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(_node_execution, "BaseChatModel", _FakeChatModel)
+
+        llm_node = LlmNode(
+            name="llm_node",
+            llm_config=LlmConfig(name="test", model_id="gpt-4o", api_provider="openai"),
+            prompt_template="irrelevant",
+            outputs=[
+                Property(json_schema={"title": "name", "type": "string"}),
+                Property(json_schema={"title": "active", "type": "boolean"}),
+            ],
+        )
+
+        fake_llm = _FakeChatModel()
+        executor = _node_execution.LlmNodeExecutor(llm_node, fake_llm)
 
     assert executor.requires_structured_generation is True
-    assert executor.structured_llm is not None
+    schema = fake_llm.captured_schema
+    assert schema is not None
+    assert schema["description"] == "Structured output for the LLM node."
+    assert schema["properties"] == {
+        "name": {"title": "name", "type": "string"},
+        "active": {"title": "active", "type": "boolean"},
+    }

--- a/pyagentspec/tests/adapters/langgraph/llms/test_ocigenai_conversion.py
+++ b/pyagentspec/tests/adapters/langgraph/llms/test_ocigenai_conversion.py
@@ -265,3 +265,84 @@ def test_reverse_convert_chatocigenai_to_agentspec_real():
     assert component.llm_config.compartment_id == OCI_COMPARTMENT_ID
     client_cfg = component.llm_config.client_config
     assert isinstance(client_cfg, OciClientConfigWithApiKey)
+
+
+def _write_throwaway_oci_config(directory: Path) -> str:
+    """Write a syntactically valid, locally-generated OCI API-key config/keypair.
+
+    Not a real credential and never sent anywhere: `ChatOCIGenAI` parses this file
+    to construct its client, but the LangGraph adapter code under test never issues
+    a network call, so no real OCI account is required.
+    """
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    key_path = directory / "oci_api_key.pem"
+    key_path.write_bytes(
+        key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+    config_path = directory / "config"
+    config_path.write_text(
+        "[DEFAULT]\n"
+        "user=ocid1.user.oc1..aaaaaaaathrowaway\n"
+        "fingerprint=aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99\n"
+        "tenancy=ocid1.tenancy.oc1..aaaaaaaathrowaway\n"
+        "region=us-ashburn-1\n"
+        f"key_file={key_path}\n"
+    )
+    return str(config_path)
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "cohere.command-a-03-2025",
+        "meta.llama-3.3-70b-instruct",
+    ],
+)
+def test_llmnodeexecutor_structured_output_supported_across_providers(
+    tmp_path: Path, model_id: str
+) -> None:
+    """`LlmNodeExecutor` must build a `with_structured_output` schema every
+    `ChatOCIGenAI` provider backend accepts, not only the ones whose tool-schema
+    validation happens to tolerate a dict with no "description" key.
+
+    `ChatOCIGenAI` picks its provider (Cohere vs. Meta/generic) from `model_id`
+    alone (`AgentSpecToLangGraphConverter` never forwards `OciGenAiConfig.provider`),
+    so the two ids above exercise the two `convert_to_oci_tool` implementations.
+    """
+    from pyagentspec.adapters.langgraph._node_execution import LlmNodeExecutor
+    from pyagentspec.flows.nodes import LlmNode
+    from pyagentspec.property import Property
+
+    auth_file_location = _write_throwaway_oci_config(tmp_path)
+    llm_node = LlmNode(
+        name="llm_node",
+        llm_config=OciGenAiConfig(
+            name="oci_cfg",
+            model_id=model_id,
+            compartment_id="ocid1.compartment.oc1..dummy",
+            client_config=OciClientConfigWithApiKey(
+                name="api_key_cfg",
+                service_endpoint=OCI_SERVICE_ENDPOINT,
+                auth_profile="DEFAULT",
+                auth_file_location=auth_file_location,
+            ),
+        ),
+        prompt_template="irrelevant",
+        outputs=[
+            Property(json_schema={"title": "name", "type": "string"}),
+            Property(json_schema={"title": "active", "type": "boolean"}),
+        ],
+    )
+
+    llm = AgentSpecToLangGraphConverter().convert(llm_node.llm_config, {})
+    executor = LlmNodeExecutor(llm_node, llm)
+
+    assert executor.requires_structured_generation is True
+    assert executor.structured_llm is not None


### PR DESCRIPTION
## Root cause

`LlmNodeExecutor.__init__` (`_node_execution.py`) builds the LangGraph structured-output
schema for an `LlmNode` as a bare dict with only `title`, `type` and `properties`, then
passes it to `self.llm.with_structured_output(json_schema)`.

For an `OciGenAiConfig`-backed model, that call reaches `langchain_oci`'s
`ChatOCIGenAI.bind_tools` -> `convert_to_oci_tool`. The generic provider (Meta/OpenAI/Gemini
model ids) only requires `title` and `properties`, so it happens to accept this dict. The
Cohere provider (`cohere.*` model ids) additionally requires `description`:

```python
if not all(k in tool for k in ("title", "description", "properties")):
    raise ValueError("Unsupported dict type. Tool must be a BaseTool instance, "
                      "JSON schema dict, or Pydantic model.")
```

so any Cohere-family model configured with a structured (non-single-string) `LlmNode`
output fails at executor construction time, before any request reaches OCI, matching the
report on #232.

## Fix

Add a static `description` key to the schema dict, mirroring the existing `title` comment.

## Verification

- Reproduced against current HEAD in a clean `python:3.12-slim` container (`pyagentspec`
  installed editable from this checkout, provenance checked via `module.__file__`):
  constructing `LlmNodeExecutor` for an `OciGenAiConfig(model_id="cohere.command-a-...")`
  node with two non-string outputs raises the `ValueError` above; a Meta/generic model id
  does not, which is why this is provider-specific rather than universal.
- Added `test_llmnodeexecutor_structured_output_supported_across_providers`
  (`test_ocigenai_conversion.py`), parametrized over a Cohere and a Meta model id, using a
  throwaway locally-generated OCI API key so it needs no real account or network call. It
  fails on `main` for the Cohere case and passes on this branch for both, run both ways in
  the same container.
- `black`, `isort`, `flake8 --select C801` (including the copyright check) and `bandit -c
  bandit.yaml -r pyagentspec/` all clean on the two changed files. `mypy` is not run here:
  the CI job excludes `pyagentspec/src/pyagentspec/adapters`.
- Full `pytest tests` (both changed and unchanged) with `SKIP_LLM_TESTS=1`, matching this
  repo's CI env: same 10 failed / 1042 passed / 666 skipped / 26 errors before and after this
  diff, all pre-existing and traced to optional extras not installed in this container
  (`langchain_ollama`, `langgraph_swarm`), not to this change.
- Not verified: like every other test in this file that constructs an `OciGenAiConfig`
  (including the pre-existing `test_reverse_convert_chatocigenai_to_agentspec`), the new test
  is skipped under the project's standard `SKIP_LLM_TESTS=1` CI run; I could only exercise it
  locally with that flag unset.

Fixes #232
