### PR TITLE
fix(langgraph): recover agent outputs from the final message when no structured response exists

### DIFF
--- a/docs/pyagentspec/source/changelog.rst
+++ b/docs/pyagentspec/source/changelog.rst
@@ -36,6 +36,15 @@ Improvements
 Bug fixes
 ^^^^^^^^^
 
+* **LangGraph adapter: agent outputs answered as plain text**
+
+  When an agent with declared outputs ended its run with a plain message instead of calling
+  the structured output tool, the adapter silently reported the declared defaults of the
+  outputs (for example the field names used as default of an ``AgentNode`` output). The
+  values are now recovered from the final agent message when it can be mapped to the
+  declared outputs (a JSON object keyed by output name, the JSON value of a single output,
+  or the free text of a single string output), and a warning is logged when they cannot.
+
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/_node_execution.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/_node_execution.py
@@ -50,6 +50,7 @@ from pyagentspec.flows.nodes import StartNode as AgentSpecStartNode
 from pyagentspec.flows.nodes import ToolNode as AgentSpecToolNode
 from pyagentspec.property import Property as AgentSpecProperty
 from pyagentspec.property import _empty_default as pyagentspec_empty_default
+from pyagentspec.property import value_is_of_compatible_type
 from pyagentspec.tracing.events import NodeExecutionEnd as AgentSpecNodeExecutionEnd
 from pyagentspec.tracing.events import NodeExecutionStart as AgentSpecNodeExecutionStart
 from pyagentspec.tracing.events.exception import ExceptionRaised
@@ -929,12 +930,94 @@ class MapNodeExecutor(NodeExecutor):
                 outputs[collected_output_name].append(output_value)
 
 
+def _get_final_agent_message_text(messages: Any) -> Optional[str]:
+    """Return the text of the agent's final message, if the run ended with a plain message.
+
+    A final message carrying tool calls (including the structured output tool call) is not
+    a plain answer, so ``None`` is returned in that case.
+    """
+    for message in reversed(list(messages or [])):
+        if getattr(message, "type", None) != "ai":
+            continue
+        if getattr(message, "tool_calls", None):
+            return None
+        content = message.content
+        if isinstance(content, list):
+            content = "".join(
+                block.get("text", "")
+                for block in content
+                if isinstance(block, dict) and block.get("type") == "text"
+            )
+        if isinstance(content, str) and content.strip():
+            return content
+        return None
+    return None
+
+
+def _recover_outputs_from_agent_message(
+    message_text: str, expected_outputs: List[AgentSpecProperty]
+) -> Dict[str, Any]:
+    """Best-effort extraction of the declared outputs from the agent's final plain message.
+
+    Models that do not call the structured output tool often answer with the values
+    themselves: a JSON object keyed by the output names, or, for a single output, the value
+    (a JSON array/number/object) or free text for a string output. Values are only used
+    when they are compatible with the declared output schema.
+    """
+    try:
+        parsed_value: Any = json.loads(message_text)
+        parsed = True
+    except ValueError:
+        parsed_value, parsed = None, False
+
+    if parsed and isinstance(parsed_value, dict):
+        recovered = {
+            output.title: parsed_value[output.title]
+            for output in expected_outputs
+            if output.title in parsed_value
+            and value_is_of_compatible_type(parsed_value[output.title], output.json_schema)
+        }
+        if recovered:
+            return recovered
+
+    if len(expected_outputs) == 1:
+        output = expected_outputs[0]
+        if output.json_schema.get("type") == "string":
+            # The free text is the answer itself
+            return {output.title: message_text}
+        if parsed and value_is_of_compatible_type(parsed_value, output.json_schema):
+            return {output.title: parsed_value}
+    return {}
+
+
 def extract_outputs_from_invoke_result(
     result: Dict[str, Any], expected_outputs: List[AgentSpecProperty]
 ) -> Dict[str, Any]:
     # Extracts the outputs from the return value of an invoke call made on an agent
     # The outputs are typically exposed as part of the `structured_response`, or as entries in the result directly.
     # We give priority to the latter.
