### PR TITLE
fix(langgraph): pass the recursion limit of the flow run on to AgentNode agents

### DIFF
--- a/docs/pyagentspec/source/changelog.rst
+++ b/docs/pyagentspec/source/changelog.rst
@@ -36,6 +36,14 @@ Improvements
 Bug fixes
 ^^^^^^^^^
 
+* **LangGraph adapter: AgentNode agents honour the recursion limit of the flow run**
+
+  The agents compiled for Flow ``AgentNode`` steps are bound by LangChain to a recursion
+  limit of 9999 steps, which overrode the ``recursion_limit`` configured for the flow run.
+  An agent that never terminated made thousands of model calls before failing. A recursion
+  limit explicitly configured for the run (or in the loader config) is now passed on to the
+  nested agent; runs using LangChain's default limit keep the agent's own limit.
+
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 

--- a/pyagentspec/src/pyagentspec/adapters/langgraph/_node_execution.py
+++ b/pyagentspec/src/pyagentspec/adapters/langgraph/_node_execution.py
@@ -563,14 +563,40 @@ class AgentNodeExecutor(NodeExecutor):
         outputs = extract_outputs_from_invoke_result(result, self.node.outputs or [])
         return outputs, NodeExecutionDetails()
 
+    def _agent_invoke_config(self) -> RunnableConfig:
+        """Config of the nested agent run.
+
+        ``create_agent`` binds ``recursion_limit=9999`` to the agents it compiles, which
+        overrides the limit of the enclosing flow run: an agent that never terminates makes
+        thousands of model calls before failing, whatever limit the caller configured.
+        Unless the loader config sets its own limit, a recursion limit explicitly configured
+        for the current run (any value other than LangChain's default) is passed on to the
+        agent so that it stops where the caller asked.
+        """
+        from langchain_core.runnables.config import DEFAULT_RECURSION_LIMIT
+        from langgraph.config import get_config
+
+        config = cast(RunnableConfig, dict(self.config or {}))
+        if "recursion_limit" in config:
+            return config
+        try:
+            run_config = get_config()
+        except RuntimeError:
+            # Not executed within a LangGraph run
+            return config
+        run_recursion_limit = run_config.get("recursion_limit", DEFAULT_RECURSION_LIMIT)
+        if run_recursion_limit != DEFAULT_RECURSION_LIMIT:
+            config["recursion_limit"] = run_recursion_limit
+        return config
+
     def _execute(self, inputs: Dict[str, Any], messages: Messages) -> ExecuteOutput:
         agent, prepared_inputs = self._prepare_agent_and_inputs(inputs, messages)
-        result = agent.invoke(prepared_inputs, self.config)
+        result = agent.invoke(prepared_inputs, self._agent_invoke_config())
         return self._format_agent_result(result)
 
     async def _aexecute(self, inputs: Dict[str, Any], messages: Messages) -> ExecuteOutput:
         agent, prepared_inputs = self._prepare_agent_and_inputs(inputs, messages)
-        result = await agent.ainvoke(prepared_inputs, self.config)
+        result = await agent.ainvoke(prepared_inputs, self._agent_invoke_config())
         return self._format_agent_result(result)
 
 

