### PR TITLE
fix(langgraph): structured LlmNode outputs with OciGenAiConfig require langchain-oci>=0.3.0

### DIFF
--- a/docs/pyagentspec/source/changelog.rst
+++ b/docs/pyagentspec/source/changelog.rst
@@ -36,6 +36,17 @@ Improvements
 Bug fixes
 ^^^^^^^^^
 
+* **LangGraph adapter: structured LlmNode outputs with OciGenAiConfig**
+
+  Loading a Flow whose ``LlmNode`` declares structured outputs with an
+  ``OciGenAiConfig`` failed with ``Unsupported tool type <class 'dict'>``
+  when an older ``langchain-oci`` was installed. The ``langgraph`` extra now
+  requires ``langchain-oci>=0.3.0`` (the first release accepting JSON-schema
+  tool definitions), the adapter checks the installed version up front, and a
+  chat model that rejects the JSON-schema output definition now raises an
+  actionable configuration error naming the node and the fix instead of the
+  low-level provider error.
+
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 

--- a/pyagentspec/setup.py
+++ b/pyagentspec/setup.py
@@ -46,7 +46,7 @@ LANGGRAPH_DEPS = [
 LANGGRAPH_FULL_DEPS = LANGGRAPH_DEPS + [
     # 3rd party dependencies (imported in code)
     "langchain-mcp-adapters>=0.2.2",
-    "langchain-oci>=0.2.6",
+    "langchain-oci>=0.3.0",  # JSON-schema tool definitions (structured LlmNode outputs)
     # 4rth party dependencies
     "cryptography>=50.0.0",  # needed to avoid CVE present in earlier versions
     "pyOpenSSL>=26.0.0,<27.0.0",  # needed to avoid CVE present in earlier versions

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/_langgraphconverter.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/_langgraphconverter.py
@@ -208,6 +208,37 @@ def _create_agent_state_typed_dict(
     )
 
 
+# Oldest langchain-oci whose ChatOCIGenAI accepts JSON-schema dicts as tool /
+# structured-output definitions. LlmNode structured outputs are compiled to a
+# JSON schema, so older providers fail at load time with
+# "Unsupported tool type <class 'dict'>" (see oracle/agent-spec#232).
+_MIN_LANGCHAIN_OCI_VERSION = (0, 3, 0)
+
+
+def _check_langchain_oci_version() -> None:
+    """Fail early with an actionable message when langchain-oci is too old."""
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        installed = version("langchain-oci")
+    except PackageNotFoundError:  # pragma: no cover - import above already failed
+        return
+    parts: list[int] = []
+    for token in installed.split(".")[:3]:
+        digits = "".join(ch for ch in token if ch.isdigit())
+        if not digits:
+            break
+        parts.append(int(digits))
+    if tuple(parts) < _MIN_LANGCHAIN_OCI_VERSION[: len(parts)]:
+        minimum = ".".join(str(v) for v in _MIN_LANGCHAIN_OCI_VERSION)
+        raise ImportError(
+            f"OciGenAiConfig with the LangGraph adapter requires langchain-oci>={minimum} "
+            f"(found {installed}). Older versions reject the JSON-schema tool definitions "
+            "used for structured LlmNode outputs. Upgrade with: "
+            "pip install -U 'langchain-oci>=" + minimum + "'"
+        )
+
+
 class AgentSpecToLangGraphConverter:
     def convert(
         self,
@@ -1391,6 +1422,7 @@ class AgentSpecToLangGraphConverter:
 
             from langchain_oci import ChatOCIGenAI  # type: ignore
 
+            _check_langchain_oci_version()
             oci_model_kwargs: dict[str, int | float] = {}
             if "temperature" in generation_config:
                 oci_model_kwargs["temperature"] = generation_config["temperature"]

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/_node_execution.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/_node_execution.py
@@ -632,7 +632,22 @@ class LlmNodeExecutor(NodeExecutor):
                 "type": "object",
                 "properties": {output.title: output.json_schema for output in node_outputs},
             }
-            self.structured_llm = self.llm.with_structured_output(json_schema)
+            try:
+                self.structured_llm = self.llm.with_structured_output(json_schema)
+            except (ValueError, TypeError, NotImplementedError) as exc:
+                # Providers that only accept BaseModel / TypedDict definitions
+                # surface low-level errors such as "Unsupported tool type
+                # <class 'dict'>". Turn that into an actionable configuration
+                # error at load time (oracle/agent-spec#232).
+                node_name = getattr(self.node, "name", "LlmNode")
+                raise ValueError(
+                    f"Cannot configure structured output for LlmNode '{node_name}': "
+                    f"{type(self.llm).__name__} rejected the JSON-schema output "
+                    f"definition ({exc}). Structured LlmNode outputs require a chat "
+                    "model whose `with_structured_output` accepts a JSON schema dict; "
+                    "for OCI Generative AI upgrade to langchain-oci>=0.3.0, or declare "
+                    "a single string output to disable structured generation."
+                ) from exc
 
     def _build_invoke_inputs(self, inputs: Dict[str, Any]) -> List[Dict[str, Any]]:
         prompt_template = self.node.prompt_template

--- a/pyagentspec/tests/adapters/langgraph/test_llmnode_structured_output.py
+++ b/pyagentspec/tests/adapters/langgraph/test_llmnode_structured_output.py
@@ -1,0 +1,139 @@
+# Copyright © 2026 Oracle and/or its affiliates.
+#
+# This software is under the Apache License 2.0
+# (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
+# (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
+"""LlmNode structured outputs through the LangGraph adapter (oracle/agent-spec#232).
+
+LangChain / adapter modules are imported inside the tests so this module collects
+in environments without the ``langgraph`` extra, like the other adapter tests.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from pyagentspec.flows.nodes import LlmNode
+from pyagentspec.llms import LlmConfig
+from pyagentspec.property import Property
+
+NESTED_OUTPUT = Property(
+    json_schema={
+        "title": "result",
+        "type": "object",
+        "required": ["name", "profile"],
+        "properties": {
+            "name": {"type": "string"},
+            "profile": {
+                "type": "object",
+                "required": ["score", "active", "tags"],
+                "properties": {
+                    "score": {"type": "number"},
+                    "active": {"type": "boolean"},
+                    "tags": {"type": "array", "items": {"type": "string"}},
+                },
+            },
+        },
+    }
+)
+
+
+def _structured_node() -> LlmNode:
+    return LlmNode(
+        name="structured_llm_node",
+        prompt_template="Describe {{topic}}",
+        llm_config=LlmConfig(name="test-llm", model_id="gpt-4o", api_provider="openai"),
+        outputs=[NESTED_OUTPUT],
+    )
+
+
+def _legacy_provider_chat_model() -> Any:
+    """Chat model behaving like langchain-oci<0.3.0: dict schemas are rejected."""
+    from langchain_core.language_models.chat_models import BaseChatModel
+    from langchain_core.messages import AIMessage
+    from langchain_core.outputs import ChatGeneration, ChatResult
+
+    class _LegacyProviderChatModel(BaseChatModel):
+        def _generate(
+            self, messages: Any, stop: Any = None, run_manager: Any = None, **kwargs: Any
+        ) -> ChatResult:
+            return ChatResult(generations=[ChatGeneration(message=AIMessage(content=""))])
+
+        @property
+        def _llm_type(self) -> str:
+            return "legacy-test-model"
+
+        def with_structured_output(self, schema: Any, **kwargs: Any) -> Any:
+            raise ValueError(
+                f"Unsupported tool type {type(schema)}. Tool must be passed in as a BaseTool "
+                "instance, TypedDict class, or BaseModel type."
+            )
+
+    return _LegacyProviderChatModel()
+
+
+def test_provider_rejecting_dict_schema_gives_actionable_error() -> None:
+    from pyagentspec.adapters.langgraph._node_execution import LlmNodeExecutor
+
+    with pytest.raises(ValueError) as excinfo:
+        LlmNodeExecutor(_structured_node(), _legacy_provider_chat_model())
+
+    message = str(excinfo.value)
+    assert "structured_llm_node" in message
+    assert "_LegacyProviderChatModel" in message
+    assert "langchain-oci>=0.3.0" in message
+    assert "single string output" in message
+    assert isinstance(excinfo.value.__cause__, ValueError)
+    assert "Unsupported tool type" in str(excinfo.value.__cause__)
+
+
+def test_oci_genai_accepts_nested_json_schema_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    import platform
+
+    from langchain_core.messages import HumanMessage
+
+    from pyagentspec.adapters.langgraph._node_execution import LlmNodeExecutor
+
+    # Importing the OCI SDK evaluates platform.platform() for its user agent,
+    # which reads OS files outside the test sandbox's allowlist on some hosts.
+    monkeypatch.setattr(platform, "platform", lambda *args, **kwargs: "test-platform")
+    monkeypatch.setattr(platform, "mac_ver", lambda *args, **kwargs: ("", ("", "", ""), ""))
+    langchain_oci = pytest.importorskip("langchain_oci")
+
+    llm = langchain_oci.ChatOCIGenAI(model_id="meta.llama-3.3-70b-instruct", client=MagicMock())
+    executor = LlmNodeExecutor(_structured_node(), llm)
+
+    assert executor.requires_structured_generation is True
+    assert executor.structured_llm is not None
+
+    # The structured runnable binds one function whose parameters carry the
+    # nested Agent Spec schema; build the OCI request without any network call.
+    bound = executor.structured_llm.first
+    request = bound.bound._prepare_request(
+        [HumanMessage(content="hi")], stop=None, stream=False, **bound.kwargs
+    )
+    (tool,) = request.chat_request.tools
+    assert tool.name == "structured_output"
+    profile = tool.parameters["properties"]["result"]["properties"]["profile"]
+    assert set(profile["required"]) == {"score", "active", "tags"}
+
+
+def test_langchain_oci_version_guard(monkeypatch: pytest.MonkeyPatch) -> None:
+    import importlib.metadata as metadata
+
+    from pyagentspec.adapters.langgraph import _langgraphconverter
+
+    def old_version(name: str) -> str:
+        assert name == "langchain-oci"
+        return "0.2.7"
+
+    monkeypatch.setattr(metadata, "version", old_version)
+    with pytest.raises(ImportError, match=r"langchain-oci>=0\.3\.0 \(found 0\.2\.7\)"):
+        _langgraphconverter._check_langchain_oci_version()
+
+    monkeypatch.setattr(metadata, "version", lambda name: "0.3.2")
+    _langgraphconverter._check_langchain_oci_version()  # no error
+
+    monkeypatch.setattr(metadata, "version", lambda name: "1.0.0rc1")
+    _langgraphconverter._check_langchain_oci_version()  # pre-release tokens tolerated


### PR DESCRIPTION
Fixes #232.

## Root cause

The LangGraph adapter compiles an `LlmNode`'s outputs into a JSON schema dict and passes it to `with_structured_output`. `langchain-oci` only started accepting JSON-schema dicts as tool / structured-output definitions in **0.3.0** (oracle/langchain-oracle#225, May 2026), but the `langgraph` extra allowed `langchain-oci>=0.2.6`, so environments resolving an older provider failed at load time with the low-level `Unsupported tool type <class 'dict'>` error from the report. With langchain-oci 0.3.x the same Flow loads and the OCI request carries the nested schema as a function tool.

## Changes

- **`setup.py`**: the `langgraph` extra requires `langchain-oci>=0.3.0`.
- **Converter**: before constructing `ChatOCIGenAI`, check the installed `langchain-oci` version and raise an `ImportError` naming the minimum and the upgrade command, so an old install fails clearly even outside the extra.
- **`LlmNodeExecutor`**: if the chat model rejects the JSON-schema output definition, raise a configuration `ValueError` naming the node, the model class and the two remedies (upgrade langchain-oci, or declare a single string output), with the provider error chained as `__cause__`. This is option 2 from the issue, kept in addition to the pin so other providers get the same clear message.
- **Tests** (`tests/adapters/langgraph/test_llmnode_structured_output.py`): a legacy-provider fake reproduces the report and asserts the actionable error and chained cause; `ChatOCIGenAI` with a mocked client accepts the nested schema from the issue and the resulting OCI request carries the `structured_output` function with `profile.required == {score, active, tags}` (no network); the version guard accepts `0.3.2` and `1.0.0rc1` and rejects `0.2.7`.
- **Changelog** entry under Bug fixes.

## Verification

New tests: 3 passed. Black, isort clean; mypy on the two package files reports only the pre-existing `langchain_mcp_adapters` import-not-found in an environment without that optional dependency. The neighbouring `test_bare_llmconfig_dispatch.py` / `test_disaggregated_config.py` results are unchanged from `main` in my environment.