+    structured_response = result.get("structured_response") or {}
+    recovered_outputs: Dict[str, Any] = {}
+    if not structured_response and expected_outputs:
+        # The model answered with a plain message instead of calling the structured output
+        # tool: the values are recovered from that message when possible, instead of
+        # silently reporting the declared defaults.
+        final_message_text = _get_final_agent_message_text(result.get("messages"))
+        if final_message_text is not None:
+            recovered_outputs = _recover_outputs_from_agent_message(
+                final_message_text, expected_outputs
+            )
+        missing_outputs = [
+            output.title
+            for output in expected_outputs
+            if output.title not in recovered_outputs and output.title not in result
+        ]
+        if missing_outputs:
+            logger.warning(
+                "The agent did not produce a structured response and its final message could "
+                "not be mapped to outputs %s; declared defaults are used when available.",
+                missing_outputs,
+            )
     return {
         # Defaults if available
         **{
@@ -942,8 +1025,10 @@ def extract_outputs_from_invoke_result(
             for output in expected_outputs or []
             if output.default is not pyagentspec_empty_default
         },
+        # Values recovered from the final agent message when no structured response exists
+        **recovered_outputs,
         # Results in `structured_response`
-        **dict(result.get("structured_response", {})),
+        **dict(structured_response),
         # Results appended to main dictionary
         **{
             output.title: result[output.title]

--- a/pyagentspec/tests/adapters/langgraph/flows/test_agentnode_output_recovery.py
+++ b/pyagentspec/tests/adapters/langgraph/flows/test_agentnode_output_recovery.py
@@ -1,0 +1,275 @@
+# Copyright © 2026 Oracle and/or its affiliates.
+#
+# This software is under the Apache License 2.0
+# (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
+# (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
+"""Agent outputs are recovered from the final agent message when no structured response exists.
+
+Covers oracle/agent-spec#224: an AgentNode whose model answered with the tool result as plain
+text (instead of calling the structured output tool) returned the declared default of its
+output, the list of field names ``["name", "CEO", "country"]``, instead of the values.
+"""
+
+import logging
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+import pytest
+
+from pyagentspec.adapters.langgraph import AgentSpecLoader
+from pyagentspec.adapters.langgraph._langgraphconverter import AgentSpecToLangGraphConverter
+from pyagentspec.adapters.langgraph._node_execution import extract_outputs_from_invoke_result
+from pyagentspec.agent import Agent
+from pyagentspec.flows.edges import ControlFlowEdge, DataFlowEdge
+from pyagentspec.flows.flow import Flow
+from pyagentspec.flows.nodes import AgentNode, EndNode, StartNode
+from pyagentspec.llms import OpenAiConfig
+from pyagentspec.property import (
+    IntegerProperty,
+    ListProperty,
+    Property,
+    StringProperty,
+)
+from pyagentspec.tools import ServerTool
+
+SEARCH_RESULTS = Property(
+    json_schema={
+        "title": "search_results",
+        "type": "array",
+        "items": {"type": "string"},
+        "default": ["name", "CEO", "country"],
+    }
+)
+QUERY = Property(json_schema={"title": "query", "type": "string", "default": ""})
+
+PEOPLE = {"Alice": ["Alice", "No", "USA"], "Karim": ["Karim", "Yes", "Morocco"]}
+
+
+def _ai_message(content: str = "", tool_calls: Any = None) -> Any:
+    from langchain_core.messages import AIMessage
+
+    return AIMessage(content=content, tool_calls=tool_calls or [])
+
+
+def _fake_model(responses: List[Any]) -> Any:
+    from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
+    from langchain_openai import ChatOpenAI
+
+    class FakeModel(FakeMessagesListChatModel, ChatOpenAI):
+        pass
+
+    return FakeModel(responses=responses)
+
+
+def _search_agent_flow() -> Flow:
+    """Mirror of the conformance test suite's ``simple_agentnode_with_tool`` configuration."""
+    search_tool = ServerTool(
+        name="search_tool",
+        description="This tool runs a web search with the given query and returns results",
+        inputs=[QUERY],
+        outputs=[SEARCH_RESULTS],
+    )
+    agent = Agent(
+        name="Search agent",
+        llm_config=OpenAiConfig(name="llm", model_id="fake-model"),
+        system_prompt=(
+            "Your task is to gather the required information for the user: {{query}}. "
+            "Do not attempt to answer yourself, simply return the tool response."
+        ),
+        inputs=[QUERY],
+        outputs=[SEARCH_RESULTS],
+        tools=[search_tool],
+    )
+    start = StartNode(name="start", inputs=[QUERY])
+    agent_node = AgentNode(name="Search agent node", agent=agent)
+    end = EndNode(name="end", outputs=[SEARCH_RESULTS])
+    return Flow(
+        name="Search agent flow",
+        start_node=start,
+        nodes=[start, agent_node, end],
+        control_flow_connections=[
+            ControlFlowEdge(name="start_to_agent", from_node=start, to_node=agent_node),
+            ControlFlowEdge(name="agent_to_end", from_node=agent_node, to_node=end),
+        ],
+        data_flow_connections=[
+            DataFlowEdge(
+                name="query_edge",
+                source_node=start,
+                source_output="query",
+                destination_node=agent_node,
+                destination_input="query",
+            ),
+            DataFlowEdge(
+                name="search_results_edge",
+                source_node=agent_node,
+                source_output="search_results",
+                destination_node=end,
+                destination_input="search_results",
+            ),
+        ],
+    )
+
+
+def _run_search_flow(model_responses: List[Any], user_message: str) -> Dict[str, Any]:
+    from langgraph.checkpoint.memory import MemorySaver
+
+    calls: List[str] = []
+
+    def get_person_info(query: str) -> List[str]:
+        calls.append(query)
+        return PEOPLE.get(query, [query, "Unknown", "Unknown"])
+
+    loader = AgentSpecLoader(
+        tool_registry={"search_tool": get_person_info}, checkpointer=MemorySaver()
+    )
+    # The AgentNode converts its agent's model when it executes, so the patch must cover the run
+    with patch.object(
+        AgentSpecToLangGraphConverter,
+        "_llm_convert_to_langgraph",
+        return_value=_fake_model(model_responses),
+    ):
+        graph = loader.load_component(_search_agent_flow())
+        result = graph.invoke(
+            {"inputs": {}, "messages": [{"role": "user", "content": user_message}]},
+            {"configurable": {"thread_id": user_message}},
+        )
+    return {"outputs": result["outputs"], "tool_calls": calls}
+
+
+@pytest.mark.parametrize(
+    "user_message, expected_search_results",
+    [
+        ("Alice", ["Alice", "No", "USA"]),
+        ("Karim", ["Karim", "Yes", "Morocco"]),
+        ("Khalid", ["Khalid", "Unknown", "Unknown"]),
+    ],
+)
+def test_agentnode_returns_tool_result_answered_as_plain_text(
+    user_message: str, expected_search_results: List[str]
+) -> None:
+    # The model calls the tool, then repeats the tool result as its final plain message
+    # instead of calling the structured output tool (oracle/agent-spec#224)
+    import json
+
+    responses = [
+        _ai_message(
+            tool_calls=[{"name": "search_tool", "args": {"query": user_message}, "id": "call_1"}]
+        ),
+        _ai_message(content=json.dumps(expected_search_results)),
+    ]
+    run = _run_search_flow(responses, user_message)
+    assert run["tool_calls"] == [user_message]
+    assert run["outputs"] == {"search_results": expected_search_results}
+
+
+def test_agentnode_uses_structured_response_when_produced() -> None:
+    responses = [
+        _ai_message(tool_calls=[{"name": "search_tool", "args": {"query": "Alice"}, "id": "c1"}]),
+        _ai_message(
+            tool_calls=[
+                {
+                    "name": "AgentOutputModel",
+                    "args": {"search_results": ["Alice", "No", "USA"]},
+                    "id": "c2",
+                }
+            ]
+        ),
+    ]
+    run = _run_search_flow(responses, "Alice")
+    assert run["outputs"] == {"search_results": ["Alice", "No", "USA"]}
+
+
+def test_agentnode_falls_back_to_default_when_message_cannot_be_mapped(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    responses = [
+        _ai_message(tool_calls=[{"name": "search_tool", "args": {"query": "Alice"}, "id": "c1"}]),
+        _ai_message(content="Alice is not a CEO and lives in the USA."),
+    ]
+    with caplog.at_level(logging.WARNING, logger="pyagentspec.adapters.langgraph._node_execution"):
+        run = _run_search_flow(responses, "Alice")
+    assert run["outputs"] == {"search_results": ["name", "CEO", "country"]}
+    assert "did not produce a structured response" in caplog.text
+    assert "search_results" in caplog.text
+
+
+# --- extract_outputs_from_invoke_result -----------------------------------------------------
+
+
+def _result(messages: List[Any], **state: Any) -> Dict[str, Any]:
+    return {"messages": messages, **state}
+
+
+def test_structured_response_takes_precedence_over_recovered_and_default_values() -> None:
+    outputs = extract_outputs_from_invoke_result(
+        _result(
+            [_ai_message(content='["from", "message"]')],
+            structured_response={"search_results": ["x"]},
+        ),
+        [SEARCH_RESULTS],
+    )
+    assert outputs == {"search_results": ["x"]}
+
+
+def test_empty_structured_response_is_treated_as_missing() -> None:
+    # AgentNodeExecutor seeds the state with an empty structured_response
+    outputs = extract_outputs_from_invoke_result(
+        _result([_ai_message(content='["Alice", "No", "USA"]')], structured_response={}),
+        [SEARCH_RESULTS],
+    )
+    assert outputs == {"search_results": ["Alice", "No", "USA"]}
+
+
+def test_single_string_output_takes_the_final_message_text() -> None:
+    answer = StringProperty(title="answer")
+    outputs = extract_outputs_from_invoke_result(
+        _result([_ai_message(content="The capital of France is Paris.")]), [answer]
+    )
+    assert outputs == {"answer": "The capital of France is Paris."}
+
+
+def test_json_object_message_is_mapped_to_matching_outputs_only() -> None:
+    count = IntegerProperty(title="count", default=0)
+    names = ListProperty(title="names", item_type=StringProperty(title="name"))
+    message = _ai_message(content='{"count": "three", "names": ["a", "b"], "other": 1}')
+    outputs = extract_outputs_from_invoke_result(_result([message]), [count, names])
+    # "three" is not an integer, so the declared default is kept for `count`
+    assert outputs == {"count": 0, "names": ["a", "b"]}
+
+
+def test_incompatible_single_value_falls_back_to_default() -> None:
+    outputs = extract_outputs_from_invoke_result(
+        _result([_ai_message(content='{"unrelated": true}')]), [SEARCH_RESULTS]
+    )
+    assert outputs == {"search_results": ["name", "CEO", "country"]}
+
+
+def test_final_message_with_tool_calls_is_not_used() -> None:
+    outputs = extract_outputs_from_invoke_result(
+        _result(
+            [
+                _ai_message(
+                    content='["Alice", "No", "USA"]',
+                    tool_calls=[{"name": "search_tool", "args": {"query": "Alice"}, "id": "c"}],
+                )
+            ]
+        ),
+        [SEARCH_RESULTS],
+    )
+    assert outputs == {"search_results": ["name", "CEO", "country"]}
+
+
+def test_text_content_blocks_are_joined() -> None:
+    message = _ai_message(
+        content=[{"type": "text", "text": '["Alice", '}, {"type": "text", "text": '"No", "USA"]'}]
+    )
+    outputs = extract_outputs_from_invoke_result(_result([message]), [SEARCH_RESULTS])
+    assert outputs == {"search_results": ["Alice", "No", "USA"]}
+
+
+def test_values_in_result_state_still_take_precedence() -> None:
+    outputs = extract_outputs_from_invoke_result(
+        _result([_ai_message(content='["from", "message"]')], search_results=["from", "state"]),
+        [SEARCH_RESULTS],
+    )
+    assert outputs == {"search_results": ["from", "state"]}


### PR DESCRIPTION
Fixes #224.

## Root cause

The `["name", "CEO", "country"]` returned by the CTS test is not the tool's field names leaking through: it is the **declared default** of the `search_results` output in the test's Agent Spec. LangChain's `create_agent(response_format=ToolStrategy(...))` only sets `structured_response` when the model calls the structured-output tool; when the model answers in plain text instead, the run ends with no structured response and `extract_outputs_from_invoke_result` fell through to the declared defaults. `AgentNodeExecutor` also seeded `structured_response: {}`, which the extractor treated as a present-but-empty response.

The CTS deterministic model answers the second turn with the tool result as plain text (it only understands provider-native `response_format`), which is why Wayflow passes and LangGraph returns the default. Reproduced live against OCI Generative AI models as well (a model answering in prose after the tool call produces the same default), and deterministically with a fake chat model.

## Changes

- `langgraph/_node_execution.py`: `extract_outputs_from_invoke_result` treats a missing or empty `structured_response` as absent and recovers the outputs from the final AI message when it is compatible with the declared schema: a JSON object keyed by output names, a JSON value for a single non-string output, or the text itself for a single string output (text content blocks are joined). Precedence is defaults, then recovered values, then `structured_response`, then values already present in the state. A `logging` warning names the outputs that fell back to their defaults. Final messages carrying tool calls are never used.
- `tests/adapters/langgraph/flows/test_agentnode_output_recovery.py`: the CTS scenario for the three names with a fake chat model, the unchanged structured-response path, the default fallback with its warning, and unit cases of the extractor. Eight tests fail on `main`, thirteen pass with the fix. No LLM calls.
- Changelog entry under Bug fixes.

## Verification

- `SKIP_LLM_TESTS=1 pytest tests/adapters/langgraph`: 163 passed, 89 skipped.
- Public CI steps (black, isort, flake8 + copyright, bandit, mypy, `tests/run_tests.sh`) reproduced locally on Python 3.10 through 3.14.

## Notes for reviewers

- PR #210 adds a `StructuredOutputGuard` that raises when `structured_response` is absent; if it lands first, the guard should run after (or skip when) this recovery succeeds.
- The schema-fidelity PR also edits `extract_outputs_from_invoke_result` (wraps the result in `to_json_value`); whichever lands second needs a trivial rebase.
- Two related observations were left out of scope: some models emit the structured-output call in the same turn as the tool call under `tool_choice="any"`, and Cohere models on OCI reject `tool_choice` entirely, so `ToolStrategy` fails for them at load time.
