### PR TITLE
fix(langgraph): keep JSON Schema semantics for object values and validate node I/O

### DIFF
--- a/docs/pyagentspec/source/changelog.rst
+++ b/docs/pyagentspec/source/changelog.rst
@@ -36,6 +36,25 @@ Improvements
 Bug fixes
 ^^^^^^^^^
 
+* **LangGraph adapter: object schemas and I/O validation**
+
+  Values flowing through LangGraph agents and flows now keep the JSON Schema semantics of
+  their Agent Spec properties:
+
+  - object schemas without declared properties (including typed dictionaries) are passed
+    through as dictionaries instead of being validated by an empty model that dropped every key;
+  - additional object properties are kept when the schema allows them (``additionalProperties``
+    is ``true``, a schema, or not specified) and are still rejected when it is ``false``;
+  - declared defaults of omitted nested properties are applied, and optional properties that were
+    neither provided nor defaulted are no longer reported as ``null``;
+  - tools receive their object arguments as plain dictionaries (as in the other runtimes) instead
+    of pydantic model instances, and structured agent outputs are exposed as plain JSON values;
+  - node inputs and outputs are validated against their declared JSON schema, so a flow run with
+    a ``StartNode`` input or an ``EndNode`` output missing a nested required property, having a
+    wrong type or an unexpected key now fails with an error naming the node, the property and
+    each violation;
+  - a ``ToolNode`` without declared outputs no longer fails when its tool returns a value.
+
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 

--- a/pyagentspec/src/pyagentspec/adapters/_utils.py
+++ b/pyagentspec/src/pyagentspec/adapters/_utils.py
@@ -5,8 +5,10 @@
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 
 import re
-from typing import Any, Dict, List, Literal, Tuple, Union
+from copy import deepcopy
+from typing import Any, ClassVar, Dict, FrozenSet, List, Literal, Tuple, Union
 
+from jsonschema import Draft202012Validator
 from pydantic import BaseModel, ConfigDict, Field, create_model
 
 from pyagentspec.property import Property as AgentSpecProperty
@@ -100,6 +102,96 @@ class SchemaRegistry:
         self.models: Dict[str, type[BaseModel]] = {}
 
 