--- a/pyagentspec/tests/adapters/langgraph/flows/test_agentnode_recursion_limit.py
+++ b/pyagentspec/tests/adapters/langgraph/flows/test_agentnode_recursion_limit.py
@@ -1,0 +1,180 @@
+# Copyright © 2026 Oracle and/or its affiliates.
+#
+# This software is under the Apache License 2.0
+# (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
+# (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
+"""The agent of a Flow ``AgentNode`` honours the recursion limit of the enclosing run.
+
+``create_agent`` binds ``recursion_limit=9999`` to the agents it compiles. Without the
+fix, an agent that never terminates inside a flow made thousands of model calls before
+failing, even when the flow run was invoked with a small ``recursion_limit``
+(oracle/agent-spec#227).
+"""
+
+from contextlib import contextmanager
+from typing import Any, Iterator, List
+from unittest.mock import patch
+
+import pytest
+
+from pyagentspec.agent import Agent
+from pyagentspec.flows.edges import ControlFlowEdge
+from pyagentspec.flows.flow import Flow
+from pyagentspec.flows.nodes import AgentNode, EndNode, StartNode
+from pyagentspec.llms import LlmConfig
+from pyagentspec.property import IntegerProperty
+from pyagentspec.tools import ServerTool
+
+MULTIPLICATION_TOOL = ServerTool(
+    name="multiplication_tool",
+    description="Multiplies two integers",
+    inputs=[IntegerProperty(title="a"), IntegerProperty(title="b")],
+    outputs=[IntegerProperty(title="result")],
+)
+
+USER_MESSAGE = {"role": "user", "content": "calculate 3x6 ?"}
+
+
+def _flow_with_agent_node() -> Flow:
+    agent = Agent(
+        name="Calculator agent",
+        # A generic LlmConfig is not skipped by SKIP_LLM_TESTS; the model is faked anyway
+        llm_config=LlmConfig(name="llm", model_id="fake", api_provider="openai"),
+        system_prompt="You are a calculator agent.",
+        tools=[MULTIPLICATION_TOOL],
+    )
+    start = StartNode(name="start")
+    agent_node = AgentNode(name="agent_node", agent=agent)
+    end = EndNode(name="end")
+    return Flow(
+        name="calculator_flow",
+        start_node=start,
+        nodes=[start, agent_node, end],
+        control_flow_connections=[
+            ControlFlowEdge(name="start_to_agent", from_node=start, to_node=agent_node),
+            ControlFlowEdge(name="agent_to_end", from_node=agent_node, to_node=end),
+        ],
+    )
+
+
+def _tool_call_messages(count: int) -> List[Any]:
+    from langchain_core.messages import AIMessage
+
+    return [
+        AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "multiplication_tool", "args": {"a": 3, "b": 6}, "id": f"call_{index}"}
+            ],
+        )
+        for index in range(count)
+    ]
+
+
+@contextmanager
+def _fake_llm(responses: List[Any]) -> Iterator[List[int]]:
+    """Answer every LLM config with a fake chat model replaying ``responses``.
+
+    Yields the list of recorded model calls (one entry per call).
+    """
+    from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
+    from langchain_openai import ChatOpenAI
+
+    from pyagentspec.adapters.langgraph._langgraphconverter import AgentSpecToLangGraphConverter
+
+    class _FakeModel(FakeMessagesListChatModel, ChatOpenAI):
+        # FakeMessagesListChatModel only overrides the sync generation; without this,
+        # async runs would reach ChatOpenAI's real client
+        async def _agenerate(self, *args: Any, **kwargs: Any) -> Any:
+            return self._generate(*args, **kwargs)
+
+    calls: List[int] = []
+    fake = _FakeModel(responses=responses)
+    original_generate = FakeMessagesListChatModel._generate
+
+    def _counting_generate(self: Any, *args: Any, **kwargs: Any) -> Any:
+        calls.append(1)
+        return original_generate(self, *args, **kwargs)
+
+    with patch.object(
+        AgentSpecToLangGraphConverter,
+        "_llm_convert_to_langgraph",
+        autospec=True,
+        side_effect=lambda _self, _llm_config, *args, **kwargs: fake,
+    ), patch.object(
+        FakeMessagesListChatModel, "bind_tools", new=lambda self_obj, *args, **kwargs: self_obj
+    ), patch.object(
+        FakeMessagesListChatModel, "_generate", new=_counting_generate
+    ):
+        yield calls
+
+
+def _load(flow: Flow, loader_config: Any = None) -> Any:
+    from langgraph.checkpoint.memory import MemorySaver
+
+    from pyagentspec.adapters.langgraph import AgentSpecLoader
+
+    return AgentSpecLoader(
+        tool_registry={"multiplication_tool": lambda a, b: a * b},
+        checkpointer=MemorySaver(),
+        config=loader_config,
+    ).load_component(flow)
+
+
+def test_agent_node_inherits_the_recursion_limit_of_the_flow_run() -> None:
+    from langgraph.errors import GraphRecursionError
+
+    # The model calls the tool forever: the agent never terminates on its own
+    with _fake_llm(_tool_call_messages(20_000)) as calls:
+        graph = _load(_flow_with_agent_node())
+        with pytest.raises(GraphRecursionError):
+            graph.invoke(
+                {"inputs": {}, "messages": [USER_MESSAGE]},
+                config={"configurable": {"thread_id": "1"}, "recursion_limit": 6},
+            )
+    # Every agent step is a model call or a tool call: 6 steps allow 3 model calls
+    assert len(calls) == 3
+
+
+@pytest.mark.anyio
+async def test_agent_node_inherits_the_recursion_limit_of_the_flow_run_async() -> None:
+    from langgraph.errors import GraphRecursionError
+
+    with _fake_llm(_tool_call_messages(20_000)) as calls:
+        graph = _load(_flow_with_agent_node())
+        with pytest.raises(GraphRecursionError):
+            await graph.ainvoke(
+                {"inputs": {}, "messages": [USER_MESSAGE]},
+                config={"configurable": {"thread_id": "1"}, "recursion_limit": 6},
+            )
+    assert len(calls) == 3
+
+
+def test_agent_node_keeps_the_loader_recursion_limit_when_configured() -> None:
+    from langgraph.errors import GraphRecursionError
+
+    with _fake_llm(_tool_call_messages(20_000)) as calls:
+        graph = _load(_flow_with_agent_node(), loader_config={"recursion_limit": 10})
+        with pytest.raises(GraphRecursionError):
+            graph.invoke(
+                {"inputs": {}, "messages": [USER_MESSAGE]},
+                config={"configurable": {"thread_id": "1"}, "recursion_limit": 6},
+            )
+    # The loader config is explicit and wins over the limit of the run: 10 steps, 5 model calls
+    assert len(calls) == 5
+
+
+def test_agent_node_keeps_the_agent_default_limit_when_the_run_uses_the_default() -> None:
+    from langchain_core.messages import AIMessage
+
+    # LangChain's default recursion limit is 25 steps. The agent compiled by create_agent
+    # allows far more and must keep doing so when the caller did not configure a limit.
+    responses = _tool_call_messages(30) + [AIMessage(content="18")]
+    with _fake_llm(responses) as calls:
+        graph = _load(_flow_with_agent_node())
+        result = graph.invoke(
+            {"inputs": {}, "messages": [USER_MESSAGE]},
+            config={"configurable": {"thread_id": "1"}},
+        )
+    assert len(calls) == 31
+    assert result["messages"][-1].content == "18"


