### PR TITLE
fix(tsagentspec): accept plugin components nested inside builtin components

### DIFF
--- a/docs/pyagentspec/source/changelog.rst
+++ b/docs/pyagentspec/source/changelog.rst
@@ -36,6 +36,17 @@ Improvements
 Bug fixes
 ^^^^^^^^^
 
+* **TypeScript SDK: custom components nested inside builtin components**
+
+  Component fields of builtin components (an Agent's ``tools``, ``toolboxes``, ``transforms``
+  and ``llmConfig``, a Flow's nodes, a ToolNode's ``tool``, MCP client transports, OCI client
+  configurations, datastores and their connection configurations) now accept plugin-provided
+  components in addition to the builtin ones, both when constructing components and when
+  deserializing them. Builtin component types are still validated by their own schemas, so a
+  builtin component of the wrong kind is rejected as before. Custom components attached to
+  builtin components can now be round-tripped through ``AgentSpecSerializer`` and
+  ``AgentSpecDeserializer`` with the corresponding plugins, as in PyAgentSpec.
+
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 

--- a/tsagentspec/src/agents/agent.ts
+++ b/tsagentspec/src/agents/agent.ts
@@ -2,7 +2,11 @@
  * Agent component.
  */
 import { z } from "zod";
-import { ComponentWithIOSchema } from "../component.js";
+import {
+  ComponentWithIOSchema,
+  openComponentUnion,
+  type CustomComponent,
+} from "../component.js";
 import type { Property } from "../property.js";
 import { getPlaceholderPropertiesFromJsonObject } from "../templating.js";
 import { LlmConfigUnion, type LlmConfig } from "../llms/index.js";