+class AgentSpecObjectModel(BaseModel):
+    """Base class of the pydantic models generated from Agent Spec object schemas.
+
+    The generated models keep the JSON Schema semantics of the property they come from:
+    additional keys are kept when the schema allows them, declared defaults are applied,
+    and optional fields that were neither provided nor defaulted are omitted when the
+    model is converted back to a plain JSON value with :func:`to_json_value`.
+    """
+
+    _agentspec_fields_with_default: ClassVar[FrozenSet[str]] = frozenset()
+
+    def to_json_value(self) -> Dict[str, Any]:
+        """Convert the model back to the plain JSON object it was validated from."""
+        result: Dict[str, Any] = {}
+        for field_name in type(self).model_fields:
+            if (
+                field_name in self.model_fields_set
+                or field_name in self._agentspec_fields_with_default
+            ):
+                result[field_name] = to_json_value(getattr(self, field_name))
+        for extra_name, extra_value in (self.model_extra or {}).items():
+            result[extra_name] = to_json_value(extra_value)
+        return result
+
+
+class _AllowExtraObjectModel(AgentSpecObjectModel):
+    """Generated object model for schemas that allow additional properties."""
+
+    model_config = ConfigDict(extra="allow")
+
+
+class _ForbidExtraObjectModel(AgentSpecObjectModel):
+    """Generated object model for schemas with ``additionalProperties: false``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+def to_json_value(value: Any) -> Any:
+    """Recursively convert generated object models (and tuples) into plain JSON values.
+
+    Pydantic models that do not come from Agent Spec schemas are left untouched so that
+    runtime-specific tools keep receiving their own argument models.
+    """
+    if isinstance(value, AgentSpecObjectModel):
+        return value.to_json_value()
+    if isinstance(value, dict):
+        return {key: to_json_value(inner_value) for key, inner_value in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [to_json_value(inner_value) for inner_value in value]
+    return value
+
+
+def apply_json_schema_defaults(value: Any, json_schema: Dict[str, Any]) -> Any:
+    """Fill the declared defaults of missing object properties, recursively.
+
+    Only object ``properties`` and array ``items`` are traversed; ``anyOf`` alternatives are
+    left untouched because the matching alternative cannot be determined reliably.
+    """
+    if isinstance(value, dict):
+        properties = json_schema.get("properties") or {}
+        if not isinstance(properties, dict):
+            return value
+        result = dict(value)
+        for property_name, property_schema in properties.items():
+            if not isinstance(property_schema, dict):
+                continue
+            if property_name in result:
+                result[property_name] = apply_json_schema_defaults(
+                    result[property_name], property_schema
+                )
+            elif "default" in property_schema:
+                result[property_name] = deepcopy(property_schema["default"])
+        return result
+    if isinstance(value, list):
+        items_schema = json_schema.get("items")
+        if isinstance(items_schema, dict):
+            return [apply_json_schema_defaults(item, items_schema) for item in value]
+    return value
+
+
+def get_json_schema_validation_errors(value: Any, json_schema: Dict[str, Any]) -> List[str]:
+    """Return human-readable validation errors of ``value`` against ``json_schema``.
+
+    An empty list means the value conforms to the schema.
+    """
+    validator = Draft202012Validator(json_schema)
+    errors = sorted(validator.iter_errors(value), key=lambda error: error.json_path)
+    return [f"{error.json_path}: {error.message}" for error in errors]
+
+
 def _build_type_from_schema(
     name: str,
     schema: Dict[str, Any],
@@ -137,6 +229,21 @@ def _build_type_from_schema(
         return List[item_type]  # type: ignore
     # objects
     if t == "object" or ("properties" in schema or "required" in schema):
+        props = schema.get("properties", {}) or {}
+        # JSON Schema allows additional properties unless the schema says otherwise
+        additional_properties = schema.get("additionalProperties", True)
+
+        if not props and additional_properties is not False:
+            # Bare object schema (or a typed dictionary): any object is accepted, so the value
+            # is passed through as a dictionary. An empty pydantic model would silently strip
+            # every key instead.
+            value_type = (
+                _build_type_from_schema(f"{name}Value", additional_properties, registry)
+                if isinstance(additional_properties, dict)
+                else Any
+            )
+            return Dict[str, value_type]  # type: ignore
+
         # Create or reuse a Pydantic model for this object schema
         model_name = schema.get("title") or name
         unique_name = model_name
@@ -145,28 +252,30 @@ def _build_type_from_schema(
             suffix += 1
             unique_name = f"{model_name}_{suffix}"
 
-        props = schema.get("properties", {}) or {}
         required = set(schema.get("required", []))
 
         fields: Dict[str, Tuple[Any, Any]] = {}
+        fields_with_default = set()
         for prop_name, prop_schema in props.items():
             prop_type = _build_type_from_schema(f"{unique_name}_{prop_name}", prop_schema, registry)
             desc = prop_schema.get("description")
-            default_field = (
-                Field(..., description=desc)
-                if prop_name in required
-                else Field(None, description=desc)
-            )
+            if prop_name in required:
+                default_field = Field(..., description=desc)
+            elif "default" in prop_schema:
+                # Omitted optional properties take their declared default
+                default_field = Field(deepcopy(prop_schema["default"]), description=desc)
+                fields_with_default.add(prop_name)
+            else:
+                default_field = Field(None, description=desc)
             fields[prop_name] = (prop_type, default_field)
 
-        # Enforce additionalProperties: False (extra=forbid)
-        extra_forbid = schema.get("additionalProperties") is False
-        model_kwargs: Dict[str, Any] = {}
-        if extra_forbid:
-            # Pydantic v2: pass a ConfigDict/dict into __config__
-            model_kwargs["__config__"] = ConfigDict(extra="forbid")
+        # additionalProperties: False -> extra=forbid, otherwise keep the extra keys (extra=allow)
+        base_model = (
+            _ForbidExtraObjectModel if additional_properties is False else _AllowExtraObjectModel
+        )
 
-        model_cls = create_model(unique_name, **fields, **model_kwargs)  # type: ignore
+        model_cls = create_model(unique_name, __base__=base_model, **fields)  # type: ignore
+        model_cls._agentspec_fields_with_default = frozenset(fields_with_default)
         registry.models[unique_name] = model_cls
         return model_cls
 

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/_langgraphconverter.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/_langgraphconverter.py
@@ -35,6 +35,7 @@ from pyagentspec.adapters._utils import (
     SchemaRegistry,
     _build_type_from_schema,
     create_pydantic_model_from_properties,
+    to_json_value,
 )
 from pyagentspec.adapters.langgraph._execution_span import patch_with_execution_span
 from pyagentspec.adapters.langgraph._managerworkers import (
@@ -787,10 +788,12 @@ class AgentSpecToLangGraphConverter:
     ) -> StructuredTool:
         tool_name = remote_tool.name
         tool_description = remote_tool.description or ""
-        _remote_tool = _confirm_then(
-            func=_create_remote_tool_func(remote_tool),
-            tool_name=tool_name,
-            requires_confirmation=remote_tool.requires_confirmation,
+        _remote_tool = _with_json_arguments(
+            _confirm_then(
+                func=_create_remote_tool_func(remote_tool),
+                tool_name=tool_name,
+                requires_confirmation=remote_tool.requires_confirmation,
+            )
         )
 
         # Use a Pydantic model for args_schema
@@ -907,6 +910,9 @@ class AgentSpecToLangGraphConverter:
         requires_confirmation = agentspec_client_tool.requires_confirmation
 
         def client_tool(*args: Any, **kwargs: Any) -> Any:
+            # The client receives plain JSON values, not the generated argument models
+            args = tuple(to_json_value(args))
+            kwargs = to_json_value(kwargs)
             if requires_confirmation:
                 if args:
                     raise ValueError("Args are not supported, please only use kwargs")
@@ -1909,6 +1915,39 @@ def _as_structured_tool_coroutine(
     return _wrapped_async
 
 
+@overload
+def _with_json_arguments(
+    func: Callable[..., Awaitable[Any]],
+) -> Callable[..., Awaitable[Any]]: ...
+
+
+@overload
+def _with_json_arguments(
+    func: Callable[..., Any],
+) -> Callable[..., Any]: ...
+
+
+def _with_json_arguments(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Wrap a tool callable so that it receives plain JSON values as arguments.
+
+    LangChain validates tool arguments with the pydantic models generated from the Agent Spec
+    input schemas and passes the model instances of nested objects to the callable. Agent Spec
+    tools are written against JSON values (as in the other runtimes), so those instances are
+    converted back to dictionaries before the call.
+    """
+    if _is_async_callable(func):
+
+        async def _wrapped_async(*args: Any, **kwargs: Any) -> Any:
+            return await func(*to_json_value(args), **to_json_value(kwargs))
+
+        return _wrapped_async
+
+    def _wrapped_sync(*args: Any, **kwargs: Any) -> Any:
+        return func(*to_json_value(args), **to_json_value(kwargs))
+
+    return _wrapped_sync
+
+
 class StructuredToolCallableKwargs(TypedDict, total=False):
     func: Callable[..., Any]
     coroutine: Callable[..., Awaitable[Any]]