### PR DESCRIPTION
Relates to #227.

## Root cause

Two things combine in the CTS failures reported in #227:

1. The non-termination itself: the adapter enables `response_format=ToolStrategy(...)` for any agent with declared outputs. With no tools, LangChain's `create_agent` routes from the model back to the model until a `structured_response` exists, so a model that answers in prose (the CTS deterministic LLM server, or any provider ignoring the structured-output tool) loops until `GraphRecursionError`. Reproduced deterministically with a fake chat model (agent with outputs and no tools: recursion error after 12 model calls; same agent without outputs: terminates in 2 calls). Open PR #210 addresses this part and, applied locally, makes the CTS case terminate in 2 calls.
2. **What this PR fixes**: `create_agent` binds `recursion_limit=9999` to the agents it compiles, and `AgentNodeExecutor` invoked the nested agent with the loader config only. The limit configured for the enclosing flow run therefore never applied inside an `AgentNode`: with `recursion_limit=12` on the flow run, a non-terminating nested agent made 9999 model calls before failing.

## Changes

- `langgraph/_node_execution.py`: `AgentNodeExecutor` reads the config of the current run and passes an explicitly configured recursion limit (any value other than LangChain's default of 25) on to the nested agent. A limit set in the loader config still takes precedence, and runs using the default limit keep the agent's own limit so tool-heavy agents are not cut at 25 steps.
- `tests/adapters/langgraph/flows/test_agentnode_recursion_limit.py`: sync and async runs with `recursion_limit=6` stop the nested agent after 3 model calls (5000 calls on `main` before the test was capped), the loader config wins over the run config, and a run with the default limit keeps the agent's limit. Fake chat model, no LLM calls.
- Changelog entry under Bug fixes.

## Verification

- `SKIP_LLM_TESTS=1 pytest tests/adapters/langgraph`: 113 passed, 89 skipped.
- Public CI steps (black, isort, flake8 + copyright, bandit, mypy, `tests/run_tests.sh`) reproduced locally on Python 3.10 through 3.14.
- Live check against OCI Generative AI models: a compliant model terminates in one turn with the structured-output tool call, so the loop only shows with models or servers that answer in prose.

## Notes for reviewers

- Independent of #210; both can land in any order.
- The CTS runtime in #117 also treats every interrupt as a client-tool request, which is the `KeyError: 'name'` of #223; a proposed patch is posted on that issue.
