### PR TITLE
fix(autogen): map properties without type to Any instead of raising KeyError

### DIFF
--- a/docs/pyagentspec/source/changelog.rst
+++ b/docs/pyagentspec/source/changelog.rst
@@ -36,6 +36,12 @@ Improvements
 Bug fixes
 ^^^^^^^^^
 
+* **AutoGen adapter: tools with untyped properties**
+
+  Converting a tool whose input has no ``type`` in its JSON schema (a property accepting any
+  value) failed with ``KeyError: 'type'``. Such properties are now mapped to ``Any``, and arrays
+  without ``items`` to ``List[Any]``.
+
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 

--- a/pyagentspec/src/pyagentspec/adapters/autogen/_autogenconverter.py
+++ b/pyagentspec/src/pyagentspec/adapters/autogen/_autogenconverter.py
@@ -75,15 +75,17 @@ def _json_schema_type_to_python_annotation(json_schema: Dict[str, Any]) -> str:
             for inner_json_schema_type in json_schema["anyOf"]
         )
         return f"Union[{','.join(possible_types)}]"
-    if isinstance(json_schema["type"], list):
+    # A schema without type accepts any value
+    json_schema_type = json_schema.get("type", "")
+    if isinstance(json_schema_type, list):
         possible_types = set(
             _json_schema_type_to_python_annotation(inner_json_schema_type)
-            for inner_json_schema_type in json_schema["type"]
+            for inner_json_schema_type in json_schema_type
         )
         return f"Union[{','.join(possible_types)}]"
 
-    if json_schema["type"] == "array":
-        return f"List[{_json_schema_type_to_python_annotation(json_schema['items'])}]"
+    if json_schema_type == "array":
+        return f"List[{_json_schema_type_to_python_annotation(json_schema.get('items', {}))}]"
     mapping = {
         "string": "str",
         "number": "float",
@@ -93,7 +95,7 @@ def _json_schema_type_to_python_annotation(json_schema: Dict[str, Any]) -> str:
         "object": "Dict[str, Any]",
     }
 
-    return mapping.get(json_schema["type"], "Any")
+    return mapping.get(json_schema_type, "Any")
 
 
 # Autogen requires that agent names be valid Python identifiers. Thus, we sanitize names to make sure they are valid.

--- a/pyagentspec/tests/adapters/autogen/test_tools.py
+++ b/pyagentspec/tests/adapters/autogen/test_tools.py
@@ -4,6 +4,7 @@
 # (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 
+from typing import Any, List
 from unittest.mock import patch
 
 import pytest
@@ -261,3 +262,32 @@ def test_remote_tool_actual_endpoint_with_autogen(
 
     assert result["value"] == "test1"
     assert result["listofvalues"] == ["a", "test2", "c"]
+
+
+def test_server_tool_with_untyped_input_can_be_converted() -> None:
+    """A property without ``type`` accepts any value; the conversion used to fail with KeyError."""
+    from pyagentspec.adapters.autogen import AgentSpecLoader
+    from pyagentspec.property import Property, StringProperty
+    from pyagentspec.tools import ServerTool
+
+    echo_tool = ServerTool(
+        name="echo",
+        description="Echoes any value as a string",
+        inputs=[
+            Property(json_schema={"title": "anything"}),
+            Property(json_schema={"title": "items", "type": "array"}),
+        ],
+        outputs=[StringProperty(title="echoed")],
+    )
+
+    def echo(anything: Any, items: List[Any]) -> str:
+        return f"{anything} {items}"
+
+    autogen_tool = AgentSpecLoader(tool_registry={"echo": echo}).load_component(echo_tool)
+
+    assert autogen_tool._func(anything={"nested": [1, 2]}, items=[1, "two"]) == (
+        "{'nested': [1, 2]} [1, 'two']"
+    )
+    schema_properties = autogen_tool.schema["parameters"]["properties"]
+    assert "anything" in schema_properties
+    assert "items" in schema_properties


### PR DESCRIPTION
Fixes #253.

## Root cause

`_json_schema_type_to_python_annotation` in `adapters/autogen/_autogenconverter.py` indexed `json_schema["type"]` and `json_schema["items"]` directly. A property without `type` accepts any value and is valid Agent Spec, so converting any tool with such an input failed with `KeyError: 'type'`. The Agent Framework converter already reads the type with `.get()`.

## Changes

- `_autogenconverter.py`: read the type with `.get()`, map a missing type to `Any` and an array without `items` to `List[Any]`.
- `tests/adapters/autogen/test_tools.py`: regression test converting a `ServerTool` with an untyped input and an array without `items`, asserting the tool runs and both parameters appear in the generated schema. Fails on `main` with the `KeyError`, passes with the fix.
- Changelog entry under Bug fixes.

## Verification

- `SKIP_LLM_TESTS=1 pytest tests/adapters/autogen/test_tools.py`: 9 passed. Full suite with adapters installed: 1180 passed, 586 skipped.
- Public CI steps (black, isort, flake8 + copyright, bandit, mypy, `tests/run_tests.sh`) reproduced locally on Python 3.10 through 3.14.