@@ -1933,24 +1972,30 @@ def _get_structured_tool_callable_kwargs(
     if isinstance(tool_obj, BaseTool):
         tool_func = getattr(tool_obj, "func", None)
         if tool_func is not None:
-            structured_tool_callable_kwargs["func"] = _confirm_then(
-                func=tool_func,
-                tool_name=tool_name,
-                requires_confirmation=requires_confirmation,
+            structured_tool_callable_kwargs["func"] = _with_json_arguments(
+                _confirm_then(
+                    func=tool_func,
+                    tool_name=tool_name,
+                    requires_confirmation=requires_confirmation,
+                )
             )
 
         tool_coroutine = getattr(tool_obj, "coroutine", None)
         if tool_coroutine is not None:
-            structured_tool_callable_kwargs["coroutine"] = _confirm_then(
-                func=tool_coroutine,
+            structured_tool_callable_kwargs["coroutine"] = _with_json_arguments(
+                _confirm_then(
+                    func=tool_coroutine,
+                    tool_name=tool_name,
+                    requires_confirmation=requires_confirmation,
+                )
+            )
+    elif callable(tool_obj):
+        wrapped_tool = _with_json_arguments(
+            _confirm_then(
+                func=tool_obj,
                 tool_name=tool_name,
                 requires_confirmation=requires_confirmation,
             )
-    elif callable(tool_obj):
-        wrapped_tool = _confirm_then(
-            func=tool_obj,
-            tool_name=tool_name,
-            requires_confirmation=requires_confirmation,
         )
         if _is_async_callable(wrapped_tool):
             structured_tool_callable_kwargs["coroutine"] = wrapped_tool

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/_node_execution.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/_node_execution.py
@@ -10,13 +10,20 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
 
 import anyio
+from pydantic import BaseModel
 
 from pyagentspec._lazy_loader import LazyLoader
 from pyagentspec.adapters._url_validation import (
     maybe_warn_about_unrestricted_templated_url,
     validate_url_against_allow_list,
 )
-from pyagentspec.adapters._utils import render_nested_object_template, render_template
+from pyagentspec.adapters._utils import (
+    apply_json_schema_defaults,
+    get_json_schema_validation_errors,
+    render_nested_object_template,
+    render_template,
+    to_json_value,
+)
 from pyagentspec.adapters.langgraph._types import (
     BaseChatModel,
     Checkpointer,
@@ -129,7 +136,11 @@ class NodeExecutor(ABC):
         for property_ in properties:
             key = property_.title
             if key in values_dict:
-                value = values_dict.get(key)
+                # Flow values are plain JSON: models generated from Agent Spec schemas
+                # (and models returned by tools) are converted back to dictionaries.
+                value = to_json_value(values_dict.get(key))
+                if isinstance(value, BaseModel):
+                    value = value.model_dump()
                 if property_.type == "string" and not isinstance(value, str):
                     value = json.dumps(value)
                 elif property_.type == "boolean" and isinstance(value, (int, float)):
@@ -138,20 +149,22 @@ class NodeExecutor(ABC):
                     value = int(value)
                 elif property_.type == "integer" and isinstance(value, str):
                     # Try converting numeric strings to integers; if it fails, leave as-is
+                    # so that the schema validation below reports the invalid value
                     try:
                         value = int(value.strip())
-                    except ValueError as e:
-                        if not str(e).startswith("could not convert string to int:"):
-                            raise e
+                    except ValueError:
+                        pass
                 elif property_.type == "number" and isinstance(value, (int, bool)):
                     value = float(value)
                 elif property_.type == "number" and isinstance(value, str):
                     # Try converting numeric strings to floats; if it fails, leave as-is
+                    # so that the schema validation below reports the invalid value
                     try:
                         value = float(value.strip())
-                    except ValueError as e:
-                        if not str(e).startswith("could not convert string to float:"):
-                            raise e
+                    except ValueError:
+                        pass
+                value = apply_json_schema_defaults(value, property_.json_schema)
+                self._validate_value_against_schema(property_, value)
                 results_dict[key] = value
             elif property_.default is not pyagentspec_empty_default:
                 results_dict[key] = property_.default
@@ -161,6 +174,16 @@ class NodeExecutor(ABC):
                     f"for property `{property_.title}`, but none was found."
                 )
         return results_dict
+
+    def _validate_value_against_schema(self, property_: AgentSpecProperty, value: Any) -> None:
+        """Raise a ValueError if the value does not conform to the property's JSON schema."""
+        errors = get_json_schema_validation_errors(value, property_.json_schema)
+        if errors:
+            error_details = "\n".join(f"  - {error}" for error in errors)
+            raise ValueError(
+                f"The value of property `{property_.title}` of node `{self.node.name}` does not "
+                f"conform to its declared JSON schema:\n{error_details}"
+            )
 
     async def _aexecute(self, inputs: Dict[str, Any], messages: Messages) -> ExecuteOutput:
         """Default async implementation delegates to sync _execute in a worker thread.
@@ -341,9 +364,9 @@ class ToolNodeExecutor(NodeExecutor):
         """
         node_output_properties = self.node.outputs or []
         if not node_output_properties:
-            # the node does not emit any output
+            # the node does not emit any output, whatever the tool returned
             mapped = {}
-        if isinstance(tool_output, list) and self._is_mcp_content_blocks_list(tool_output):
+        elif isinstance(tool_output, list) and self._is_mcp_content_blocks_list(tool_output):
             extracted_values = self._extract_values_from_content_blocks(tool_output)
             mapped = {
                 property_.title: extracted_values[i]
@@ -935,7 +958,7 @@ def extract_outputs_from_invoke_result(
     # Extracts the outputs from the return value of an invoke call made on an agent
     # The outputs are typically exposed as part of the `structured_response`, or as entries in the result directly.
     # We give priority to the latter.
-    return {
+    outputs = {
         # Defaults if available
         **{
             output.title: output.default
@@ -951,3 +974,6 @@ def extract_outputs_from_invoke_result(
             if output.title in result
         },
     }
+    # Structured responses are generated through pydantic models built from the Agent Spec
+    # output schemas; expose them as plain JSON values.
+    return cast(Dict[str, Any], to_json_value(outputs))

--- a/pyagentspec/tests/adapters/langgraph/flows/test_schema_fidelity.py
+++ b/pyagentspec/tests/adapters/langgraph/flows/test_schema_fidelity.py
@@ -1,0 +1,370 @@
+# Copyright © 2026 Oracle and/or its affiliates.
+#
+# This software is under the Apache License 2.0
+# (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
+# (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
+"""Flows executed with the LangGraph adapter honour the JSON schemas declared on their nodes.
+
+Covers oracle/agent-spec#220, #231, #233, #239 and #241, plus ToolNodes without outputs.
+"""
+
+from typing import Any, Callable, Dict, List
+
+import pytest
+
+from pyagentspec.adapters.langgraph import AgentSpecLoader
+from pyagentspec.flows.edges import ControlFlowEdge, DataFlowEdge
+from pyagentspec.flows.flow import Flow
+from pyagentspec.flows.nodes import EndNode, StartNode, ToolNode
+from pyagentspec.property import IntegerProperty, Property, StringProperty
+from pyagentspec.tools import ServerTool
+
+PAYLOAD_SCHEMA: Dict[str, Any] = {
+    "title": "payload",
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "profile": {
+            "type": "object",
+            "properties": {
+                "score": {"type": "number"},
+                "active": {"type": "boolean"},
+                "tags": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": ["score", "active", "tags"],
+        },
+    },
+    "required": ["name", "profile"],
+    "additionalProperties": False,
+}
+
+# Same shape as PAYLOAD_SCHEMA, but nothing is required
+PERMISSIVE_PAYLOAD_SCHEMA: Dict[str, Any] = {
+    "title": "payload",
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "profile": {
+            "type": "object",
+            "properties": {
+                "score": {"type": "number"},
+                "active": {"type": "boolean"},
+                "tags": {"type": "array", "items": {"type": "string"}},
+            },
+        },
+    },
+    "additionalProperties": False,
+}
+
+STATE_SCHEMA: Dict[str, Any] = {
+    "title": "state",
+    "type": "object",
+    "properties": {
+        "counter": {"type": "integer"},
+        "trace": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": ["counter", "trace"],
+    "additionalProperties": True,
+}
+
+REQUEST_SCHEMA: Dict[str, Any] = {
+    "title": "request",
+    "type": "object",
+    "properties": {
+        "customer_id": {"type": "string"},
+        "profile": {
+            "type": "object",
+            "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
+            "required": ["name", "age"],
+        },
+        "tags": {"type": "array", "items": {"type": "string"}},
+        "priority": {"type": "string", "default": "normal"},
+        "notifications": {"type": "boolean", "default": True},
+    },
+    "required": ["customer_id", "profile", "tags"],
+    "additionalProperties": False,
+}
+
+
+def _chain_of_tool_nodes_flow(
+    flow_input: Property,
+    flow_output: Property,
+    tools: List[ServerTool],
+) -> Flow:
+    """Start -> ToolNode(tools[0]) -> ... -> ToolNode(tools[-1]) -> End, passing one value along."""
+    start = StartNode(name="start", inputs=[flow_input])
+    end = EndNode(name="end", outputs=[flow_output])
+    tool_nodes = [ToolNode(name=f"{tool.name}_node", tool=tool) for tool in tools]
+    nodes = [start, *tool_nodes, end]
+
+    control_flow_connections = [
+        ControlFlowEdge(name=f"{source.name}_to_{target.name}", from_node=source, to_node=target)
+        for source, target in zip(nodes[:-1], nodes[1:])
+    ]
+    data_flow_connections = [
+        DataFlowEdge(
+            name=f"{source.name}_value_to_{target.name}",
+            source_node=source,
+            source_output=(source.outputs or [])[0].title if source.outputs else flow_input.title,
+            destination_node=target,
+            destination_input=(
+                (target.inputs or [])[0].title if target.inputs else flow_output.title
+            ),
+        )
+        for source, target in zip(nodes[:-1], nodes[1:])
+    ]
+    return Flow(
+        name="schema_fidelity_flow",
+        start_node=start,
+        nodes=nodes,
+        control_flow_connections=control_flow_connections,
+        data_flow_connections=data_flow_connections,
+    )
+
+
+def _start_to_end_flow(flow_input: Property, flow_output: Property) -> Flow:
+    start = StartNode(name="start", inputs=[flow_input])
+    end = EndNode(name="end", outputs=[flow_output])
+    return Flow(
+        name="start_to_end_flow",
+        start_node=start,
+        nodes=[start, end],
+        control_flow_connections=[
+            ControlFlowEdge(name="start_to_end", from_node=start, to_node=end)
+        ],
+        data_flow_connections=[
+            DataFlowEdge(
+                name="value",
+                source_node=start,
+                source_output=flow_input.title,
+                destination_node=end,
+                destination_input=flow_output.title,
+            )
+        ],
+    )
+
+
+def _run(flow: Flow, inputs: Dict[str, Any], tool_registry: Dict[str, Callable[..., Any]]) -> Any:
+    graph = AgentSpecLoader(tool_registry=tool_registry).load_component(flow)
+    return graph.invoke({"inputs": inputs})["outputs"]
+
+
+@pytest.mark.parametrize("tool_return_value", [None, "done", 3, [1, 2]])
+def test_toolnode_without_outputs_accepts_any_tool_return_value(tool_return_value: Any) -> None:
+    # A ToolNode with no declared output used to fail with "Unsupported multi-output mapping"
+    notify = ServerTool(
+        name="notify",
+        description="Sends a notification and returns nothing useful",
+        inputs=[StringProperty(title="message")],
+        outputs=[],
+    )
+    start = StartNode(name="start", inputs=[StringProperty(title="message")])
+    notify_node = ToolNode(name="notify_node", tool=notify)
+    end = EndNode(name="end", outputs=[])
+    flow = Flow(
+        name="notify_flow",
+        start_node=start,
+        nodes=[start, notify_node, end],
+        control_flow_connections=[
+            ControlFlowEdge(name="start_to_notify", from_node=start, to_node=notify_node),
+            ControlFlowEdge(name="notify_to_end", from_node=notify_node, to_node=end),
+        ],
+        data_flow_connections=[
+            DataFlowEdge(
+                name="message",
+                source_node=start,
+                source_output="message",
+                destination_node=notify_node,
+                destination_input="message",
+            )
+        ],
+    )
+    received: List[str] = []
+
+    def notify_tool(message: str) -> Any:
+        received.append(message)
+        return tool_return_value
+
+    assert _run(flow, {"message": "hello"}, {"notify": notify_tool}) == {}
+    assert received == ["hello"]
+
+
+def test_server_tool_receives_object_inputs_as_plain_dictionaries() -> None:
+    # Tools are written against JSON values, as in the other runtimes
+    request = Property(json_schema=REQUEST_SCHEMA)
+    echo = ServerTool(name="echo", description="Echoes", inputs=[request], outputs=[request])
+    flow = _chain_of_tool_nodes_flow(request, request, [echo])
+    received: List[Any] = []
+
+    def echo_tool(request: Any) -> Any:
+        received.append(request)
+        return request
+
+    _run(
+        flow,
+        {"request": {"customer_id": "C-1", "profile": {"name": "Ada", "age": 36}, "tags": []}},
+        {"echo": echo_tool},
+    )
+    assert type(received[0]) is dict
+    assert type(received[0]["profile"]) is dict
+
+
+def test_additional_object_fields_are_preserved_across_tool_nodes() -> None:
+    # oracle/agent-spec#239
+    state = Property(json_schema=STATE_SCHEMA)
+    tools = [
+        ServerTool(name=f"step{i}", description=f"Step {i}", inputs=[state], outputs=[state])
+        for i in (1, 2, 3)
+    ]
+    flow = _chain_of_tool_nodes_flow(state, state, tools)
+
+    def make_step(step_name: str, increment: int, label: str) -> Callable[..., Any]:
+        def step(state: Dict[str, Any]) -> Dict[str, Any]:
+            new_state = dict(state)
+            new_state["counter"] = state["counter"] + increment
+            new_state["trace"] = [*state["trace"], step_name]
+            new_state[step_name] = label
+            return new_state
+
+        return step
+
+    outputs = _run(
+        flow,
+        {"state": {"counter": 0, "trace": []}},
+        {
+            "step1": make_step("step1", 1, "initialized"),
+            "step2": make_step("step2", 10, "enriched"),
+            "step3": make_step("step3", 100, "finalized"),
+        },
+    )
+    assert outputs == {
+        "state": {
+            "counter": 111,
+            "trace": ["step1", "step2", "step3"],
+            "step1": "initialized",
+            "step2": "enriched",
+            "step3": "finalized",
+        }
+    }
+
+
+def test_declared_defaults_are_applied_to_omitted_nested_fields() -> None:
+    # oracle/agent-spec#241
+    request = Property(json_schema=REQUEST_SCHEMA)
+    normalize = ServerTool(
+        name="normalize", description="Normalizes", inputs=[request], outputs=[request]
+    )
+    flow = _chain_of_tool_nodes_flow(request, request, [normalize])
+    received: List[Any] = []
+
+    def normalize_tool(request: Dict[str, Any]) -> Dict[str, Any]:
+        received.append(request)
+        return request
+
+    expected = {
+        "customer_id": "C-1042",
+        "profile": {"name": "Ada", "age": 36},
+        "tags": ["priority", "verified"],
+        "priority": "normal",
+        "notifications": True,
+    }
+    outputs = _run(
+        flow,
+        {
+            "request": {
+                "customer_id": "C-1042",
+                "profile": {"name": "Ada", "age": 36},
+                "tags": ["priority", "verified"],
+            }
+        },
+        {"normalize": normalize_tool},
+    )
+    assert received == [expected]
+    assert outputs == {"request": expected}
+
+
+def test_bare_object_items_keep_their_keys() -> None:
+    # oracle/agent-spec#220
+    components = Property(
+        json_schema={"title": "components", "type": "array", "items": {"type": "object"}}
+    )
+    render = ServerTool(
+        name="render", description="Renders", inputs=[components], outputs=[components]
+    )
+    flow = _chain_of_tool_nodes_flow(components, components, [render])
+    value = [{"id": "root", "component": "Card", "children": [{"id": "title"}]}]
+    outputs = _run(flow, {"components": value}, {"render": lambda components: components})
+    assert outputs == {"components": value}
+
+
+def test_start_node_rejects_input_not_conforming_to_nested_schema() -> None:
+    # oracle/agent-spec#231
+    payload = Property(json_schema=PAYLOAD_SCHEMA)
+    flow = _start_to_end_flow(payload, payload)
+    with pytest.raises(
+        ValueError, match=r"(?s)`payload` of node `start`.*'active' is a required"
+    ) as e:
+        _run(
+            flow,
+            {"payload": {"name": "Ada", "profile": {"score": 0.98, "tags": ["verified"]}}},
+            {},
+        )
+    assert "$.profile" in str(e.value)
+
+
+def test_start_node_reports_all_schema_violations() -> None:
+    payload = Property(json_schema=PAYLOAD_SCHEMA)
+    flow = _start_to_end_flow(payload, payload)
+    with pytest.raises(ValueError) as e:
+        _run(
+            flow,
+            {"payload": {"name": 123, "profile": {"score": "high", "tags": []}, "extra": 1}},
+            {},
+        )
+    message = str(e.value)
+    assert "Additional properties are not allowed ('extra' was unexpected)" in message
+    assert "$.name: 123 is not of type 'string'" in message
+    assert "$.profile: 'active' is a required property" in message
+    assert "$.profile.score: 'high' is not of type 'number'" in message
+
+
+def test_end_node_rejects_value_not_conforming_to_its_schema() -> None:
+    # oracle/agent-spec#233: a permissive StartNode lets the value in, the strict EndNode
+    # must still reject it
+    flow = _start_to_end_flow(
+        Property(json_schema=PERMISSIVE_PAYLOAD_SCHEMA), Property(json_schema=PAYLOAD_SCHEMA)
+    )
+    with pytest.raises(ValueError, match=r"(?s)`payload` of node `end`.*'active' is a required"):
+        _run(
+            flow,
+            {"payload": {"name": "Ada", "profile": {"score": 0.98, "tags": ["verified"]}}},
+            {},
+        )
+
+
+def test_end_node_accepts_conforming_value() -> None:
+    flow = _start_to_end_flow(
+        Property(json_schema=PERMISSIVE_PAYLOAD_SCHEMA), Property(json_schema=PAYLOAD_SCHEMA)
+    )
+    value = {"name": "Ada", "profile": {"score": 0.98, "active": True, "tags": ["verified"]}}
+    assert _run(flow, {"payload": value}, {}) == {"payload": value}
+
+
+def test_integer_input_given_non_numeric_string_raises_schema_error() -> None:
+    number = IntegerProperty(title="n")
+    flow = _start_to_end_flow(number, number)
+    with pytest.raises(
+        ValueError, match=r"(?s)`n` of node `start`.*'abc' is not of type 'integer'"
+    ):
+        _run(flow, {"n": "abc"}, {})
+    with pytest.raises(ValueError, match=r"\[1, 2\] is not of type 'integer'"):
+        _run(flow, {"n": [1, 2]}, {})
+    # Numeric strings are still accepted and cast
+    assert _run(flow, {"n": " 7 "}, {}) == {"n": 7}
+
+
+def test_untyped_property_accepts_any_value() -> None:
+    anything = Property(json_schema={"title": "anything"})
+    flow = _start_to_end_flow(anything, anything)
+    value = {"nested": [1, "two", None, {"three": 3.0}]}
+    assert _run(flow, {"anything": value}, {}) == {"anything": value}

--- a/pyagentspec/tests/adapters/langgraph/flows/test_toolnode.py
+++ b/pyagentspec/tests/adapters/langgraph/flows/test_toolnode.py
@@ -188,9 +188,10 @@ def test_toolnode_single_output_wraps_single_dict_under_declared_key() -> None:
 
 
 def test_toolnode_single_output_unwraps_single_dict_under_same_key() -> None:
+    # The unwrapped value is not an object, so the declared output is untyped
     flow = _build_flow_with_client_tool(
         input_prop=NumberProperty(title="x"),
-        output_props=[ObjectProperty(title="out_dict", properties={})],
+        output_props=[Property(json_schema={"title": "out_dict"})],
     )
     expected_return_value = {"out_dict": 1}
     outputs = _run_flow_and_resume(flow, expected_return_value)

--- a/pyagentspec/tests/adapters/langgraph/test_tool_json_arguments.py
+++ b/pyagentspec/tests/adapters/langgraph/test_tool_json_arguments.py
@@ -1,0 +1,134 @@
+# Copyright © 2026 Oracle and/or its affiliates.
+#
+# This software is under the Apache License 2.0
+# (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
+# (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
+"""Tools converted to LangGraph receive their object arguments as plain JSON values.
+
+LangChain validates tool calls with the pydantic models generated from the Agent Spec input
+schemas and would otherwise hand the nested model instances to the tool callable.
+"""
+
+from typing import Any, Dict, List
+
+import pytest
+
+from pyagentspec.adapters.langgraph import AgentSpecLoader
+from pyagentspec.flows.edges import ControlFlowEdge, DataFlowEdge
+from pyagentspec.flows.flow import Flow
+from pyagentspec.flows.nodes import EndNode, StartNode, ToolNode
+from pyagentspec.property import Property, StringProperty
+from pyagentspec.tools import ClientTool, ServerTool
+
+LOCATION_SCHEMA: Dict[str, Any] = {
+    "title": "location",
+    "type": "object",
+    "properties": {
+        "city": {"type": "string"},
+        "coordinates": {
+            "type": "object",
+            "properties": {"lat": {"type": "number"}, "lon": {"type": "number"}},
+            "required": ["lat", "lon"],
+        },
+        "units": {"type": "string", "default": "metric"},
+    },
+    "required": ["city", "coordinates"],
+}
+
+LOCATION_CALL = {"location": {"city": "Zurich", "coordinates": {"lat": 47.37, "lon": 8.54}}}
+EXPECTED_LOCATION = {
+    "city": "Zurich",
+    "coordinates": {"lat": 47.37, "lon": 8.54},
+    "units": "metric",
+}
+
+
+def _forecast_tool() -> ServerTool:
+    return ServerTool(
+        name="forecast",
+        description="Forecasts the weather at a location",
+        inputs=[Property(json_schema=LOCATION_SCHEMA)],
+        outputs=[StringProperty(title="forecast")],
+    )
+
+
+def test_sync_server_tool_receives_plain_dictionaries() -> None:
+    received: List[Any] = []
+
+    def forecast(location: Dict[str, Any]) -> str:
+        received.append(location)
+        return f"sunny in {location['city']}"
+
+    langgraph_tool = AgentSpecLoader(tool_registry={"forecast": forecast}).load_component(
+        _forecast_tool()
+    )
+    assert langgraph_tool.invoke(LOCATION_CALL) == "sunny in Zurich"
+    assert received == [EXPECTED_LOCATION]
+    assert type(received[0]) is dict
+    assert type(received[0]["coordinates"]) is dict
+
+
+@pytest.mark.anyio
+async def test_async_server_tool_receives_plain_dictionaries() -> None:
+    received: List[Any] = []
+
+    async def forecast(location: Dict[str, Any]) -> str:
+        received.append(location)
+        return f"sunny in {location['city']}"
+
+    langgraph_tool = AgentSpecLoader(tool_registry={"forecast": forecast}).load_component(
+        _forecast_tool()
+    )
+    assert await langgraph_tool.ainvoke(LOCATION_CALL) == "sunny in Zurich"
+    assert received == [EXPECTED_LOCATION]
+    assert type(received[0]) is dict
+
+
+def test_client_tool_interrupt_payload_contains_plain_dictionaries() -> None:
+    from langchain_core.runnables import RunnableConfig
+    from langgraph.checkpoint.memory import MemorySaver
+
+    location = Property(json_schema=LOCATION_SCHEMA)
+    forecast_output = StringProperty(title="forecast")
+    client_tool = ClientTool(
+        name="forecast",
+        description="Forecasts the weather at a location, on the client",
+        inputs=[location],
+        outputs=[forecast_output],
+    )
+    start = StartNode(name="start", inputs=[location])
+    tool_node = ToolNode(name="forecast_node", tool=client_tool)
+    end = EndNode(name="end", outputs=[forecast_output])
+    flow = Flow(
+        name="forecast_flow",
+        start_node=start,
+        nodes=[start, tool_node, end],
+        control_flow_connections=[
+            ControlFlowEdge(name="start_to_tool", from_node=start, to_node=tool_node),
+            ControlFlowEdge(name="tool_to_end", from_node=tool_node, to_node=end),
+        ],
+        data_flow_connections=[
+            DataFlowEdge(
+                name="location",
+                source_node=start,
+                source_output="location",
+                destination_node=tool_node,
+                destination_input="location",
+            ),
+            DataFlowEdge(
+                name="forecast",
+                source_node=tool_node,
+                source_output="forecast",
+                destination_node=end,
+                destination_input="forecast",
+            ),
+        ],
+    )
+    graph = AgentSpecLoader(checkpointer=MemorySaver()).load_component(flow)
+    config = RunnableConfig({"configurable": {"thread_id": "forecast"}})
+    result = graph.invoke({"inputs": LOCATION_CALL}, config=config)
+
+    tool_request = result["__interrupt__"][0].value
+    assert tool_request["name"] == "forecast"
+    assert tool_request["inputs"]["kwargs"] == {"location": EXPECTED_LOCATION}
+    assert type(tool_request["inputs"]["kwargs"]["location"]) is dict

--- a/pyagentspec/tests/adapters/test_schema_models.py
+++ b/pyagentspec/tests/adapters/test_schema_models.py
@@ -1,0 +1,264 @@
+# Copyright © 2026 Oracle and/or its affiliates.
+#
+# This software is under the Apache License 2.0
+# (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
+# (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
+"""Pydantic models generated from Agent Spec JSON schemas keep the JSON Schema semantics."""
+
+from copy import deepcopy
+from typing import Any, Dict
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from pyagentspec.adapters._utils import (
+    AgentSpecObjectModel,
+    apply_json_schema_defaults,
+    create_pydantic_model_from_properties,
+    get_json_schema_validation_errors,
+    to_json_value,
+)
+from pyagentspec.property import DictProperty, IntegerProperty, Property
+
+REQUEST_SCHEMA: Dict[str, Any] = {
+    "title": "request",
+    "type": "object",
+    "properties": {
+        "customer_id": {"type": "string"},
+        "profile": {
+            "type": "object",
+            "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
+            "required": ["name", "age"],
+        },
+        "tags": {"type": "array", "items": {"type": "string"}},
+        "priority": {"type": "string", "default": "normal"},
+        "notifications": {"type": "boolean", "default": True},
+        "note": {"type": "string"},
+    },
+    "required": ["customer_id", "profile", "tags"],
+    "additionalProperties": False,
+}
+
+STATE_SCHEMA: Dict[str, Any] = {
+    "title": "state",
+    "type": "object",
+    "properties": {
+        "counter": {"type": "integer"},
+        "trace": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": ["counter", "trace"],
+    "additionalProperties": True,
+}
+
+
+def test_bare_object_schema_is_passed_through_as_dictionary() -> None:
+    # oracle/agent-spec#220: an empty model used to silently strip every key
+    model = create_pydantic_model_from_properties(
+        "ToolArgs",
+        [Property(title="components", json_schema={"type": "array", "items": {"type": "object"}})],
+    )
+    parsed = model(components=[{"id": "root", "component": "Card"}])
+    assert to_json_value(parsed.components) == [{"id": "root", "component": "Card"}]
+
+
+def test_typed_dictionary_schema_keeps_keys_and_validates_values() -> None:
+    model = create_pydantic_model_from_properties(
+        "ToolArgs", [DictProperty(title="scores", value_type=IntegerProperty())]
+    )
+    assert model(scores={"a": 1, "b": 2}).scores == {"a": 1, "b": 2}
+    with pytest.raises(ValidationError):
+        model(scores={"a": "not an integer"})
+
+
+def test_additional_properties_are_kept_when_allowed() -> None:
+    # oracle/agent-spec#239
+    model = create_pydantic_model_from_properties("Args", [Property(json_schema=STATE_SCHEMA)])
+    parsed = model(state={"counter": 1, "trace": ["step1"], "step1": "initialized"})
+    assert isinstance(parsed.state, AgentSpecObjectModel)
+    assert to_json_value(parsed.state) == {
+        "counter": 1,
+        "trace": ["step1"],
+        "step1": "initialized",
+    }
+
+
+def test_additional_properties_are_kept_when_unspecified() -> None:
+    schema = {key: value for key, value in STATE_SCHEMA.items() if key != "additionalProperties"}
+    model = create_pydantic_model_from_properties("Args", [Property(json_schema=schema)])
+    parsed = model(state={"counter": 1, "trace": [], "extra": "kept"})
+    assert to_json_value(parsed.state) == {"counter": 1, "trace": [], "extra": "kept"}
+
+
+def test_additional_properties_are_rejected_when_forbidden() -> None:
+    model = create_pydantic_model_from_properties("Args", [Property(json_schema=REQUEST_SCHEMA)])
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        model(
+            request={
+                "customer_id": "C-1042",
+                "profile": {"name": "Ada", "age": 36},
+                "tags": [],
+                "extra": 1,
+            }
+        )
+
+
+def test_declared_defaults_are_applied_and_unset_optionals_are_omitted() -> None:
+    # oracle/agent-spec#241: omitted defaulted fields used to come out as None
+    model = create_pydantic_model_from_properties("Args", [Property(json_schema=REQUEST_SCHEMA)])
+    parsed = model(
+        request={
+            "customer_id": "C-1042",
+            "profile": {"name": "Ada", "age": 36},
+            "tags": ["priority", "verified"],
+        }
+    )
+    assert to_json_value(parsed.request) == {
+        "customer_id": "C-1042",
+        "profile": {"name": "Ada", "age": 36},
+        "tags": ["priority", "verified"],
+        "priority": "normal",
+        "notifications": True,
+    }
+
+
+def test_explicitly_provided_values_take_precedence_over_defaults() -> None:
+    model = create_pydantic_model_from_properties("Args", [Property(json_schema=REQUEST_SCHEMA)])
+    parsed = model(
+        request={
+            "customer_id": "C-1042",
+            "profile": {"name": "Ada", "age": 36},
+            "tags": [],
+            "priority": "high",
+            "notifications": False,
+            "note": "call back",
+        }
+    )
+    assert to_json_value(parsed.request) == {
+        "customer_id": "C-1042",
+        "profile": {"name": "Ada", "age": 36},
+        "tags": [],
+        "priority": "high",
+        "notifications": False,
+        "note": "call back",
+    }
+
+
+def test_nested_required_fields_are_still_validated() -> None:
+    model = create_pydantic_model_from_properties("Args", [Property(json_schema=REQUEST_SCHEMA)])
+    with pytest.raises(ValidationError, match="age"):
+        model(request={"customer_id": "C-1042", "profile": {"name": "Ada"}, "tags": []})
+
+
+def test_to_json_value_converts_nested_models_recursively() -> None:
+    schema = {
+        "title": "order",
+        "type": "object",
+        "properties": {
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {"sku": {"type": "string"}, "qty": {"type": "integer"}},
+                    "required": ["sku"],
+                },
+            },
+            "shipping": {
+                "type": "object",
+                "properties": {"express": {"type": "boolean", "default": False}},
+            },
+        },
+        "required": ["items"],
+    }
+    model = create_pydantic_model_from_properties("Args", [Property(json_schema=schema)])
+    parsed = model(order={"items": [{"sku": "A", "qty": 2}, {"sku": "B"}], "shipping": {}})
+    assert to_json_value(parsed.order) == {
+        "items": [{"sku": "A", "qty": 2}, {"sku": "B"}],
+        "shipping": {"express": False},
+    }
+
+
+def test_to_json_value_leaves_foreign_models_untouched_and_converts_tuples() -> None:
+    class ForeignArguments(BaseModel):
+        value: int
+
+    foreign = ForeignArguments(value=1)
+    assert to_json_value({"model": foreign, "pair": (1, 2)}) == {"model": foreign, "pair": [1, 2]}
+    assert to_json_value("text") == "text"
+
+
+@pytest.mark.parametrize(
+    "value, json_schema, expected",
+    [
+        (
+            {"customer_id": "C-1"},
+            REQUEST_SCHEMA,
+            {"customer_id": "C-1", "priority": "normal", "notifications": True},
+        ),
+        # Provided values are not overwritten
+        (
+            {"customer_id": "C-1", "priority": "high"},
+            REQUEST_SCHEMA,
+            {"customer_id": "C-1", "priority": "high", "notifications": True},
+        ),
+        # Defaults are applied inside array items
+        (
+            [{"a": 1}, {}],
+            {
+                "type": "array",
+                "items": {"type": "object", "properties": {"a": {"type": "integer", "default": 0}}},
+            },
+            [{"a": 1}, {"a": 0}],
+        ),
+        # Defaults are applied inside nested objects
+        (
+            {"inner": {}},
+            {
+                "type": "object",
+                "properties": {
+                    "inner": {
+                        "type": "object",
+                        "properties": {"flag": {"type": "boolean", "default": True}},
+                    }
+                },
+            },
+            {"inner": {"flag": True}},
+        ),
+        # Non-object values and untyped schemas are returned as they are
+        ("text", {"type": "string", "default": "other"}, "text"),
+        ({"a": 1}, {}, {"a": 1}),
+    ],
+)
+def test_apply_json_schema_defaults(value: Any, json_schema: Dict[str, Any], expected: Any) -> None:
+    original_value = deepcopy(value)
+    assert apply_json_schema_defaults(value, json_schema) == expected
+    # The input value is not mutated
+    assert value == original_value
+
+
+def test_apply_json_schema_defaults_copies_mutable_defaults() -> None:
+    json_schema = {
+        "type": "object",
+        "properties": {"tags": {"type": "array", "items": {"type": "string"}, "default": []}},
+    }
+    first = apply_json_schema_defaults({}, json_schema)
+    first["tags"].append("mutated")
+    assert apply_json_schema_defaults({}, json_schema) == {"tags": []}
+
+
+def test_get_json_schema_validation_errors() -> None:
+    assert (
+        get_json_schema_validation_errors(
+            {"customer_id": "C-1", "profile": {"name": "Ada", "age": 36}, "tags": []},
+            REQUEST_SCHEMA,
+        )
+        == []
+    )
+    errors = get_json_schema_validation_errors(
+        {"customer_id": 1, "profile": {"name": "Ada"}, "tags": []}, REQUEST_SCHEMA
+    )
+    assert errors == [
+        "$.customer_id: 1 is not of type 'string'",
+        "$.profile: 'age' is a required property",
+    ]
+    # An empty schema accepts any value
+    assert get_json_schema_validation_errors({"anything": [1, None]}, {}) == []


### PR DESCRIPTION
Fixes #220, #231, #233, #239, #251, #252. Fixes the LangGraph part of #241 (the Wayflow part lives in wayflowcore).

## Root cause

Values flowing through the LangGraph adapter lost the JSON Schema semantics of their Agent Spec properties, and nothing checked them against the declared schemas:

- `_build_type_from_schema` (`adapters/_utils.py`) turned a bare `{"type": "object"}` into an empty pydantic model, which silently stripped every key (#220); dropped additional properties even when the schema allowed them (#239); and replaced omitted nested properties with `None` instead of their declared default (#241).
- LangChain validates tool calls with the generated `args_schema` and passes `getattr(result, field)` to the callable, so tools received pydantic model instances for object inputs, and those instances leaked into flow outputs and client-tool interrupt payloads (#252).
- `_cast_values_and_add_defaults` only cast top-level primitives, so `StartNode` inputs and `EndNode` outputs violating a nested schema (missing required property, wrong type, unexpected key) were accepted (#231, #233), while Wayflow rejects them. The integer-cast branch also compared against a Python error message that never occurs, so a non-numeric string for an integer input crashed with a raw `int()` error.
- `ToolNodeExecutor._format_tool_result` used `if` instead of `elif` for the "no declared outputs" case, so any non-dict/tuple tool return value raised `Unsupported multi-output mapping` (#251).

## Changes

- **`adapters/_utils.py`**: generated object models derive from a new `AgentSpecObjectModel`. Bare object schemas and typed dictionaries map to `Dict[str, ...]`; extra keys are kept unless `additionalProperties` is `false` (JSON Schema default); declared defaults are applied; `to_json_value()` converts models back to plain JSON, omitting optional fields that were neither provided nor defaulted. New helpers `apply_json_schema_defaults` and `get_json_schema_validation_errors` (uses the `jsonschema` package that is already a core dependency).
- **`langgraph/_langgraphconverter.py`**: tool callables (server, remote, client, and `BaseTool` func/coroutine) are wrapped with `_with_json_arguments` so they receive JSON values; user-provided `StructuredTool`s with their own `args_schema` are untouched (`to_json_value` only converts models generated from Agent Spec schemas).
- **`langgraph/_node_execution.py`**: node inputs and outputs are converted to JSON values, nested defaults are applied, and each value is validated against its property's JSON schema with an error naming the node, the property and every violation. Structured agent outputs go through `to_json_value`. The zero-output `ToolNode` branch short-circuits.
- **Tests**: `tests/adapters/test_schema_models.py` (unit, no runtime needed), `tests/adapters/langgraph/flows/test_schema_fidelity.py` (the scenarios of the issues end to end, plus the zero-output ToolNode), `tests/adapters/langgraph/test_tool_json_arguments.py` (sync, async and client-tool interrupt payloads). One existing test declared an object output but expected the scalar `1` to come out of it; it now declares an untyped output.
- **Changelog** entry under Bug fixes.

## Behaviour changes to be aware of

- Flows that used to run with values not conforming to their declared schemas now fail at the node boundary with an explicit error. This matches Wayflow and the spec's intent; lenient casts (numeric strings to numbers, anything to string) are kept.
- Objects whose schema does not mention `additionalProperties` now keep extra keys instead of silently dropping them (JSON Schema default).
- The CrewAI adapter shares `create_pydantic_model_from_properties`, so its nested object models gain the same defaults/extras behaviour. Its tests were not run (CrewAI is not installable alongside the other adapters).

## Verification

- New tests: 35 passed. Full suite with the LangGraph, AutoGen, Agent Framework, OpenAI Agents and evaluation extras: 1214 passed, 586 skipped (`SKIP_LLM_TESTS=1`), up from 1179 on `main`.
- Public CI steps (black, isort, flake8 + copyright, bandit, mypy, `tests/run_tests.sh` with core dependencies only) reproduced locally on Python 3.10 through 3.14.
- The same flows were run on wayflowcore 26.3.0 for comparison: outputs and rejections now match across the two runtimes.

## Notes for reviewers

- Touches `extract_outputs_from_invoke_result`, which the fix for #224 also edits; whichever lands second needs a trivial rebase.
- PR #210 adds a helper right after `_build_type_from_schema`; no textual conflict.
