### PR TITLE
fix(property): do not mutate schemas when normalizing union types

### DIFF
--- a/docs/pyagentspec/source/changelog.rst
+++ b/docs/pyagentspec/source/changelog.rst
@@ -36,6 +36,12 @@ Improvements
 Bug fixes
 ^^^^^^^^^
 
+* **Property type comparison no longer mutates schemas**
+
+  Comparing or checking the castability of a JSON schema that combines a ``type`` list with
+  ``anyOf`` appended the normalized types to the schema's own ``anyOf`` list. The schema is now
+  left untouched.
+
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 

--- a/pyagentspec/src/pyagentspec/property.py
+++ b/pyagentspec/src/pyagentspec/property.py
@@ -339,7 +339,8 @@ def _normalize_json_schema_union_types(schema: JsonSchemaValue) -> List[JsonSche
     json_schema_types = (
         json_schema_type if isinstance(json_schema_type, list) else [json_schema_type]
     )
-    all_types: List[JsonSchemaValue] = schema.get("anyOf", [])
+    # Copy the list: the normalized types must not be appended to the schema's own anyOf
+    all_types: List[JsonSchemaValue] = list(schema.get("anyOf", []))
     for json_schema_type in json_schema_types:
         if json_schema_type == "array":
             # If one of the basic types is array, we put the items definition in it

--- a/pyagentspec/tests/test_properties.py
+++ b/pyagentspec/tests/test_properties.py
@@ -4,6 +4,7 @@
 # (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 
+from copy import deepcopy
 from typing import Any, Dict, List, Type
 
 import pytest
@@ -1048,3 +1049,20 @@ def test_property_deduplication(properties: List[Property], expected_deduplicati
     else:
         with pytest.raises(expected_deduplication):
             print(deduplicate_properties_by_title_and_type(properties))
+
+
+def test_type_comparison_does_not_mutate_schemas_combining_type_and_any_of() -> None:
+    # Normalizing the union types used to append the entries of `type` to the schema's own
+    # `anyOf` list, so comparing a schema silently changed it
+    schema_a = {"type": ["integer", "null"], "anyOf": [{"type": "string"}]}
+    schema_b = {"anyOf": [{"type": "string"}, {"type": "integer"}, {"type": "null"}]}
+    original_schema_a = deepcopy(schema_a)
+    original_schema_b = deepcopy(schema_b)
+
+    assert json_schemas_have_same_type(schema_a, schema_b)
+    assert json_schema_is_castable_to(schema_a, schema_b)
+    assert value_is_of_compatible_type(3, schema_a)
+    assert json_schemas_have_same_type(schema_a, schema_b)
+
+    assert schema_a == original_schema_a
+    assert schema_b == original_schema_b


### PR DESCRIPTION
Fixes #254.

## Root cause

`_normalize_json_schema_union_types` in `property.py` used `schema.get("anyOf", [])` as the accumulator of normalized types and appended the entries of the `type` list to it. When the schema already had an `anyOf` list, the appends went into the caller's list, so every `json_schemas_have_same_type` / `json_schema_is_castable_to` / `value_is_of_compatible_type` call on such a schema grew its `anyOf`. These functions run during `Flow` and `DataFlowEdge` validation, so a `Property.json_schema` could change as a side effect of building a flow.

## Changes

- `property.py`: accumulate the normalized types in a copy of the `anyOf` list.
- `tests/test_properties.py`: regression test comparing a schema that combines a `type` list with `anyOf` several times and asserting both schemas are unchanged. Fails on `main`, passes with the fix.
- Changelog entry under Bug fixes.

## Verification

- `pytest tests/test_properties.py`: 177 passed, 2 skipped. Full suite: 1180 passed, 586 skipped (`SKIP_LLM_TESTS=1`).
- Public CI steps (black, isort, flake8 + copyright, bandit, mypy, `tests/run_tests.sh`) reproduced locally on Python 3.10 through 3.14.
