### PR TITLE
chore: bump pyagentspec dependency constraints

### DIFF
--- a/docs/pyagentspec/source/changelog.rst
+++ b/docs/pyagentspec/source/changelog.rst
@@ -20,7 +20,7 @@ Bug fixes
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 
-Agent Spec 26.3.0
+Agent Spec 26.3.1
 -----------------
 
 Improvements

--- a/pyagentspec/README.md
+++ b/pyagentspec/README.md
@@ -1,29 +1,127 @@
-This folder and subfolders contain the code that constitutes the Agent Spec reading/writing python library.
+# 🔗 Open Agent Specification (PyAgentSpec)
 
-## Build (recommended)
+[![AgentSpec downloads][badge-dl]][downloads] [![AgentSpec docs][badge-docs]][docs] [![AgentSpec Reference Sheet][badge-reference-sheet]][reference-sheet] [![License][badge-license]](#license)
 
-It is advised that you create a Python environment for all modules. In the main folder:
+Agent Spec is a portable, platform-agnostic configuration language that allows Agents
+and Agentic Systems to be described with sufficient fidelity.
+It defines the conceptual objects and called components that compose Agents in typical Agent systems,
+including the properties that determine the components' configuration, and their respective semantics.
+Agent Spec is based on two main runnable standalone components:
 
-```bash
-$ source ./clean-install-dev.sh
-```
+* Agents (e.g., ReAct), that are conversational agents or agent components;
+* Flows (e.g., business process) that are structured, workflow-based processes.
 
-Then for development, install the assistant in editable mode and the dev dependencies with:
+Runtimes implement the Agent Spec components for execution with Agentic frameworks or libraries.
+Agent Spec would be supported by SDKs in various languages (e.g. Python) to be able to serialize/deserialize Agents to JSON/YAML,
+or create them from object representations with the assurance of conformance to the specification.
 
-```bash
-$ cd pyagentspec
-$ ./install-dev.sh
-```
+For more information, including the motivation and specification, see the [dedicated section](https://oracle.github.io/agent-spec/development/agentspec/index.html) in the Agent Spec documentation.
 
-## Run tests
+---
 
-To run the tests, please export the URL to the model
-
-```bash
-export LLAMA_API_URL=/url/to/some/remote/llm
-```
-and run the tests with:
+## ⚡ Quick Install
 
 ```bash
-pytest tests
+pip install pyagentspec
 ```
+
+(Optional, faster installation using `uv`)
+
+```bash
+pip install uv
+uv pip install pyagentspec
+```
+
+---
+
+## 🧠 Quick Start
+
+### 1) Configure an LLM
+
+Initialize a Large Language Model (LLM) of your choice using PyAgentSpec configs:
+
+
+| OCI Gen AI                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | Open AI                                                                                                                                      | Ollama                                                                                                                                                                |
+|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <pre>from pyagentspec.llms import OciGenAiConfig<br>from pyagentspec.llms.ociclientconfig import OciClientConfigWithApiKey<br><br>OCIGENAI_ENDPOINT = "https://inference.generativeai.<oci region>.oci.oraclecloud.com"<br>COMPARTMENT_ID = "ocid1.compartment.oc1..<compartment_id>"<br>llm = OciGenAiConfig(<br>    name="OCI model",<br>    model_id="model_id",<br>    compartment_id=COMPARTMENT_ID,<br>    client_config=OciClientConfigWithApiKey(<br>        name="client_config",<br>        service_endpoint=OCIGENAI_ENDPOINT,<br>        auth_file_location="~/.oci/config",<br>        auth_profile="DEFAULT",<br>    ),<br>)</pre> | <pre>from pyagentspec.llms import OpenAiConfig<br><br>llm = OpenAiConfig(<br>    name="OpenAI model",<br>    model_id="model_id",<br>)</pre> | <pre>from pyagentspec.llms import OllamaConfig<br><br>llm = OllamaConfig(<br>    name="Ollama model",<br>    url="ollama_url",<br>    model_id="model_id",<br>)</pre> |
+
+
+> See the list of supported LLMs in the PyAgentSpec documentation: https://oracle.github.io/agent-spec/development/howtoguides/howto_llm_from_different_providers.html
+
+### 2) Create an Agent
+
+```python
+from pyagentspec.agent import Agent
+from pyagentspec.property import Property
+
+expertise_property = Property(json_schema={"title": "domain_of_expertise", "type": "string"})
+system_prompt = """
+You are an expert in {{domain_of_expertise}}.
+Please help the users with their requests.
+"""
+
+agent = Agent(
+    name="Adaptive expert agent",
+    system_prompt=system_prompt,
+    llm_config=llm_config,  # from step 1
+    inputs=[expertise_property],
+)
+```
+
+For more examples on building flexible Agents, structured Flows, and multi-agent patterns, read the Guides: https://oracle.github.io/agent-spec/development/howtoguides/index.html
+
+---
+
+## 🚀 Execute Agent Spec configurations
+
+Agent Spec configurations can be executed using Agent Spec–compatible runtimes or adapters that translate the spec into the target framework representation.
+
+- WayFlow is an Agent Spec reference runtime developed by Oracle: https://github.com/oracle/wayflow/
+- PyAgentSpec includes adapters for common frameworks (install extras as needed). Examples are available in the `adapters_examples` folder:
+  - LangGraph: https://github.com/oracle/agent-spec/tree/main/adapters_examples/langgraph
+  - AutoGen: https://github.com/oracle/agent-spec/tree/main/adapters_examples/autogen
+
+Refer to the installation guide for adapter-specific extras: https://oracle.github.io/agent-spec/development/installation.html
+
+---
+
+## 💁 Get Support
+
+- Open a GitHub issue for bugs, questions, or enhancement requests: https://github.com/oracle/agent-spec/issues
+- Report a security vulnerability: https://www.oracle.com/corporate/security-practices/assurance/vulnerability/reporting.html
+
+---
+
+## 🤝 Contributing
+
+Contributions are welcome! Please refer to the contributor guide located at the root of the repository.
+
+---
+
+## 🔐 Security
+
+For responsibly reporting security issues, please refer to the project's security guidelines.
+
+---
+
+## 📄 License
+
+Copyright (c) 2025 Oracle and/or its affiliates.
+
+This software is dual-licensed under the Apache License 2.0 (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) and the Universal Permissive License (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl).
+
+
+[badge-dl]: https://img.shields.io/pepy/dt/pyagentspec
+[badge-docs]: https://img.shields.io/badge/documentation-AgentSpec-orange
+[badge-license]: https://img.shields.io/badge/license-apache_2.0+UPL_1.0-green
+[badge-reference-sheet]: https://img.shields.io/badge/reference%20sheet-read-red
+[contributors]: https://oracle.github.io/agent-spec/development/contributing.html
+[docs]: https://oracle.github.io/agent-spec/index.html
+[downloads]: https://oracle.github.io/agent-spec/development/installation.html
+[getting-started]: https://oracle.github.io/agent-spec/development/docs_home.html
+[issues]: https://github.com/oracle/agent-spec/issues
+[reference-sheet]: https://oracle.github.io/agent-spec/development/misc/reference_sheet.html
+[reporting-vulnerabilities]: https://www.oracle.com/corporate/security-practices/assurance/vulnerability/reporting.html
+[website-wayflow]: https://oracle.github.io/wayflow/
+[website-agentspec]: https://oracle.github.io/agent-spec/
+[website-ecosystem]: https://oracle.github.io/agent-spec/development/agentspec/positioning.html

--- a/pyagentspec/constraints/constraints.txt
+++ b/pyagentspec/constraints/constraints.txt
@@ -1,4 +1,4 @@
-jsonschema==4.23.0
+jsonschema==4.26.0
 pydantic==2.12.5
 pyyaml==6.0.3
 httpx==0.28.1
@@ -15,7 +15,7 @@ crewai==1.6.1
 # LangGraph adapter
 langgraph==1.2.4
 langchain==1.3.9
-langchain-core==1.4.6
+langchain-core==1.4.9
 langchain-openai==1.2.1
 langchain-ollama==1.0.1
 langchain-oci==0.2.6

--- a/pyagentspec/constraints/constraints_dev.txt
+++ b/pyagentspec/constraints/constraints_dev.txt
@@ -1,4 +1,4 @@
-jsonschema==4.23.0
+jsonschema==4.26.0
 pydantic==2.12.5
 pyyaml==6.0.3
 httpx==0.28.1
@@ -15,7 +15,7 @@ crewai==1.6.1
 # LangGraph adapter
 langgraph==1.2.4
 langchain==1.3.9
-langchain-core==1.4.6
+langchain-core==1.4.9
 langchain-openai==1.2.1
 langchain-ollama==1.0.1
 langchain-oci==0.2.6

--- a/pyagentspec/constraints/constraints_v26.3.0.txt
+++ b/pyagentspec/constraints/constraints_v26.3.0.txt
@@ -1,4 +1,4 @@
-jsonschema==4.23.0
+jsonschema==4.26.0
 pydantic==2.12.5
 pyyaml==6.0.3
 httpx==0.28.1
@@ -12,7 +12,7 @@ autogen-agentchat==0.7.4
 # LangGraph adapter
 langgraph==1.2.4
 langchain==1.3.9
-langchain-core==1.4.6
+langchain-core==1.4.9
 langchain-openai==1.2.1
 langchain-ollama==1.0.1
 langchain-oci==0.2.6

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/_agentspec_converter_flow.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/_agentspec_converter_flow.py
@@ -235,7 +235,7 @@ def _langgraph_branch_convert_to_agentspec(
 
 
 def _get_start_end_nodes(
-    graph: StateGraph[Any, Any, Any],
+    graph: StateGraph[Any, Any, Any, Any],
     referenced_objects: Dict[str, AgentSpecComponent],
 ) -> Tuple[AgentSpecNode, AgentSpecNode]:
     START, END = _langgraph_start_end()
@@ -300,7 +300,7 @@ def _get_property_from_schema(schema: Type[Any]) -> Property:
 
 
 def _resolve_output_properties(
-    graph: StateGraph[Any, Any, Any],
+    graph: StateGraph[Any, Any, Any, Any],
     target_nodes: List[str],
 ) -> Property:
     START, END = _langgraph_start_end()
@@ -327,9 +327,9 @@ def _resolve_output_properties(
 
 
 def _langgraph_node_convert_to_agentspec(
-    graph: StateGraph[Any, Any, Any],
+    graph: StateGraph[Any, Any, Any, Any],
     node_name: str,
-    node: "StateNodeSpec[Any]",
+    node: "StateNodeSpec[Any, Any]",
     referenced_objects: Dict[str, AgentSpecComponent],
 ) -> AgentSpecNode:
     if node_name in referenced_objects:
@@ -377,7 +377,7 @@ def _langgraph_edges_convert_to_agentspec_ctrl_flow(
 
 
 def _langgraph_edges_convert_to_agentspec_data_flow(
-    graph: StateGraph[Any, Any, Any],
+    graph: StateGraph[Any, Any, Any, Any],
     edge: Tuple[str, str],
     referenced_objects: Dict[str, AgentSpecComponent],
 ) -> DataFlowEdge:

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/_agentspecconverter.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/_agentspecconverter.py
@@ -444,7 +444,7 @@ class LangGraphToAgentSpecConverter:
 
     def _extract_first_agent_name_from_swarm(
         self,
-        compiled_swarm: CompiledStateGraph[Any, Any, Any],
+        compiled_swarm: CompiledStateGraph[Any, Any, Any, Any],
         agent_names: List[str],
     ) -> Optional[str]:
         """Extract the initial agent name for a LangGraph swarm.

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/_langgraphconverter.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/_langgraphconverter.py
@@ -148,6 +148,7 @@ from pyagentspec.tracing.spans import AgentExecutionSpan as AgentSpecAgentExecut
 from pyagentspec.tracing.spans import FlowExecutionSpan as AgentSpecFlowExecutionSpan
 
 if TYPE_CHECKING:
+    from langchain_core.tools import ArgsSchema
     from langchain_mcp_adapters.sessions import (
         SSEConnection,
         StdioConnection,
@@ -388,7 +389,7 @@ class AgentSpecToLangGraphConverter:
         checkpointer: Optional[Checkpointer],
         config: RunnableConfig,
         middleware: List[Any],
-    ) -> CompiledStateGraph[Any, Any, Any]:
+    ) -> CompiledStateGraph[Any, Any, Any, Any]:
         graph_builder = StateGraph(
             FlowStateSchema,
             input_schema=FlowInputSchema,
@@ -831,7 +832,7 @@ class AgentSpecToLangGraphConverter:
         requires_confirmation = agentspec_server_tool.requires_confirmation
         structured_tool_name: str
         structured_tool_description: str
-        args_schema: Union[type[BaseModel], Dict[str, Any]]
+        args_schema: "ArgsSchema"
         if not (
             _is_structured_tool(tool_obj) or isinstance(tool_obj, BaseTool) or callable(tool_obj)
         ):
@@ -1017,7 +1018,7 @@ class AgentSpecToLangGraphConverter:
         checkpointer: Optional[Checkpointer],
         config: RunnableConfig,
         middleware: List[Any],
-    ) -> CompiledStateGraph[Any, Any, Any]:
+    ) -> CompiledStateGraph[Any, Any, Any, Any]:
         if agentspec_component.handoff is AgentSpecHandoffMode.NEVER:
             # As of now, we cannot control what langgraph-swarm does internally in terms of conversation sharing.
             # The closest behaviors are OPTIONAL (probably best) or ALWAYS, but NEVER is not really supported.
@@ -1053,7 +1054,7 @@ class AgentSpecToLangGraphConverter:
         for from_agent, to_agent in agentspec_component.relationships:
             handoffs[from_agent.name].append(to_agent.name)
         # We re-create the agents with the additional handoff tools
-        langgraph_agents: list[CompiledStateGraph[Any, Any, Any]] = [
+        langgraph_agents: list[CompiledStateGraph[Any, Any, Any, Any]] = [
             self._create_react_agent_with_given_info(
                 agent=agent,
                 name=agent.name,
@@ -1199,7 +1200,7 @@ class AgentSpecToLangGraphConverter:
         config: RunnableConfig,
         middleware: List[Any],
         additional_langgraph_tools: Optional[List[LangGraphTool]] = None,
-    ) -> CompiledStateGraph[Any, Any, Any]:
+    ) -> CompiledStateGraph[Any, Any, Any, Any]:
         model = self.convert(
             llm_config,
             tool_registry=tool_registry,
@@ -1268,7 +1269,7 @@ class AgentSpecToLangGraphConverter:
         )
         if middleware:
             create_agent_kwargs["middleware"] = middleware
-        compiled_graph: CompiledStateGraph[Any, Any, Any] = langchain_agents.create_agent(
+        compiled_graph: CompiledStateGraph[Any, Any, Any, Any] = langchain_agents.create_agent(
             **create_agent_kwargs
         )
 
@@ -1295,7 +1296,7 @@ class AgentSpecToLangGraphConverter:
         checkpointer: Optional[Checkpointer],
         config: RunnableConfig,
         middleware: List[Any],
-    ) -> CompiledStateGraph[Any, Any, Any]:
+    ) -> CompiledStateGraph[Any, Any, Any, Any]:
         return self._create_react_agent_with_given_info(
             name=agentspec_component.name,
             system_prompt=agentspec_component.system_prompt,

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/_node_execution.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/_node_execution.py
@@ -19,7 +19,6 @@ from pyagentspec.adapters._url_validation import (
 from pyagentspec.adapters._utils import render_nested_object_template, render_template
 from pyagentspec.adapters.langgraph._types import (
     BaseChatModel,
-    BaseMessage,
     Checkpointer,
     CompiledStateGraph,
     ExecuteOutput,
@@ -59,6 +58,7 @@ from pyagentspec.tracing.spans.span import get_current_span
 
 if TYPE_CHECKING:
     import httpx
+    from langchain_core.messages import MessageLikeRepresentation
     from langchain_core.messages.content import (
         FileContentBlock,
         ImageContentBlock,
@@ -66,8 +66,6 @@ if TYPE_CHECKING:
     )
 else:
     httpx = LazyLoader("httpx")
-
-MessageLike = Union[BaseMessage, List[str], Tuple[str, str], str, Dict[str, Any]]
 
 logger = logging.getLogger(__name__)
 
@@ -497,7 +495,7 @@ class AgentNodeExecutor(NodeExecutor):
         self.converted_components = converted_components
         self.config = config
         self._middleware: List[Any] = list(middleware or [])
-        self._agents_cache: Dict[str, CompiledStateGraph[Any, Any]] = {}
+        self._agents_cache: Dict[str, CompiledStateGraph[Any, Any, Any, Any]] = {}
 
     def _conversion_kwargs(self) -> Dict[str, Any]:
         """The converter arguments every compile from this executor passes through."""
@@ -511,7 +509,7 @@ class AgentNodeExecutor(NodeExecutor):
 
     def _create_react_agent_with_given_input_values(
         self, inputs: Dict[str, Any]
-    ) -> CompiledStateGraph[Any, Any]:
+    ) -> CompiledStateGraph[Any, Any, Any, Any]:
         from pyagentspec.adapters.langgraph._langgraphconverter import AgentSpecToLangGraphConverter
 
         if not isinstance(self.node.agent, AgentSpecAgent):
@@ -545,7 +543,7 @@ class AgentNodeExecutor(NodeExecutor):
 
     def _prepare_agent_and_inputs(
         self, inputs: Dict[str, Any], messages: Messages
-    ) -> Tuple[CompiledStateGraph[Any, Any], Dict[str, Any]]:
+    ) -> Tuple[CompiledStateGraph[Any, Any, Any, Any], Dict[str, Any]]:
         agent = self._create_react_agent_with_given_input_values(inputs)
         inputs |= {
             "remaining_steps": 20,  # Get the right number of steps left
@@ -557,7 +555,7 @@ class AgentNodeExecutor(NodeExecutor):
     def _format_agent_result(self, result: Dict[str, Any]) -> ExecuteOutput:
         if not self.node.outputs:
             generated_message = result["messages"][-1]
-            generated_messages: List[MessageLike] = [
+            generated_messages: List[MessageLikeRepresentation] = [
                 {"role": "assistant", "content": generated_message.content}
             ]
             return {}, NodeExecutionDetails(generated_messages=generated_messages)
@@ -586,7 +584,9 @@ class InputMessageNodeExecutor(NodeExecutor):
             if self.node.outputs
             else AgentSpecInputMessageNode.DEFAULT_OUTPUT
         )
-        generated_messages: List[MessageLike] = [{"role": "user", "content": response}]
+        generated_messages: List[MessageLikeRepresentation] = [
+            {"role": "user", "content": response}
+        ]
         return {output_name: response}, NodeExecutionDetails(generated_messages=generated_messages)
 
 
@@ -595,7 +595,9 @@ class OutputMessageNodeExecutor(NodeExecutor):
 
     def _execute(self, inputs: Dict[str, Any], messages: Messages) -> ExecuteOutput:
         message = render_template(self.node.message, inputs)
-        generated_messages: List[MessageLike] = [{"role": "assistant", "content": message}]
+        generated_messages: List[MessageLikeRepresentation] = [
+            {"role": "assistant", "content": message}
+        ]
         return {}, NodeExecutionDetails(generated_messages=generated_messages)
 
 
@@ -770,7 +772,7 @@ class FlowNodeExecutor(NodeExecutor):
     def __init__(
         self,
         node: AgentSpecFlowNode,
-        subflow: CompiledStateGraph[Any, Any],
+        subflow: CompiledStateGraph[Any, Any, Any, Any],
         config: RunnableConfig,
     ) -> None:
         super().__init__(node)
@@ -800,7 +802,7 @@ class CatchExceptionNodeExecutor(NodeExecutor):
     def __init__(
         self,
         node: AgentSpecCatchExceptionNode,
-        subflow: CompiledStateGraph[Any, Any],
+        subflow: CompiledStateGraph[Any, Any, Any, Any],
         config: RunnableConfig,
     ) -> None:
         super().__init__(node)
@@ -853,7 +855,7 @@ class MapNodeExecutor(NodeExecutor):
     def __init__(
         self,
         node: AgentSpecMapNode,
-        subflow: CompiledStateGraph[Any, Any],
+        subflow: CompiledStateGraph[Any, Any, Any, Any],
         config: RunnableConfig,
     ) -> None:
         super().__init__(node)

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/_types.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/_types.py
@@ -63,7 +63,9 @@ else:
 
 LangGraphTool: TypeAlias = Union[BaseTool, Callable[..., Any]]
 if TYPE_CHECKING:
-    LangGraphComponent = Union[StateGraph[Any, Any, Any], CompiledStateGraph[Any, Any, Any]]
+    LangGraphComponent = Union[
+        StateGraph[Any, Any, Any, Any], CompiledStateGraph[Any, Any, Any, Any]
+    ]
 else:
     LangGraphComponent = Union[StateGraph, CompiledStateGraph]
 LangGraphRuntimeComponent: TypeAlias = Union[LangGraphComponent, BaseChatModel, StructuredTool]

--- a/pyagentspec/tests/adapters/langgraph/flows/test_inputmessagenode.py
+++ b/pyagentspec/tests/adapters/langgraph/flows/test_inputmessagenode.py
@@ -4,8 +4,6 @@
 # (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 
-import sys
-
 import pytest
 
 from pyagentspec.flows.edges import ControlFlowEdge, DataFlowEdge
@@ -86,10 +84,6 @@ async def test_inputmessagenode_can_be_executed_async(input_message_flow: Flow) 
     agent = AgentSpecLoader(checkpointer=MemorySaver()).load_component(input_message_flow)
 
     config = RunnableConfig({"configurable": {"thread_id": "1"}})
-    if sys.version_info < (3, 11):
-        with pytest.raises(RuntimeError, match="Called get_config outside of a runnable context"):
-            await agent.ainvoke({}, config=config)
-        return
     result = await agent.ainvoke({}, config=config)
     assert "__interrupt__" in result
 

--- a/pyagentspec/tests/adapters/langgraph/flows/test_toolnode.py
+++ b/pyagentspec/tests/adapters/langgraph/flows/test_toolnode.py
@@ -4,7 +4,6 @@
 # (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 
-import sys
 from typing import Any, Dict, List
 
 import pytest
@@ -95,10 +94,6 @@ async def test_toolnode_can_be_executed_async_with_interrupt_resume(tool_flow: F
     agent = AgentSpecLoader(checkpointer=MemorySaver()).load_component(tool_flow)
 
     config = RunnableConfig({"configurable": {"thread_id": "1"}})
-    if sys.version_info < (3, 11):
-        with pytest.raises(RuntimeError, match="Called get_config outside of a runnable context"):
-            await agent.ainvoke({"inputs": {"input": 4}}, config=config)
-        return
     result = await agent.ainvoke({"inputs": {"input": 4}}, config=config)
     assert "__interrupt__" in result
 

--- a/pyagentspec/tests/adapters/langgraph/mcp/test_mcp.py
+++ b/pyagentspec/tests/adapters/langgraph/mcp/test_mcp.py
@@ -5,8 +5,6 @@
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 
 import ssl
-import sys
-from contextlib import nullcontext
 
 import pytest
 from pydantic import SecretStr
@@ -351,16 +349,7 @@ async def test_flow_with_mcp_tool_with_interrupt(sse_client_transport):
     langgraph_flow = AgentSpecLoader(checkpointer=MemorySaver()).load_component(flow)
     config = RunnableConfig({"configurable": {"thread_id": "1"}})
 
-    is_py310 = sys.version_info < (3, 11)
-    pytest_warning_raises = pytest.raises(
-        RuntimeError, match="Called get_config outside of a runnable context"
-    )
-    with pytest_warning_raises if is_py310 else nullcontext():
-        # in lower python versions, langchain interrupt does not support interrupts
-        interrupted = await langgraph_flow.ainvoke({"inputs": {"a": 2, "b": 5}}, config=config)
-
-    if is_py310:
-        return
+    interrupted = await langgraph_flow.ainvoke({"inputs": {"a": 2, "b": 5}}, config=config)
 
     assert "__interrupt__" in interrupted  # because of InputMessageNode
 


### PR DESCRIPTION
Cherry-pick dependency constraint update 287a8e20d3f275ee13dba1389b735748811e267c.\n\nChanges jsonschema from 4.23.0 to 4.26.0 and langchain-core from 1.4.6 to 1.4.9 across the runtime, development, and 26.3.0 constraint files.