@@ -14,27 +18,27 @@ import {
 
 export const AgentSchema = ComponentWithIOSchema.extend({
   componentType: z.literal("Agent"),
-  llmConfig: LlmConfigUnion,
+  llmConfig: openComponentUnion(LlmConfigUnion),
   systemPrompt: z.string(),
-  tools: z.array(ToolUnion).default([]),
-  toolboxes: z.array(ToolBoxUnion).default([]),
+  tools: z.array(openComponentUnion(ToolUnion)).default([]),
+  toolboxes: z.array(openComponentUnion(ToolBoxUnion)).default([]),
   humanInTheLoop: z.boolean().default(true),
-  transforms: z.array(MessageTransformUnion).default([]),
+  transforms: z.array(openComponentUnion(MessageTransformUnion)).default([]),
 });
 
 export type Agent = z.infer<typeof AgentSchema>;
 
 export function createAgent(opts: {
   name: string;
-  llmConfig: LlmConfig;
+  llmConfig: LlmConfig | CustomComponent;
   systemPrompt: string;
   id?: string;
   description?: string;
   metadata?: Record<string, unknown>;
-  tools?: Tool[];
-  toolboxes?: ToolBox[];
+  tools?: Array<Tool | CustomComponent>;
+  toolboxes?: Array<ToolBox | CustomComponent>;
   humanInTheLoop?: boolean;
-  transforms?: MessageTransform[];
+  transforms?: Array<MessageTransform | CustomComponent>;
   inputs?: Property[];
   outputs?: Property[];
 }): Agent {

--- a/tsagentspec/src/agents/specialized-agent.ts
+++ b/tsagentspec/src/agents/specialized-agent.ts
@@ -2,7 +2,11 @@
  * SpecializedAgent and AgentSpecializationParameters.
  */
 import { z } from "zod";
-import { ComponentWithIOSchema } from "../component.js";
+import {
+  ComponentWithIOSchema,
+  openComponentUnion,
+  type CustomComponent,
+} from "../component.js";
 import type { Property } from "../property.js";
 import { deduplicatePropertiesByTitleAndType } from "../property.js";
 import { getPlaceholderPropertiesFromJsonObject } from "../templating.js";
@@ -13,7 +17,7 @@ export const AgentSpecializationParametersSchema =
   ComponentWithIOSchema.extend({
     componentType: z.literal("AgentSpecializationParameters"),
     additionalInstructions: z.string().optional(),
-    additionalTools: z.array(ToolUnion).optional(),
+    additionalTools: z.array(openComponentUnion(ToolUnion)).optional(),
     humanInTheLoop: z.boolean().optional(),
   });
 
@@ -35,7 +39,7 @@ export function createAgentSpecializationParameters(opts: {
   description?: string;
   metadata?: Record<string, unknown>;
   additionalInstructions?: string;
-  additionalTools?: Tool[];
+  additionalTools?: Array<Tool | CustomComponent>;
   humanInTheLoop?: boolean;
   inputs?: Property[];
   outputs?: Property[];

--- a/tsagentspec/src/component.ts
+++ b/tsagentspec/src/component.ts
@@ -51,60 +51,137 @@ export type AbstractComponentType =
   | "Datastore"
   | "MessageTransform";
 
+/** All concrete builtin component type names (the keys of the component registry) */
+export const BUILTIN_COMPONENT_TYPE_NAMES = [
+  "Agent",
+  "Swarm",
+  "ManagerWorkers",
+  "RemoteAgent",
+  "A2AAgent",
+  "SpecializedAgent",
+  "Flow",
+  "StartNode",
+  "EndNode",
+  "LlmNode",
+  "ToolNode",
+  "AgentNode",
+  "FlowNode",
+  "BranchingNode",
+  "MapNode",
+  "ParallelMapNode",
+  "ParallelFlowNode",
+  "ApiNode",
+  "InputMessageNode",
+  "OutputMessageNode",
+  "CatchExceptionNode",
+  "ServerTool",
+  "ClientTool",
+  "RemoteTool",
+  "BuiltinTool",
+  "MCPTool",
+  "MCPToolSpec",
+  "OpenAiCompatibleConfig",
+  "OllamaConfig",
+  "VllmConfig",
+  "OpenAiConfig",
+  "OciGenAiConfig",
+  "ControlFlowEdge",
+  "DataFlowEdge",
+  "MCPToolBox",
+  "StdioTransport",
+  "SSETransport",
+  "SSEmTLSTransport",
+  "StreamableHTTPTransport",
+  "StreamableHTTPmTLSTransport",
+  "RemoteTransport",
+  "OciClientConfigWithApiKey",
+  "OciClientConfigWithInstancePrincipal",
+  "OciClientConfigWithResourcePrincipal",
+  "OciClientConfigWithSecurityToken",
+  "InMemoryCollectionDatastore",
+  "OracleDatabaseDatastore",
+  "PostgresDatabaseDatastore",
+  "TlsOracleDatabaseConnectionConfig",
+  "MTlsOracleDatabaseConnectionConfig",
+  "TlsPostgresDatabaseConnectionConfig",
+  "A2AConnectionConfig",
+  "AgentSpecializationParameters",
+  "MessageSummarizationTransform",
+  "ConversationSummarizationTransform",
+] as const;
+
 /** All concrete component type string literals */
-export type ComponentTypeName =
-  | "Agent"
-  | "Swarm"
-  | "ManagerWorkers"
-  | "RemoteAgent"
-  | "A2AAgent"
-  | "SpecializedAgent"
-  | "Flow"
-  | "StartNode"
-  | "EndNode"
-  | "LlmNode"
-  | "ToolNode"
-  | "AgentNode"
-  | "FlowNode"
-  | "BranchingNode"
-  | "MapNode"
-  | "ParallelMapNode"
-  | "ParallelFlowNode"
-  | "ApiNode"
-  | "InputMessageNode"
-  | "OutputMessageNode"
-  | "CatchExceptionNode"
-  | "ServerTool"
-  | "ClientTool"
-  | "RemoteTool"
-  | "BuiltinTool"
-  | "MCPTool"
-  | "MCPToolSpec"
-  | "OpenAiCompatibleConfig"
-  | "OllamaConfig"
-  | "VllmConfig"
-  | "OpenAiConfig"
-  | "OciGenAiConfig"
-  | "ControlFlowEdge"
-  | "DataFlowEdge"
-  | "MCPToolBox"
-  | "StdioTransport"
-  | "SSETransport"
-  | "SSEmTLSTransport"
-  | "StreamableHTTPTransport"
-  | "StreamableHTTPmTLSTransport"
-  | "RemoteTransport"
-  | "OciClientConfigWithApiKey"
-  | "OciClientConfigWithInstancePrincipal"
-  | "OciClientConfigWithResourcePrincipal"
-  | "OciClientConfigWithSecurityToken"
-  | "InMemoryCollectionDatastore"
-  | "OracleDatabaseDatastore"
-  | "PostgresDatabaseDatastore"
-  | "TlsOracleDatabaseConnectionConfig"
-  | "MTlsOracleDatabaseConnectionConfig"
-  | "TlsPostgresDatabaseConnectionConfig"
-  | "A2AConnectionConfig"
-  | "AgentSpecializationParameters"
-  | "MessageSummarizationTransform"
-  | "ConversationSummarizationTransform";
+export type ComponentTypeName = (typeof BUILTIN_COMPONENT_TYPE_NAMES)[number];
+
+const BUILTIN_COMPONENT_TYPE_NAME_SET: ReadonlySet<string> = new Set(
+  BUILTIN_COMPONENT_TYPE_NAMES,
+);
+
+/** Check if a component type name is one of the builtin component types */
+export function isBuiltinComponentTypeName(
+  componentType: string,
+): componentType is ComponentTypeName {
+  return BUILTIN_COMPONENT_TYPE_NAME_SET.has(componentType);
+}
+
+/**
+ * A component whose type is provided by serialization/deserialization plugins rather than
+ * being one of the builtin component types.
+ *
+ * Only the base component fields are validated; the plugin-specific fields are kept as-is.
+ */
+export const CustomComponentSchema = ComponentBaseSchema.passthrough().refine(
+  (component) => !isBuiltinComponentTypeName(component.componentType),
+  {
+    message: "Builtin component types are validated by their own schema",
+    path: ["componentType"],
+  },
+);
+
+export type CustomComponent = ComponentBase & { [key: string]: unknown };
+
+/** Check if a value is a component-like object with a non-builtin componentType */
+function hasCustomComponentType(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  const componentType = (value as Record<string, unknown>)["componentType"];
+  return (
+    typeof componentType === "string" && !isBuiltinComponentTypeName(componentType)
+  );
+}
+
+/**
+ * Open a union of builtin component schemas to plugin-provided (custom) components.
+ *
+ * Builtin component types are still validated by `builtinUnion`, so a builtin component of
+ * the wrong kind (e.g. an Agent where a Tool is expected) is rejected as before. Components
+ * with a non-builtin `componentType` are validated with `CustomComponentSchema` instead.
+ * This mirrors pyagentspec, where a field typed with an abstract component accepts
+ * user-defined subclasses, and lets custom components nested inside builtin components
+ * round-trip through the plugin system.
+ */
+export function openComponentUnion<Schema extends z.ZodTypeAny>(
+  builtinUnion: Schema,
+): z.ZodType<
+  z.output<Schema> | CustomComponent,
+  z.ZodTypeDef,
+  z.input<Schema> | CustomComponent
+> {
+  const schema = z.unknown().transform((value, ctx) => {
+    const target: z.ZodTypeAny = hasCustomComponentType(value)
+      ? CustomComponentSchema
+      : builtinUnion;
+    const result = target.safeParse(value);
+    if (!result.success) {
+      for (const issue of result.error.issues) {
+        ctx.addIssue(issue);
+      }
+      return z.NEVER;
+    }
+    return result.data as z.output<Schema> | CustomComponent;
+  });
+  return schema as unknown as z.ZodType<
+    z.output<Schema> | CustomComponent,
+    z.ZodTypeDef,
+    z.input<Schema> | CustomComponent
+  >;
+}

--- a/tsagentspec/src/datastores/oracle-datastore.ts
+++ b/tsagentspec/src/datastores/oracle-datastore.ts
@@ -2,7 +2,11 @@
  * Oracle Database datastore and connection configs.
  */
 import { z } from "zod";
-import { ComponentBaseSchema } from "../component.js";
+import {
+  ComponentBaseSchema,
+  openComponentUnion,
+  type CustomComponent,
+} from "../component.js";
 
 export const TlsOracleDatabaseConnectionConfigSchema =
   ComponentBaseSchema.extend({
@@ -37,7 +41,7 @@ const OracleConnectionConfigUnion = z.discriminatedUnion("componentType", [
 export const OracleDatabaseDatastoreSchema = ComponentBaseSchema.extend({
   componentType: z.literal("OracleDatabaseDatastore"),
   datastoreSchema: z.record(z.record(z.unknown())),
-  connectionConfig: OracleConnectionConfigUnion,
+  connectionConfig: openComponentUnion(OracleConnectionConfigUnion),
 });
 
 export type OracleDatabaseDatastore = z.infer<
@@ -87,7 +91,10 @@ export function createMTlsOracleDatabaseConnectionConfig(opts: {
 export function createOracleDatabaseDatastore(opts: {
   name: string;
   datastoreSchema: Record<string, Record<string, unknown>>;
-  connectionConfig: TlsOracleDatabaseConnectionConfig | MTlsOracleDatabaseConnectionConfig;
+  connectionConfig:
+    | TlsOracleDatabaseConnectionConfig
+    | MTlsOracleDatabaseConnectionConfig
+    | CustomComponent;
   id?: string;
   description?: string;
   metadata?: Record<string, unknown>;

--- a/tsagentspec/src/flows/nodes/agent-node.ts
+++ b/tsagentspec/src/flows/nodes/agent-node.ts
@@ -3,19 +3,20 @@
  */
 import { z } from "zod";
 import type { Property } from "../../property.js";
+import { openComponentUnion, type CustomComponent } from "../../component.js";
 import { AgenticComponentUnion } from "../../agents/index.js";
 import { NodeBaseSchema, DEFAULT_NEXT_BRANCH } from "../node.js";
 
 export const AgentNodeSchema = NodeBaseSchema.extend({
   componentType: z.literal("AgentNode"),
-  agent: AgenticComponentUnion,
+  agent: openComponentUnion(AgenticComponentUnion),
 });
 
 export type AgentNode = z.infer<typeof AgentNodeSchema>;
 
 export function createAgentNode(opts: {
   name: string;
-  agent: z.infer<typeof AgenticComponentUnion>;
+  agent: z.infer<typeof AgenticComponentUnion> | CustomComponent;
   id?: string;
   description?: string;
   metadata?: Record<string, unknown>;

--- a/tsagentspec/src/flows/nodes/index.ts
+++ b/tsagentspec/src/flows/nodes/index.ts
@@ -16,6 +16,7 @@ import { ApiNodeSchema } from "./api-node.js";
 import { InputMessageNodeSchema } from "./input-message-node.js";
 import { OutputMessageNodeSchema } from "./output-message-node.js";
 import { CatchExceptionNodeSchema } from "./catch-exception-node.js";
+import { openComponentUnion } from "../../component.js";
 import { registerNodeUnionSchema } from "../lazy-schemas.js";
 
 /** Discriminated union of all node types */
@@ -36,7 +37,8 @@ export const NodeUnion = z.discriminatedUnion("componentType", [
   CatchExceptionNodeSchema,
 ]);
 
-registerNodeUnionSchema(NodeUnion);
+// Flows may contain plugin-provided (custom) nodes next to the builtin ones
+registerNodeUnionSchema(openComponentUnion(NodeUnion));
 
 export type Node = z.infer<typeof NodeUnion>;
 

--- a/tsagentspec/src/flows/nodes/llm-node.ts
+++ b/tsagentspec/src/flows/nodes/llm-node.ts
@@ -4,6 +4,7 @@
 import { z } from "zod";
 import { stringProperty, type Property } from "../../property.js";
 import { getPlaceholderPropertiesFromJsonObject } from "../../templating.js";
+import { openComponentUnion, type CustomComponent } from "../../component.js";
 import { LlmConfigUnion, type LlmConfig } from "../../llms/index.js";
 import { NodeBaseSchema, DEFAULT_NEXT_BRANCH } from "../node.js";
 
@@ -11,7 +12,7 @@ export const DEFAULT_LLM_OUTPUT = "generated_text";
 
 export const LlmNodeSchema = NodeBaseSchema.extend({
   componentType: z.literal("LlmNode"),
-  llmConfig: LlmConfigUnion,
+  llmConfig: openComponentUnion(LlmConfigUnion),
   promptTemplate: z.string(),
 });
 
@@ -19,7 +20,7 @@ export type LlmNode = z.infer<typeof LlmNodeSchema>;
 
 export function createLlmNode(opts: {
   name: string;
-  llmConfig: LlmConfig;
+  llmConfig: LlmConfig | CustomComponent;
   promptTemplate: string;
   id?: string;
   description?: string;

--- a/tsagentspec/src/flows/nodes/tool-node.ts
+++ b/tsagentspec/src/flows/nodes/tool-node.ts
@@ -3,27 +3,29 @@
  */
 import { z } from "zod";
 import type { Property } from "../../property.js";
+import { openComponentUnion, type CustomComponent } from "../../component.js";
 import { ToolUnion, type Tool } from "../../tools/index.js";
 import { NodeBaseSchema, DEFAULT_NEXT_BRANCH } from "../node.js";
 
 export const ToolNodeSchema = NodeBaseSchema.extend({
   componentType: z.literal("ToolNode"),
-  tool: ToolUnion,
+  tool: openComponentUnion(ToolUnion),
 });
 
 export type ToolNode = z.infer<typeof ToolNodeSchema>;
 
 export function createToolNode(opts: {
   name: string;
-  tool: Tool;
+  tool: Tool | CustomComponent;
   id?: string;
   description?: string;
   metadata?: Record<string, unknown>;
   inputs?: Property[];
   outputs?: Property[];
 }): ToolNode {
-  const inputs = opts.inputs ?? opts.tool.inputs ?? [];
-  const outputs = opts.outputs ?? opts.tool.outputs ?? [];
+  const tool = opts.tool as { inputs?: Property[]; outputs?: Property[] };
+  const inputs = opts.inputs ?? tool.inputs ?? [];
+  const outputs = opts.outputs ?? tool.outputs ?? [];
   return Object.freeze(
     ToolNodeSchema.parse({
       ...opts,

--- a/tsagentspec/src/index.ts
+++ b/tsagentspec/src/index.ts
@@ -39,9 +39,14 @@ export {
 export {
   ComponentBaseSchema,
   ComponentWithIOSchema,
+  CustomComponentSchema,
+  BUILTIN_COMPONENT_TYPE_NAMES,
   isComponent,
+  isBuiltinComponentTypeName,
+  openComponentUnion,
   type ComponentBase,
   type ComponentWithIO,
+  type CustomComponent,
   type AbstractComponentType,
   type ComponentTypeName,
 } from "./component.js";

--- a/tsagentspec/src/llms/oci-genai-config.ts
+++ b/tsagentspec/src/llms/oci-genai-config.ts
@@ -2,7 +2,11 @@
  * OCI GenAI LLM config.
  */
 import { z } from "zod";
-import { ComponentBaseSchema } from "../component.js";
+import {
+  ComponentBaseSchema,
+  openComponentUnion,
+  type CustomComponent,
+} from "../component.js";
 import { LlmGenerationConfigSchema } from "./llm-config.js";
 import { OciClientConfigUnion, type OciClientConfig } from "./oci-client-config.js";
 
@@ -48,7 +52,7 @@ export const OciGenAiConfigSchema = ComponentBaseSchema.extend({
       ModelProvider.OTHER,
     ])
     .optional(),
-  clientConfig: OciClientConfigUnion,
+  clientConfig: openComponentUnion(OciClientConfigUnion),
   apiType: z
     .enum([
       OciAPIType.OPENAI_CHAT_COMPLETIONS,
@@ -66,7 +70,7 @@ export function createOciGenAiConfig(opts: {
   name: string;
   modelId: string;
   compartmentId: string;
-  clientConfig: OciClientConfig;
+  clientConfig: OciClientConfig | CustomComponent;
   id?: string;
   description?: string;
   metadata?: Record<string, unknown>;

--- a/tsagentspec/src/mcp/mcp-tool.ts
+++ b/tsagentspec/src/mcp/mcp-tool.ts
@@ -2,21 +2,25 @@
  * MCP Tool and MCP ToolSpec.
  */
 import { z } from "zod";
-import { ComponentWithIOSchema } from "../component.js";
+import {
+  ComponentWithIOSchema,
+  openComponentUnion,
+  type CustomComponent,
+} from "../component.js";
 import type { Property } from "../property.js";
 import { ToolBaseSchema } from "../tools/tool.js";
 import { ClientTransportUnion, type ClientTransport } from "./client-transport.js";
 
 export const MCPToolSchema = ToolBaseSchema.extend({
   componentType: z.literal("MCPTool"),
-  clientTransport: ClientTransportUnion,
+  clientTransport: openComponentUnion(ClientTransportUnion),
 });
 
 export type MCPTool = z.infer<typeof MCPToolSchema>;
 
 export function createMCPTool(opts: {
   name: string;
-  clientTransport: ClientTransport;
+  clientTransport: ClientTransport | CustomComponent;
   id?: string;
   description?: string;
   metadata?: Record<string, unknown>;

--- a/tsagentspec/src/tools/toolbox.ts
+++ b/tsagentspec/src/tools/toolbox.ts
@@ -2,13 +2,17 @@
  * ToolBox and MCPToolBox.
  */
 import { z } from "zod";
-import { ComponentBaseSchema } from "../component.js";
+import {
+  ComponentBaseSchema,
+  openComponentUnion,
+  type CustomComponent,
+} from "../component.js";
 import { ClientTransportUnion, type ClientTransport } from "../mcp/client-transport.js";
 import { MCPToolSpecSchema } from "../mcp/mcp-tool.js";
 
 export const MCPToolBoxSchema = ComponentBaseSchema.extend({
   componentType: z.literal("MCPToolBox"),
-  clientTransport: ClientTransportUnion,
+  clientTransport: openComponentUnion(ClientTransportUnion),
   toolFilter: z
     .array(z.union([MCPToolSpecSchema, z.string()]))
     .optional(),
@@ -19,7 +23,7 @@ export type MCPToolBox = z.infer<typeof MCPToolBoxSchema>;
 
 export function createMCPToolBox(opts: {
   name: string;
-  clientTransport: ClientTransport;
+  clientTransport: ClientTransport | CustomComponent;
   id?: string;
   description?: string;
   metadata?: Record<string, unknown>;

--- a/tsagentspec/src/transforms/message-transform.ts
+++ b/tsagentspec/src/transforms/message-transform.ts
@@ -2,7 +2,11 @@
  * Message transform types.
  */
 import { z } from "zod";
-import { ComponentBaseSchema } from "../component.js";
+import {
+  ComponentBaseSchema,
+  openComponentUnion,
+  type CustomComponent,
+} from "../component.js";
 import { LlmConfigUnion, type LlmConfig } from "../llms/index.js";
 import {
   InMemoryCollectionDatastoreSchema,
@@ -26,7 +30,7 @@ export type SupportedDatastores =
 
 export const MessageSummarizationTransformSchema = ComponentBaseSchema.extend({
   componentType: z.literal("MessageSummarizationTransform"),
-  llm: LlmConfigUnion,
+  llm: openComponentUnion(LlmConfigUnion),
   maxMessageSize: z.number().int().default(20000),
   summarizationInstructions: z.string().default(
     "Please make a summary of this message. Include relevant information and keep it short. " +
@@ -40,7 +44,7 @@ export const MessageSummarizationTransformSchema = ComponentBaseSchema.extend({
   cacheCollectionName: z
     .string()
     .default("summarized_messages_cache"),
-  datastore: SupportedDatastoresSchema.optional(),
+  datastore: openComponentUnion(SupportedDatastoresSchema).optional(),
 });
 
 export type MessageSummarizationTransform = z.infer<
@@ -50,7 +54,7 @@ export type MessageSummarizationTransform = z.infer<
 export const ConversationSummarizationTransformSchema =
   ComponentBaseSchema.extend({
     componentType: z.literal("ConversationSummarizationTransform"),
-    llm: LlmConfigUnion,
+    llm: openComponentUnion(LlmConfigUnion),
     maxNumMessages: z.number().int().default(50),
     minNumMessages: z.number().int().default(10),
     summarizationInstructions: z.string().default(
@@ -65,7 +69,7 @@ export const ConversationSummarizationTransformSchema =
     cacheCollectionName: z
       .string()
       .default("summarized_conversations_cache"),
-    datastore: SupportedDatastoresSchema.optional(),
+    datastore: openComponentUnion(SupportedDatastoresSchema).optional(),
   });
 
 export type ConversationSummarizationTransform = z.infer<
@@ -81,7 +85,7 @@ export type MessageTransform = z.infer<typeof MessageTransformUnion>;
 
 export function createMessageSummarizationTransform(opts: {
   name: string;
-  llm: LlmConfig;
+  llm: LlmConfig | CustomComponent;
   id?: string;
   description?: string;
   metadata?: Record<string, unknown>;
@@ -91,7 +95,7 @@ export function createMessageSummarizationTransform(opts: {
   maxCacheSize?: number | null;
   maxCacheLifetime?: number | null;
   cacheCollectionName?: string;
-  datastore?: SupportedDatastores;
+  datastore?: SupportedDatastores | CustomComponent;
 }): MessageSummarizationTransform {
   return Object.freeze(
     MessageSummarizationTransformSchema.parse({
@@ -103,7 +107,7 @@ export function createMessageSummarizationTransform(opts: {
 
 export function createConversationSummarizationTransform(opts: {
   name: string;
-  llm: LlmConfig;
+  llm: LlmConfig | CustomComponent;
   id?: string;
   description?: string;
   metadata?: Record<string, unknown>;
@@ -114,7 +118,7 @@ export function createConversationSummarizationTransform(opts: {
   maxCacheSize?: number | null;
   maxCacheLifetime?: number | null;
   cacheCollectionName?: string;
-  datastore?: SupportedDatastores;
+  datastore?: SupportedDatastores | CustomComponent;
 }): ConversationSummarizationTransform {
   const parsed = ConversationSummarizationTransformSchema.parse({
     ...opts,

--- a/tsagentspec/tests/component-registry.test.ts
+++ b/tsagentspec/tests/component-registry.test.ts
@@ -6,12 +6,26 @@ import {
   isBuiltinComponentType,
   getComponentFactory,
 } from "../src/component-registry.js";
+import {
+  BUILTIN_COMPONENT_TYPE_NAMES,
+  isBuiltinComponentTypeName,
+} from "../src/component.js";
 
 describe("component-registry", () => {
   it("should have matching keys in schema and factory maps", () => {
     expect(Object.keys(BUILTIN_SCHEMA_MAP).sort()).toEqual(
       Object.keys(BUILTIN_FACTORY_MAP).sort(),
     );
+  });
+
+  it("should list the same component type names as the registry", () => {
+    expect([...BUILTIN_COMPONENT_TYPE_NAMES].sort()).toEqual(
+      Object.keys(BUILTIN_SCHEMA_MAP).sort(),
+    );
+    for (const componentType of Object.keys(BUILTIN_SCHEMA_MAP)) {
+      expect(isBuiltinComponentTypeName(componentType)).toBe(true);
+    }
+    expect(isBuiltinComponentTypeName("FunctionTransform")).toBe(false);
   });
 
   it("should return the schema for a known component type", () => {

--- a/tsagentspec/tests/serialization/nested-custom-components.test.ts
+++ b/tsagentspec/tests/serialization/nested-custom-components.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect } from "vitest";
+import {
+  AgentSpecSerializer,
+  AgentSpecDeserializer,
+  camelToSnake,
+  snakeToCamel,
+  createAgent,
+  createControlFlowEdge,
+  createEndNode,
+  createFlow,
+  createOpenAiCompatibleConfig,
+  createServerTool,
+  createStartNode,
+  createToolNode,
+  stringProperty,
+  type Agent,
+  type ComponentBase,
+  type ComponentDeserializationPlugin,
+  type ComponentSerializationPlugin,
+  type Flow,
+  type ToolNode,
+} from "../../src/index.js";
+import type { SerializedDict, SerializedFields } from "../../src/serialization/types.js";
+import type { SerializationContext } from "../../src/serialization/serialization-context.js";
+import type { DeserializationContext } from "../../src/serialization/deserialization-context.js";
+
+// Plugin-provided component types, as an integrator would define them
+// (see oracle/agent-spec#219: FunctionTransform / ConnectorToolBox attached to an Agent).
+interface FunctionTransform extends ComponentBase {
+  componentType: "FunctionTransform";
+  functionName: string;
+}
+
+interface ConnectorToolBox extends ComponentBase {
+  componentType: "ConnectorToolBox";
+  connectorId: string;
+}
+
+interface CalculatorTool extends ComponentBase {
+  componentType: "CalculatorTool";
+  precision: number;
+  requiresConfirmation: boolean;
+}
+
+interface AuditNode extends ComponentBase {
+  componentType: "AuditNode";
+  branches: string[];
+  inputs: never[];
+  outputs: never[];
+  auditLevel: string;
+}
+
+const CUSTOM_COMPONENT_TYPES = [
+  "FunctionTransform",
+  "ConnectorToolBox",
+  "CalculatorTool",
+  "AuditNode",
+];
+
+const PROTOCOL_FIELDS = new Set([
+  "component_type",
+  "component_plugin_name",
+  "component_plugin_version",
+  "agentspec_version",
+  "$referenced_components",
+]);
+
+class AcmeSerializationPlugin implements ComponentSerializationPlugin {
+  readonly pluginName = "AcmeComponentsPlugin";
+  readonly pluginVersion = "1.0.0";
+
+  supportedComponentTypes(): string[] {
+    return CUSTOM_COMPONENT_TYPES;
+  }
+
+  serialize(component: ComponentBase, context: SerializationContext): SerializedFields {
+    const fields: SerializedFields = {};
+    for (const [key, value] of Object.entries(component)) {
+      if (key === "componentType") continue;
+      fields[camelToSnake(key)] = context.dumpField(value);
+    }
+    return fields;
+  }
+}
+
+class AcmeDeserializationPlugin implements ComponentDeserializationPlugin {
+  readonly pluginName = "AcmeComponentsPlugin";
+  readonly pluginVersion = "1.0.0";
+
+  supportedComponentTypes(): string[] {
+    return CUSTOM_COMPONENT_TYPES;
+  }
+
+  deserialize(data: SerializedDict, context: DeserializationContext): ComponentBase {
+    const component: Record<string, unknown> = {
+      componentType: context.getComponentType(data),
+    };
+    for (const [key, value] of Object.entries(data)) {
+      if (PROTOCOL_FIELDS.has(key)) continue;
+      component[snakeToCamel(key)] = context.loadField(value);
+    }
+    return component as unknown as ComponentBase;
+  }
+}
+
+const functionTransform: FunctionTransform = {
+  id: "11111111-1111-4111-8111-111111111111",
+  name: "redact-pii",
+  metadata: {},
+  componentType: "FunctionTransform",
+  functionName: "redactPii",
+};
+
+const connectorToolBox: ConnectorToolBox = {
+  id: "22222222-2222-4222-8222-222222222222",
+  name: "crm-connector",
+  description: "Tools exposed by the CRM connector",
+  metadata: {},
+  componentType: "ConnectorToolBox",
+  connectorId: "crm-prod",
+};
+
+const calculatorTool: CalculatorTool = {
+  id: "33333333-3333-4333-8333-333333333333",
+  name: "calculator",
+  metadata: {},
+  componentType: "CalculatorTool",
+  precision: 4,
+  requiresConfirmation: false,
+};
+
+const auditNode: AuditNode = {
+  id: "44444444-4444-4444-8444-444444444444",
+  name: "audit",
+  metadata: {},
+  componentType: "AuditNode",
+  branches: ["next"],
+  inputs: [],
+  outputs: [],
+  auditLevel: "full",
+};
+
+function makeLlmConfig() {
+  return createOpenAiCompatibleConfig({
+    name: "test-llm",
+    url: "http://localhost:8000",
+    modelId: "test-model",
+  });
+}
+
+function makeSerializer(): AgentSpecSerializer {
+  return new AgentSpecSerializer([new AcmeSerializationPlugin()]);
+}
+
+function makeDeserializer(): AgentSpecDeserializer {
+  return new AgentSpecDeserializer([new AcmeDeserializationPlugin()]);
+}
+
+describe("Custom components nested inside builtin components", () => {
+  it("round-trips an Agent whose transforms, toolboxes and tools hold plugin components", () => {
+    const agent = createAgent({
+      name: "assistant",
+      llmConfig: makeLlmConfig(),
+      systemPrompt: "Help the user.",
+      tools: [calculatorTool],
+      toolboxes: [connectorToolBox],
+      transforms: [functionTransform],
+    });
+
+    const json = makeSerializer().toJson(agent) as string;
+    const doc = JSON.parse(json) as Record<string, unknown[]>;
+    const serializedTransform = doc["transforms"]![0] as Record<string, unknown>;
+    expect(serializedTransform["component_type"]).toBe("FunctionTransform");
+    expect(serializedTransform["component_plugin_name"]).toBe("AcmeComponentsPlugin");
+    expect(serializedTransform["function_name"]).toBe("redactPii");
+
+    const loaded = makeDeserializer().fromJson(json) as Agent;
+    expect(loaded.componentType).toBe("Agent");
+    expect(loaded.transforms).toEqual([functionTransform]);
+    expect(loaded.toolboxes).toEqual([connectorToolBox]);
+    expect(loaded.tools).toEqual([calculatorTool]);
+  });
+
+  it("round-trips the same document through YAML", () => {
+    const agent = createAgent({
+      name: "assistant",
+      llmConfig: makeLlmConfig(),
+      systemPrompt: "Help the user.",
+      transforms: [functionTransform],
+    });
+
+    const yaml = makeSerializer().toYaml(agent) as string;
+    const loaded = makeDeserializer().fromYaml(yaml) as Agent;
+    expect(loaded.transforms).toEqual([functionTransform]);
+  });
+
+  it("accepts plugin components next to builtin ones at construction time", () => {
+    const serverTool = createServerTool({
+      name: "lookup",
+      description: "Looks something up",
+      inputs: [stringProperty({ title: "query" })],
+    });
+
+    const agent = createAgent({
+      name: "assistant",
+      llmConfig: makeLlmConfig(),
+      systemPrompt: "Help the user.",
+      tools: [serverTool, calculatorTool],
+    });
+
+    // Builtin defaults are still applied, custom components are kept as provided
+    expect(agent.tools[0]).toMatchObject({
+      componentType: "ServerTool",
+      requiresConfirmation: false,
+    });
+    expect(agent.tools[1]).toEqual(calculatorTool);
+  });
+
+  it("still rejects builtin components of the wrong kind", () => {
+    const llmConfig = makeLlmConfig();
+    const serverTool = createServerTool({ name: "lookup", description: "Looks up" });
+
+    expect(() =>
+      createAgent({
+        name: "assistant",
+        llmConfig,
+        systemPrompt: "x",
+        tools: [llmConfig],
+      }),
+    ).toThrow(/Invalid discriminator value/);
+
+    expect(() =>
+      createAgent({
+        name: "assistant",
+        llmConfig,
+        systemPrompt: "x",
+        transforms: [serverTool],
+      }),
+    ).toThrow(/Invalid discriminator value/);
+  });
+
+  it("still validates the base component fields of plugin components", () => {
+    const incomplete = { componentType: "FunctionTransform", functionName: "redactPii" };
+
+    expect(() =>
+      createAgent({
+        name: "assistant",
+        llmConfig: makeLlmConfig(),
+        systemPrompt: "x",
+        transforms: [incomplete as unknown as ComponentBase],
+      }),
+    ).toThrow(/name/);
+  });
+
+  it("fails clearly when no plugin handles the nested component type", () => {
+    const agent = createAgent({
+      name: "assistant",
+      llmConfig: makeLlmConfig(),
+      systemPrompt: "Help the user.",
+      transforms: [functionTransform],
+    });
+    const json = makeSerializer().toJson(agent) as string;
+
+    expect(() => new AgentSpecDeserializer().fromJson(json)).toThrow(
+      'No plugin to deserialize component type "FunctionTransform"',
+    );
+  });
+
+  it("round-trips a Flow with a plugin node and a ToolNode holding a plugin tool", () => {
+    const start = createStartNode({ name: "start" });
+    const toolNode = createToolNode({ name: "calculate", tool: calculatorTool });
+    const end = createEndNode({ name: "end" });
+    const flow = createFlow({
+      name: "audited-flow",
+      startNode: start,
+      nodes: [start, auditNode, toolNode, end],
+      controlFlowConnections: [
+        createControlFlowEdge({ name: "start_to_audit", fromNode: start, toNode: auditNode }),
+        createControlFlowEdge({ name: "audit_to_tool", fromNode: auditNode, toNode: toolNode }),
+        createControlFlowEdge({ name: "tool_to_end", fromNode: toolNode, toNode: end }),
+      ],
+    });
+    expect(toolNode.tool).toEqual(calculatorTool);
+
+    const json = makeSerializer().toJson(flow) as string;
+    const loaded = makeDeserializer().fromJson(json) as Flow;
+
+    expect(loaded.nodes.map((node) => node["componentType"])).toEqual([
+      "StartNode",
+      "AuditNode",
+      "ToolNode",
+      "EndNode",
+    ]);
+    expect(loaded.nodes[1]).toEqual(auditNode);
+    expect((loaded.nodes[2] as ToolNode).tool).toEqual(calculatorTool);
+  });
+});


### PR DESCRIPTION
Fixes #219.

## Root cause

Every component-container field of the builtin TypeScript components (`Agent.tools/toolboxes/transforms/llmConfig`, `ToolNode.tool`, `AgentNode.agent`, `LlmNode.llmConfig`, the Flow node union, MCP `clientTransport`, OCI `clientConfig`, transform `llm`/`datastore`, Oracle datastore `connectionConfig`) was a closed `z.discriminatedUnion` of the builtin schemas. A plugin could serialize and deserialize its own component, but the builtin factory then re-validated the parent against the closed union and threw `ZodError: Invalid discriminator value`. Registering a replacement plugin for the builtin parent is not possible because duplicate component types are rejected.

## Changes

- `src/component.ts`: `ComponentTypeName` is derived from a runtime `BUILTIN_COMPONENT_TYPE_NAMES` list; new `isBuiltinComponentTypeName`, `CustomComponentSchema` (base fields validated, extra fields passed through, builtin type names refused) and `openComponentUnion(union)`, a Zod transform that dispatches on `componentType`: builtin names go through the original union (so a wrong-kind builtin still fails with the same message), any other registered name goes through `CustomComponentSchema`.
- Applied at every field listed above and to the registered lazy `NodeUnion`; factory option types widened accordingly. New symbols exported from `src/index.ts`.
- `tests/serialization/nested-custom-components.test.ts`: the scenario of the issue (custom transform, toolbox and tool inside an `Agent`; custom node and custom tool inside a `Flow`/`ToolNode`) through both the factories and the serializer round trip, plus a check that a wrong-kind builtin is still rejected. Six of the seven tests fail on `main`. `tests/component-registry.test.ts` asserts the name list matches the schema map.
- Changelog entry (TypeScript SDK) under Bug fixes.

## Behaviour change to be aware of

Public output types widen from e.g. `Tool[]` to `(Tool | CustomComponent)[]`, which is the honest type of the values now accepted. Consumers narrowing on `componentType` literals keep working for builtin names.

## Verification

From `tsagentspec/`: `npm test` 51 files / 745 tests passed (737 on `main`), `npm run lint` clean, `npm run build` succeeds.
